### PR TITLE
feat(kermt): add static eval definitions for the open-model skills

### DIFF
--- a/open-models-skills/kermt/skills/kermt-continue-pretrain/evals/evals.json
+++ b/open-models-skills/kermt/skills/kermt-continue-pretrain/evals/evals.json
@@ -55,6 +55,20 @@
       ],
       "expected_skill": null,
       "expected_script": null
+    },
+    {
+      "id": "kermt-continue-pretrain-005",
+      "prompt": "I'd like to continue pretraining from the publicly released KERMT model nvidia/NV-KERMT-70M-v2 on my own SMILES corpus at /data/corpus.csv for a few more epochs. I don't have the checkpoint locally yet.",
+      "expected_output": "The agent recognized that no --ckpt was provided, obtained explicit consent (or honored --pretrained-release) to download the released hybrid model nvidia/NV-KERMT-70M-v2 via fetch_released_model.py, noted the bundle ships its three pretrain vocab files alongside the checkpoint so the authoritative-vocab pass-through works automatically, validated the checkpoint for continue-pretrain (auto-detecting hybrid mode), prepared the corpus, and launched pretrain_ddp.py detached in the kermt container.",
+      "assertions": [
+        "The agent read the kermt-continue-pretrain SKILL.md and, finding no --ckpt, defaulted to the released model nvidia/NV-KERMT-70M-v2 via the consent gate (or an explicit --pretrained-release flag)",
+        "The agent downloaded the released bundle with fetch_released_model.py (huggingface_hub) into the --model-dir mount, relying on the bundled pretrain_*_vocab files being auto-detected in the checkpoint's parent directory",
+        "The agent validated the downloaded checkpoint using check_checkpoint.py with --mode continue_pretrain and auto-dispatched --pretrain_mode as hybrid based on the checkpoint type",
+        "The agent prepared the corpus and launched pretrain_ddp.py inside the kermt container in detached mode, reporting the run directory",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-continue-pretrain",
+      "expected_script": null
     }
   ]
 }

--- a/open-models-skills/kermt/skills/kermt-embed/evals/evals.json
+++ b/open-models-skills/kermt/skills/kermt-embed/evals/evals.json
@@ -55,6 +55,20 @@
       ],
       "expected_skill": null,
       "expected_script": null
+    },
+    {
+      "id": "kermt-embed-005",
+      "prompt": "I don't have my own KERMT checkpoint. Can you extract per-molecule embeddings for the SMILES in /data/biogen_admet.csv using the publicly released model? I want all four readout types so I can cluster the compounds downstream.",
+      "expected_output": "The agent recognized that no --ckpt was provided and defaulted to the released hybrid model nvidia/NV-KERMT-70M-v2, obtained explicit consent (or honored --pretrained-release) before downloading, fetched the bundle with fetch_released_model.py via huggingface_hub into the --model-dir mount, validated the downloaded checkpoint for an encoder, and ran run_extract_embeddings.py to produce the four readout .npy files.",
+      "assertions": [
+        "The agent read the kermt-embed SKILL.md and, finding no --ckpt, defaulted to the released model nvidia/NV-KERMT-70M-v2 rather than erroring",
+        "The agent obtained explicit user consent (or honored an explicit --pretrained-release flag) before downloading, per the skill's released-model consent gate",
+        "The agent invoked fetch_released_model.py inside the kermt container to download the nvidia/NV-KERMT-70M-v2 bundle via huggingface_hub into the --model-dir mount, reusing an already-complete bundle if present",
+        "The agent validated the downloaded checkpoint using check_checkpoint.py with --mode embed and launched run_extract_embeddings.py, reporting the four readout .npy files (atom_from_atom, bond_from_atom, atom_from_bond, bond_from_bond)",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-embed",
+      "expected_script": null
     }
   ]
 }

--- a/open-models-skills/kermt/skills/kermt-finetune/evals/evals.json
+++ b/open-models-skills/kermt/skills/kermt-finetune/evals/evals.json
@@ -55,6 +55,20 @@
       ],
       "expected_skill": null,
       "expected_script": null
+    },
+    {
+      "id": "kermt-finetune-005",
+      "prompt": "I want to finetune the publicly released KERMT model (nvidia/NV-KERMT-70M-v2) on the Biogen multi-task ADME dataset at /data/biogen/train.csv — it has four regression endpoints: HLM, RLM, MDCK, and logS. I don't have a local checkpoint. Please set it up for 3 epochs to start.",
+      "expected_output": "The agent recognized that no --ckpt was provided, obtained explicit consent (or honored --pretrained-release) to download the released hybrid model nvidia/NV-KERMT-70M-v2 via fetch_released_model.py, validated the downloaded pretrain checkpoint for finetune init, validated the Biogen multi-task CSV, and launched a detached finetune run over the four HLM/RLM/MDCK/logS regression targets for 3 epochs.",
+      "assertions": [
+        "The agent read the kermt-finetune SKILL.md and, finding no --ckpt, defaulted to the released model nvidia/NV-KERMT-70M-v2 via the consent gate (or an explicit --pretrained-release flag)",
+        "The agent downloaded the released bundle with fetch_released_model.py (huggingface_hub) into the --model-dir mount before finetuning, reusing an already-complete bundle if present",
+        "The agent validated the downloaded checkpoint using check_checkpoint.py with --mode finetune_init and confirmed the four regression targets (HLM, RLM, MDCK, logS) in the CSV",
+        "The agent launched the detached finetune run with --dataset-type regression and --epochs 3, reporting the run directory and container name",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-finetune",
+      "expected_script": null
     }
   ]
 }


### PR DESCRIPTION
Expose the task-eval definitions used to measure the KERMT skills, matching the NIM skills' evals/ convention. Adds open-models-skills/kermt/evals/<skill>/ evals.json for the 6 evaluated skills (finetune, embed, continue-pretrain, add-cmim-pretrain, pretrain-scratch, infer).