### PR TITLE
Add nim-hosted evals

### DIFF
--- a/nim-skills/boltz2-nim/evals/config.yml
+++ b/nim-skills/boltz2-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/boltz2-nim/evals/evals.json
+++ b/nim-skills/boltz2-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to predict the structure of insulin using Boltz2. The sequence is MALWMRLLPLLALLALWGPDPAAAFVNQHLCGSHLVEALYLVCGERGFFYTPKTRREAEDLQVGQVELGGGPGAGSLQPLALEGSLQKRGIVEQCCTSICSLYQLENYCN. Use the hosted NVIDIA API.",
-      "expected_output": "A working Python script that calls the hosted Boltz2 endpoint with the NGC_API_KEY as a Bearer token, submits the insulin sequence as a protein polymer, saves the returned mmCIF structure to a .cif file, and prints the confidence score.",
+      "prompt": "I want to predict the structure of insulin using Boltz2. The sequence is MALWMRLLPLLALLALWGPDPAAAFVNQHLCGSHLVEALYLVCGERGFFYTPKTRREAEDLQVGQVELGGGPGAGSLQPLALEGSLQKRGIVEQCCTSICSLYQLENYCN. Use the hosted NVIDIA API. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted Boltz2 request using NGC_API_KEY as a Bearer token, submitting the insulin sequence as a protein polymer, plus the actual confidence score and returned mmCIF structure artifact.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived confidence values and the saved .cif path"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted endpoint URL (health.api.nvidia.com)",
@@ -38,7 +43,9 @@
           "check": "Script uses os.environ or os.getenv to read NGC_API_KEY"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I have a protein target (sequence: MTEYKLVVVGACGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVID) and I want to dock aspirin (SMILES: CC(=O)OC1=CC=CC=C1C(=O)O) to it and get a binding affinity score. Use the hosted API. My NGC_API_KEY is already set in my environment.",
@@ -78,6 +85,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me set up the Boltz2 NIM locally with Docker. I have an A100 GPU and my NGC_API_KEY is set. Once it's running, predict the structure of this short peptide: ACDEFGHIKLMNPQRSTVWY",
       "expected_output": "Step-by-step Docker setup commands that use shell env first and optional repo-root .env overrides, require NGC_API_KEY or NVIDIA_API_KEY fallback plus LOCAL_NIM_CACHE, run health checks, then send a no Authorization local request to localhost:8000 and save the output .cif file.",

--- a/nim-skills/diffdock-nim/evals/config.yml
+++ b/nim-skills/diffdock-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/diffdock-nim/evals/evals.json
+++ b/nim-skills/diffdock-nim/evals/evals.json
@@ -3,10 +3,17 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to dock aspirin (SMILES: CC(=O)OC1=CC=CC=C1C(=O)O) to a protein target. I have the protein structure in protein.pdb. Generate 10 docking poses and show me the confidence scores. Use the hosted NVIDIA DiffDock API.",
-      "expected_output": "A Python script that reads protein.pdb and filters to a non-empty ATOM-only receptor, calls the hosted DiffDock endpoint with Bearer auth, ligand_file_type='txt' for SMILES input, num_poses=10, and prints ranked poses with their confidence scores.",
-      "files": [],
+      "prompt": "I want to dock aspirin (SMILES: CC(=O)OC1=CC=CC=C1C(=O)O) to a protein target using the staged receptor at /workspace/input/protein.pdb. Generate 10 docking poses and show me the confidence scores using the hosted NVIDIA DiffDock API. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted DiffDock request that reads the staged protein.pdb, filters it to a non-empty ATOM-only receptor, uses Bearer auth, ligand_file_type='txt', and num_poses=10, then saves returned poses and reports actual ranked confidence scores.",
+      "files": [
+        "evals/files/protein.pdb"
+      ],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived pose scores and saved artifact paths"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted DiffDock endpoint URL",
@@ -38,7 +45,9 @@
           "check": "Script accesses 'position_confidence' from response and prints or reports scores"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I have an SDF file of a drug candidate (ligand.sdf) and want to dock it to my protein (receptor.pdb). Use the DiffDock hosted API to generate 20 poses and save each pose as a separate SDF file named by its rank and confidence score.",
@@ -78,6 +87,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me set up DiffDock locally with Docker on my GPU. I have an A100 and NGC_API_KEY is set. After setup, dock a small molecule (SMILES: c1ccccc1) to my protein (protein.pdb).",
       "expected_output": "Docker setup commands using shell env first and optional repo-root .env overrides, requiring NGC_API_KEY or NVIDIA_API_KEY fallback plus LOCAL_NIM_CACHE, with the exact pinned image tag :2.2.0, NVIDIA_VISIBLE_DEVICES=0 env var, --shm-size=2G and --ulimit flags, health check, then a local no-auth docking script using localhost:8000 without /v1/ prefix.",

--- a/nim-skills/diffdock-nim/evals/files/protein.pdb
+++ b/nim-skills/diffdock-nim/evals/files/protein.pdb
@@ -1,0 +1,3120 @@
+HEADER    TRANSFERASE                             17-JUN-02   1M17              
+TITLE     EPIDERMAL GROWTH FACTOR RECEPTOR TYROSINE KINASE DOMAIN WITH 4-       
+TITLE    2 ANILINOQUINAZOLINE INHIBITOR ERLOTINIB                               
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: EPIDERMAL GROWTH FACTOR RECEPTOR;                          
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: TYROSINE KINASE DOMAIN (RESIDUES 671-998);                 
+COMPND   5 SYNONYM: RECEPTOR PROTEIN-TYROSINE KINASE ERBB-1;                    
+COMPND   6 EC: 2.7.1.112;                                                       
+COMPND   7 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: EGFR;                                                          
+SOURCE   6 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE   7 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE   8 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE   9 EXPRESSION_SYSTEM_STRAIN: AUTOGRAPHICA CALIFORNICA/T.NICOPLUSIA;     
+SOURCE  10 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  11 EXPRESSION_SYSTEM_VECTOR_TYPE: PLASMID;                              
+SOURCE  12 EXPRESSION_SYSTEM_PLASMID: PVL1392                                   
+KEYWDS    TRANSFERASE, TYROSINE KINASE DOMAIN                                   
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    J.STAMOS,M.X.SLIWKOWSKI,C.EIGENBROT                                   
+REVDAT   4   14-FEB-24 1M17    1       REMARK SEQADV                            
+REVDAT   3   24-FEB-09 1M17    1       VERSN                                    
+REVDAT   2   25-FEB-03 1M17    1       JRNL                                     
+REVDAT   1   04-SEP-02 1M17    0                                                
+JRNL        AUTH   J.STAMOS,M.X.SLIWKOWSKI,C.EIGENBROT                          
+JRNL        TITL   STRUCTURE OF THE EPIDERMAL GROWTH FACTOR RECEPTOR KINASE     
+JRNL        TITL 2 DOMAIN ALONE AND IN COMPLEX WITH A 4-ANILINOQUINAZOLINE      
+JRNL        TITL 3 INHIBITOR.                                                   
+JRNL        REF    J.BIOL.CHEM.                  V. 277 46265 2002              
+JRNL        REFN                   ISSN 0021-9258                               
+JRNL        PMID   12196540                                                     
+JRNL        DOI    10.1074/JBC.M207135200                                       
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.60 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : X-PLOR 98.1                                          
+REMARK   3   AUTHORS     : BRUNGER                                              
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.60                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 30.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.200                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : 1000000.000                    
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : 0.0010                         
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 99.8                           
+REMARK   3   NUMBER OF REFLECTIONS             : 16628                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE            (WORKING SET) : 0.251                           
+REMARK   3   FREE R VALUE                     : 0.295                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 4.100                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 689                             
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : 0.011                           
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 10                           
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.60                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 2.69                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 97.80                        
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 1560                         
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.5850                       
+REMARK   3   BIN FREE R VALUE                    : 0.5770                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : 3.30                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : 53                           
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : 0.059                        
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 2497                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 29                                      
+REMARK   3   SOLVENT ATOMS            : 20                                      
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 88.50                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 70.40                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : 9.70000                                              
+REMARK   3    B22 (A**2) : 9.70000                                              
+REMARK   3    B33 (A**2) : 9.70000                                              
+REMARK   3    B12 (A**2) : 0.00000                                              
+REMARK   3    B13 (A**2) : 0.00000                                              
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.36                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.33                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : 5.00                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.41                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.41                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.011                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.500                           
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : 23.30                           
+REMARK   3   IMPROPER ANGLES        (DEGREES) : 1.810                           
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : RESTRAINED                                
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : 4.850 ; 2.000                
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : 7.220 ; 3.000                
+REMARK   3   SIDE-CHAIN BOND              (A**2) : 10.250; 4.000                
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : 13.670; 6.000                
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : MSI_XPLOR_PARHCSDX.PRO                         
+REMARK   3  PARAMETER FILE  2  : TAR.PAR                                        
+REMARK   3  PARAMETER FILE  3  : PARWAT.PRO                                     
+REMARK   3  PARAMETER FILE  4  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : MSI_XPLOR_TOPHCSDX.PRO                         
+REMARK   3  TOPOLOGY FILE  2   : TAR.TOP                                        
+REMARK   3  TOPOLOGY FILE  3   : TOPWAT.PRO                                     
+REMARK   3  TOPOLOGY FILE  4   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: BULK SOLVENT MODEL USED                   
+REMARK   4                                                                      
+REMARK   4 1M17 COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 01-JUL-02.                  
+REMARK 100 THE DEPOSITION ID IS D_1000016470.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 18-NOV-01                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 7.0                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : ALS                                
+REMARK 200  BEAMLINE                       : 5.0.1                              
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.00                               
+REMARK 200  MONOCHROMATOR                  : CURVED CRYSTAL MONOCHROMATOR       
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : ADSC QUANTUM 4                     
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO, TRUNCATE                    
+REMARK 200  DATA SCALING SOFTWARE          : CCP4 (TRUNCATE)                    
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 16628                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.600                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 30.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : -3.000                             
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 100.0                              
+REMARK 200  DATA REDUNDANCY                : 11.00                              
+REMARK 200  R MERGE                    (I) : 0.09300                            
+REMARK 200  R SYM                      (I) : 0.09300                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 27.0000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.60                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.69                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 100.0                              
+REMARK 200  DATA REDUNDANCY IN SHELL       : 10.50                              
+REMARK 200  R MERGE FOR SHELL          (I) : 0.99000                            
+REMARK 200  R SYM FOR SHELL            (I) : 0.99000                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 2.800                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: AMORE                                                 
+REMARK 200 STARTING MODEL: PDB ENTRY 1FGK; POLY ALANINE                         
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 65.35                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 3.55                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: TARTRATE, PH 7.0, VAPOR DIFFUSION,       
+REMARK 280  HANGING DROP, TEMPERATURE 292K                                      
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: I 2 3                            
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,-Y,Z                                                 
+REMARK 290       3555   -X,Y,-Z                                                 
+REMARK 290       4555   X,-Y,-Z                                                 
+REMARK 290       5555   Z,X,Y                                                   
+REMARK 290       6555   Z,-X,-Y                                                 
+REMARK 290       7555   -Z,-X,Y                                                 
+REMARK 290       8555   -Z,X,-Y                                                 
+REMARK 290       9555   Y,Z,X                                                   
+REMARK 290      10555   -Y,Z,-X                                                 
+REMARK 290      11555   Y,-Z,-X                                                 
+REMARK 290      12555   -Y,-Z,X                                                 
+REMARK 290      13555   X+1/2,Y+1/2,Z+1/2                                       
+REMARK 290      14555   -X+1/2,-Y+1/2,Z+1/2                                     
+REMARK 290      15555   -X+1/2,Y+1/2,-Z+1/2                                     
+REMARK 290      16555   X+1/2,-Y+1/2,-Z+1/2                                     
+REMARK 290      17555   Z+1/2,X+1/2,Y+1/2                                       
+REMARK 290      18555   Z+1/2,-X+1/2,-Y+1/2                                     
+REMARK 290      19555   -Z+1/2,-X+1/2,Y+1/2                                     
+REMARK 290      20555   -Z+1/2,X+1/2,-Y+1/2                                     
+REMARK 290      21555   Y+1/2,Z+1/2,X+1/2                                       
+REMARK 290      22555   -Y+1/2,Z+1/2,-X+1/2                                     
+REMARK 290      23555   Y+1/2,-Z+1/2,-X+1/2                                     
+REMARK 290      24555   -Y+1/2,-Z+1/2,X+1/2                                     
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   5  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY2   5  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   5  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   6  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY2   6 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   6  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   7  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY2   7 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   7  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   8  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY2   8  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   8  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   9  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   9  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY3   9  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  10  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  10  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY3  10 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  11  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  11  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY3  11 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  12  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  12  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY3  12  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  13  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  13  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  13  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY1  14 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  14  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  14  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY1  15 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  15  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  15  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY1  16  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  16  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  16  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY1  17  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY2  17  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  17  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  18  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY2  18 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  18  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  19  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY2  19 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  19  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  20  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY2  20  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  20  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  21  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  21  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY3  21  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  22  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  22  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY3  22 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  23  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  23  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY3  23 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  24  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  24  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY3  24  1.000000  0.000000  0.000000       73.90000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     GLY A   666                                                      
+REMARK 465     SER A   667                                                      
+REMARK 465     HIS A   668                                                      
+REMARK 465     MET A   669                                                      
+REMARK 465     ALA A   670                                                      
+REMARK 465     SER A   671                                                      
+REMARK 465     LEU A   965                                                      
+REMARK 465     PRO A   966                                                      
+REMARK 465     SER A   967                                                      
+REMARK 465     PRO A   968                                                      
+REMARK 465     THR A   969                                                      
+REMARK 465     ASP A   970                                                      
+REMARK 465     SER A   971                                                      
+REMARK 465     ASN A   972                                                      
+REMARK 465     PHE A   973                                                      
+REMARK 465     TYR A   974                                                      
+REMARK 465     ARG A   975                                                      
+REMARK 465     ALA A   976                                                      
+REMARK 465     GLN A   996                                                      
+REMARK 465     GLN A   997                                                      
+REMARK 465     GLY A   998                                                      
+REMARK 475                                                                      
+REMARK 475 ZERO OCCUPANCY RESIDUES                                              
+REMARK 475 THE FOLLOWING RESIDUES WERE MODELED WITH ZERO OCCUPANCY.             
+REMARK 475 THE LOCATION AND PROPERTIES OF THESE RESIDUES MAY NOT                
+REMARK 475 BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;                      
+REMARK 475 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE)          
+REMARK 475   M RES C  SSEQI                                                     
+REMARK 475     GLU A   725                                                      
+REMARK 480                                                                      
+REMARK 480 ZERO OCCUPANCY ATOM                                                  
+REMARK 480 THE FOLLOWING RESIDUES HAVE ATOMS MODELED WITH ZERO                  
+REMARK 480 OCCUPANCY. THE LOCATION AND PROPERTIES OF THESE ATOMS                
+REMARK 480 MAY NOT BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;              
+REMARK 480 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):         
+REMARK 480   M RES C SSEQI ATOMS                                                
+REMARK 480     LYS A  730   CG   CD   CE   NZ                                   
+REMARK 480     GLU A  961   CB   CG   CD   OE1  OE2                             
+REMARK 480     ARG A  962   CB   CG   CD   NE   CZ   NH1  NH2                   
+REMARK 480     MET A  963   CB   CG   SD   CE                                   
+REMARK 480     MET A  978   CB   CG   SD   CE                                   
+REMARK 480     ILE A  994   CB   CG1  CG2  CD1                                  
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    PRO A 951   C   -  N   -  CA  ANGL. DEV. =  10.6 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ILE A 691      -25.30   -142.93                                   
+REMARK 500    LYS A 692      142.35   -174.91                                   
+REMARK 500    SER A 696       64.50   -113.56                                   
+REMARK 500    PHE A 699      -18.20   -164.03                                   
+REMARK 500    GLU A 712     -179.24    -59.98                                   
+REMARK 500    THR A 759     -148.11   -104.25                                   
+REMARK 500    ASP A 783        2.15    -69.42                                   
+REMARK 500    HIS A 811      -70.63    -22.63                                   
+REMARK 500    ASP A 813       49.55   -155.75                                   
+REMARK 500    ASP A 831       80.70     54.04                                   
+REMARK 500    ASP A 831       82.14     54.44                                   
+REMARK 500    GLU A 848      -89.90   -131.32                                   
+REMARK 500    LYS A 851       19.04   -142.06                                   
+REMARK 500    ASP A 892      -38.02    -39.93                                   
+REMARK 500    ILE A 894      130.75    -26.87                                   
+REMARK 500    ALA A 896      -33.42    -36.08                                   
+REMARK 500    GLU A 961      -95.66    171.34                                   
+REMARK 500    ARG A 962      -41.08   -139.59                                   
+REMARK 500    MET A 963       53.16     72.86                                   
+REMARK 500    MET A 978      101.51    -50.90                                   
+REMARK 500    ASP A 982       65.59   -103.83                                   
+REMARK 500    ILE A 994       99.42    -19.72                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: MAIN CHAIN PLANARITY                                       
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING RESIDUES HAVE A PSEUDO PLANARITY                       
+REMARK 500 TORSION ANGLE, C(I) - CA(I) - N(I+1) - O(I), GREATER                 
+REMARK 500 10.0 DEGREES. (M=MODEL NUMBER; RES=RESIDUE NAME;                     
+REMARK 500 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;                            
+REMARK 500 I=INSERTION CODE).                                                   
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        ANGLE                                           
+REMARK 500    HIS A 811        -14.02                                           
+REMARK 500    ARG A 812        -10.67                                           
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE AQ4 A 999                 
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 1M14   RELATED DB: PDB                                   
+REMARK 900 APO-FORM EPIDERMAL GROWTH FACTOR RECEPTOR KINASE DOMAIN              
+DBREF  1M17 A  671   998  UNP    P00533   EGFR_HUMAN     695   1022             
+SEQADV 1M17 GLY A  666  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 SER A  667  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 HIS A  668  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 MET A  669  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 ALA A  670  UNP  P00533              CLONING ARTIFACT               
+SEQRES   1 A  333  GLY SER HIS MET ALA SER GLY GLU ALA PRO ASN GLN ALA          
+SEQRES   2 A  333  LEU LEU ARG ILE LEU LYS GLU THR GLU PHE LYS LYS ILE          
+SEQRES   3 A  333  LYS VAL LEU GLY SER GLY ALA PHE GLY THR VAL TYR LYS          
+SEQRES   4 A  333  GLY LEU TRP ILE PRO GLU GLY GLU LYS VAL LYS ILE PRO          
+SEQRES   5 A  333  VAL ALA ILE LYS GLU LEU ARG GLU ALA THR SER PRO LYS          
+SEQRES   6 A  333  ALA ASN LYS GLU ILE LEU ASP GLU ALA TYR VAL MET ALA          
+SEQRES   7 A  333  SER VAL ASP ASN PRO HIS VAL CYS ARG LEU LEU GLY ILE          
+SEQRES   8 A  333  CYS LEU THR SER THR VAL GLN LEU ILE THR GLN LEU MET          
+SEQRES   9 A  333  PRO PHE GLY CYS LEU LEU ASP TYR VAL ARG GLU HIS LYS          
+SEQRES  10 A  333  ASP ASN ILE GLY SER GLN TYR LEU LEU ASN TRP CYS VAL          
+SEQRES  11 A  333  GLN ILE ALA LYS GLY MET ASN TYR LEU GLU ASP ARG ARG          
+SEQRES  12 A  333  LEU VAL HIS ARG ASP LEU ALA ALA ARG ASN VAL LEU VAL          
+SEQRES  13 A  333  LYS THR PRO GLN HIS VAL LYS ILE THR ASP PHE GLY LEU          
+SEQRES  14 A  333  ALA LYS LEU LEU GLY ALA GLU GLU LYS GLU TYR HIS ALA          
+SEQRES  15 A  333  GLU GLY GLY LYS VAL PRO ILE LYS TRP MET ALA LEU GLU          
+SEQRES  16 A  333  SER ILE LEU HIS ARG ILE TYR THR HIS GLN SER ASP VAL          
+SEQRES  17 A  333  TRP SER TYR GLY VAL THR VAL TRP GLU LEU MET THR PHE          
+SEQRES  18 A  333  GLY SER LYS PRO TYR ASP GLY ILE PRO ALA SER GLU ILE          
+SEQRES  19 A  333  SER SER ILE LEU GLU LYS GLY GLU ARG LEU PRO GLN PRO          
+SEQRES  20 A  333  PRO ILE CYS THR ILE ASP VAL TYR MET ILE MET VAL LYS          
+SEQRES  21 A  333  CYS TRP MET ILE ASP ALA ASP SER ARG PRO LYS PHE ARG          
+SEQRES  22 A  333  GLU LEU ILE ILE GLU PHE SER LYS MET ALA ARG ASP PRO          
+SEQRES  23 A  333  GLN ARG TYR LEU VAL ILE GLN GLY ASP GLU ARG MET HIS          
+SEQRES  24 A  333  LEU PRO SER PRO THR ASP SER ASN PHE TYR ARG ALA LEU          
+SEQRES  25 A  333  MET ASP GLU GLU ASP MET ASP ASP VAL VAL ASP ALA ASP          
+SEQRES  26 A  333  GLU TYR LEU ILE PRO GLN GLN GLY                              
+HET    AQ4  A 999      29                                                       
+HETNAM     AQ4 [6,7-BIS(2-METHOXY-ETHOXY)QUINAZOLINE-4-YL]-(3-                  
+HETNAM   2 AQ4  ETHYNYLPHENYL)AMINE                                             
+HETSYN     AQ4 ERLOTINIB                                                        
+FORMUL   2  AQ4    C22 H23 N3 O4                                                
+FORMUL   3  HOH   *20(H2 O)                                                     
+HELIX    1   1 LYS A  684  THR A  686  5                                   3    
+HELIX    2   2 SER A  728  ALA A  743  1                                  16    
+HELIX    3   3 CYS A  773  GLU A  780  1                                   8    
+HELIX    4   4 HIS A  781  ILE A  785  5                                   5    
+HELIX    5   5 GLY A  786  ARG A  807  1                                  22    
+HELIX    6   6 ALA A  815  ARG A  817  5                                   3    
+HELIX    7   7 PRO A  853  MET A  857  5                                   5    
+HELIX    8   8 ALA A  858  ARG A  865  1                                   8    
+HELIX    9   9 THR A  868  THR A  885  1                                  18    
+HELIX   10  10 PRO A  895  LYS A  905  1                                  11    
+HELIX   11  11 THR A  916  CYS A  926  1                                  11    
+HELIX   12  12 ASP A  930  ARG A  934  5                                   5    
+HELIX   13  13 LYS A  936  ARG A  949  1                                  14    
+HELIX   14  14 ASP A  950  TYR A  954  5                                   5    
+HELIX   15  15 ASP A  988  TYR A  992  5                                   5    
+SHEET    1   A 5 PHE A 688  GLY A 695  0                                        
+SHEET    2   A 5 THR A 701  TRP A 707 -1  O  LEU A 706   N  LYS A 689           
+SHEET    3   A 5 ILE A 716  GLU A 722 -1  O  ILE A 720   N  TYR A 703           
+SHEET    4   A 5 VAL A 762  GLN A 767 -1  O  LEU A 764   N  LYS A 721           
+SHEET    5   A 5 LEU A 753  LEU A 758 -1  N  GLY A 755   O  ILE A 765           
+SHEET    1   B 2 LEU A 809  VAL A 810  0                                        
+SHEET    2   B 2 LYS A 836  LEU A 837 -1  O  LYS A 836   N  VAL A 810           
+SHEET    1   C 2 VAL A 819  THR A 823  0                                        
+SHEET    2   C 2 HIS A 826  ILE A 829 -1  O  LYS A 828   N  LEU A 820           
+SHEET    1   D 2 TYR A 845  HIS A 846  0                                        
+SHEET    2   D 2 ILE A 866  TYR A 867 -1  O  TYR A 867   N  TYR A 845           
+SITE     1 AC1 14 HOH A  10  LEU A 694  ALA A 719  LEU A 764                    
+SITE     2 AC1 14 THR A 766  GLN A 767  LEU A 768  MET A 769                    
+SITE     3 AC1 14 PRO A 770  PHE A 771  GLY A 772  LEU A 820                    
+SITE     4 AC1 14 THR A 830  ASP A 831                                          
+CRYST1  147.800  147.800  147.800  90.00  90.00  90.00 I 2 3        24          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.006766  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.006766  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.006766        0.00000                         
+ATOM      1  N   GLY A 672      55.000   8.448  68.519  1.00101.99           N  
+ATOM      2  CA  GLY A 672      54.168   8.340  69.707  1.00104.94           C  
+ATOM      3  C   GLY A 672      52.692   8.194  69.380  1.00105.46           C  
+ATOM      4  O   GLY A 672      51.877   9.045  69.750  1.00108.67           O  
+ATOM      5  N   GLU A 673      52.359   7.101  68.691  1.00102.41           N  
+ATOM      6  CA  GLU A 673      50.994   6.785  68.274  1.00 89.17           C  
+ATOM      7  C   GLU A 673      50.624   5.325  68.585  1.00 81.77           C  
+ATOM      8  O   GLU A 673      51.438   4.411  68.405  1.00 81.88           O  
+ATOM      9  CB  GLU A 673      50.850   7.050  66.777  1.00 96.53           C  
+ATOM     10  CG  GLU A 673      50.252   8.399  66.438  1.00 99.19           C  
+ATOM     11  CD  GLU A 673      48.788   8.486  66.827  1.00115.45           C  
+ATOM     12  OE1 GLU A 673      48.062   7.477  66.681  1.00116.71           O  
+ATOM     13  OE2 GLU A 673      48.356   9.561  67.286  1.00113.58           O  
+ATOM     14  N   ALA A 674      49.387   5.109  69.023  1.00 67.27           N  
+ATOM     15  CA  ALA A 674      48.912   3.768  69.370  1.00 63.11           C  
+ATOM     16  C   ALA A 674      48.702   2.826  68.174  1.00 58.54           C  
+ATOM     17  O   ALA A 674      48.064   3.183  67.186  1.00 62.02           O  
+ATOM     18  CB  ALA A 674      47.616   3.866  70.189  1.00 47.04           C  
+ATOM     19  N   PRO A 675      49.260   1.612  68.240  1.00 55.66           N  
+ATOM     20  CA  PRO A 675      49.087   0.665  67.134  1.00 52.95           C  
+ATOM     21  C   PRO A 675      47.629   0.261  66.997  1.00 48.19           C  
+ATOM     22  O   PRO A 675      46.975  -0.018  67.990  1.00 52.74           O  
+ATOM     23  CB  PRO A 675      49.957  -0.520  67.559  1.00 47.27           C  
+ATOM     24  CG  PRO A 675      49.985  -0.423  69.030  1.00 45.81           C  
+ATOM     25  CD  PRO A 675      50.160   1.054  69.259  1.00 50.66           C  
+ATOM     26  N   ASN A 676      47.124   0.267  65.767  1.00 44.01           N  
+ATOM     27  CA  ASN A 676      45.735  -0.094  65.484  1.00 40.28           C  
+ATOM     28  C   ASN A 676      45.670  -1.611  65.311  1.00 48.80           C  
+ATOM     29  O   ASN A 676      45.949  -2.152  64.242  1.00 55.33           O  
+ATOM     30  CB  ASN A 676      45.253   0.656  64.234  1.00 20.42           C  
+ATOM     31  CG  ASN A 676      43.833   0.305  63.840  1.00 38.31           C  
+ATOM     32  OD1 ASN A 676      43.184  -0.547  64.462  1.00 38.69           O  
+ATOM     33  ND2 ASN A 676      43.352   0.935  62.761  1.00 34.99           N  
+ATOM     34  N   GLN A 677      45.279  -2.295  66.375  1.00 48.40           N  
+ATOM     35  CA  GLN A 677      45.231  -3.744  66.357  1.00 40.03           C  
+ATOM     36  C   GLN A 677      43.926  -4.343  65.921  1.00 45.90           C  
+ATOM     37  O   GLN A 677      43.625  -5.501  66.240  1.00 49.60           O  
+ATOM     38  CB  GLN A 677      45.616  -4.279  67.715  1.00 29.98           C  
+ATOM     39  CG  GLN A 677      47.009  -3.846  68.116  1.00 42.03           C  
+ATOM     40  CD  GLN A 677      47.436  -4.467  69.415  1.00 62.22           C  
+ATOM     41  OE1 GLN A 677      47.647  -5.682  69.495  1.00 70.94           O  
+ATOM     42  NE2 GLN A 677      47.561  -3.643  70.450  1.00 59.09           N  
+ATOM     43  N   ALA A 678      43.161  -3.570  65.163  1.00 34.42           N  
+ATOM     44  CA  ALA A 678      41.893  -4.066  64.686  1.00 35.12           C  
+ATOM     45  C   ALA A 678      42.111  -5.288  63.790  1.00 44.91           C  
+ATOM     46  O   ALA A 678      43.117  -5.391  63.081  1.00 41.52           O  
+ATOM     47  CB  ALA A 678      41.180  -2.978  63.914  1.00 32.34           C  
+ATOM     48  N   LEU A 679      41.136  -6.189  63.819  1.00 48.66           N  
+ATOM     49  CA  LEU A 679      41.137  -7.401  63.023  1.00 45.01           C  
+ATOM     50  C   LEU A 679      40.349  -7.257  61.728  1.00 48.23           C  
+ATOM     51  O   LEU A 679      39.169  -6.941  61.768  1.00 56.09           O  
+ATOM     52  CB  LEU A 679      40.525  -8.546  63.825  1.00 44.12           C  
+ATOM     53  CG  LEU A 679      41.521  -9.444  64.556  1.00 51.90           C  
+ATOM     54  CD1 LEU A 679      42.537  -8.601  65.285  1.00 58.50           C  
+ATOM     55  CD2 LEU A 679      40.775 -10.364  65.507  1.00 42.04           C  
+ATOM     56  N   LEU A 680      40.996  -7.482  60.581  1.00 49.83           N  
+ATOM     57  CA  LEU A 680      40.291  -7.423  59.298  1.00 43.39           C  
+ATOM     58  C   LEU A 680      39.949  -8.882  58.974  1.00 48.99           C  
+ATOM     59  O   LEU A 680      40.826  -9.740  58.934  1.00 53.76           O  
+ATOM     60  CB  LEU A 680      41.175  -6.827  58.207  1.00 37.01           C  
+ATOM     61  CG  LEU A 680      40.573  -6.816  56.796  1.00 35.30           C  
+ATOM     62  CD1 LEU A 680      39.397  -5.821  56.701  1.00 37.97           C  
+ATOM     63  CD2 LEU A 680      41.665  -6.429  55.796  1.00 35.95           C  
+ATOM     64  N   ARG A 681      38.667  -9.166  58.795  1.00 44.02           N  
+ATOM     65  CA  ARG A 681      38.223 -10.519  58.522  1.00 42.32           C  
+ATOM     66  C   ARG A 681      37.949 -10.740  57.035  1.00 45.12           C  
+ATOM     67  O   ARG A 681      37.255  -9.945  56.386  1.00 38.01           O  
+ATOM     68  CB  ARG A 681      36.972 -10.804  59.347  1.00 41.38           C  
+ATOM     69  CG  ARG A 681      36.533 -12.246  59.396  1.00 46.82           C  
+ATOM     70  CD  ARG A 681      36.971 -12.935  60.685  1.00 82.56           C  
+ATOM     71  NE  ARG A 681      36.424 -14.290  60.780  1.00 86.14           N  
+ATOM     72  CZ  ARG A 681      35.187 -14.578  61.182  1.00 84.63           C  
+ATOM     73  NH1 ARG A 681      34.352 -13.610  61.546  1.00 72.91           N  
+ATOM     74  NH2 ARG A 681      34.766 -15.836  61.176  1.00 83.37           N  
+ATOM     75  N   ILE A 682      38.552 -11.795  56.496  1.00 39.80           N  
+ATOM     76  CA  ILE A 682      38.382 -12.164  55.101  1.00 47.32           C  
+ATOM     77  C   ILE A 682      37.343 -13.270  55.114  1.00 51.12           C  
+ATOM     78  O   ILE A 682      37.536 -14.301  55.751  1.00 59.26           O  
+ATOM     79  CB  ILE A 682      39.697 -12.693  54.479  1.00 49.82           C  
+ATOM     80  CG1 ILE A 682      40.840 -11.707  54.727  1.00 56.94           C  
+ATOM     81  CG2 ILE A 682      39.533 -12.862  52.973  1.00 51.45           C  
+ATOM     82  CD1 ILE A 682      40.727 -10.401  53.970  1.00 56.08           C  
+ATOM     83  N   LEU A 683      36.228 -13.026  54.437  1.00 53.87           N  
+ATOM     84  CA  LEU A 683      35.113 -13.966  54.380  1.00 52.97           C  
+ATOM     85  C   LEU A 683      35.007 -14.617  53.017  1.00 56.46           C  
+ATOM     86  O   LEU A 683      35.076 -13.933  51.990  1.00 55.89           O  
+ATOM     87  CB  LEU A 683      33.800 -13.220  54.654  1.00 51.20           C  
+ATOM     88  CG  LEU A 683      33.288 -12.808  56.041  1.00 54.79           C  
+ATOM     89  CD1 LEU A 683      34.366 -12.460  56.994  1.00 51.48           C  
+ATOM     90  CD2 LEU A 683      32.346 -11.632  55.877  1.00 66.29           C  
+ATOM     91  N   LYS A 684      34.781 -15.928  53.010  1.00 58.26           N  
+ATOM     92  CA  LYS A 684      34.639 -16.678  51.758  1.00 59.33           C  
+ATOM     93  C   LYS A 684      33.318 -16.321  51.089  1.00 54.25           C  
+ATOM     94  O   LYS A 684      32.303 -16.216  51.763  1.00 58.73           O  
+ATOM     95  CB  LYS A 684      34.684 -18.185  52.032  1.00 67.19           C  
+ATOM     96  CG  LYS A 684      36.076 -18.725  52.314  1.00 66.13           C  
+ATOM     97  CD  LYS A 684      36.039 -20.146  52.877  1.00 88.84           C  
+ATOM     98  CE  LYS A 684      36.020 -20.161  54.414  1.00 96.10           C  
+ATOM     99  NZ  LYS A 684      37.299 -19.673  55.046  1.00 87.18           N  
+ATOM    100  N   GLU A 685      33.343 -16.113  49.776  1.00 57.85           N  
+ATOM    101  CA  GLU A 685      32.135 -15.771  49.021  1.00 62.13           C  
+ATOM    102  C   GLU A 685      31.104 -16.891  49.081  1.00 62.48           C  
+ATOM    103  O   GLU A 685      29.931 -16.662  48.802  1.00 63.27           O  
+ATOM    104  CB  GLU A 685      32.453 -15.464  47.551  1.00 68.26           C  
+ATOM    105  CG  GLU A 685      31.226 -15.010  46.765  1.00 84.32           C  
+ATOM    106  CD  GLU A 685      31.443 -14.943  45.262  1.00 91.80           C  
+ATOM    107  OE1 GLU A 685      32.017 -15.896  44.688  1.00 84.66           O  
+ATOM    108  OE2 GLU A 685      31.002 -13.944  44.647  1.00 98.29           O  
+ATOM    109  N   THR A 686      31.550 -18.099  49.421  1.00 61.51           N  
+ATOM    110  CA  THR A 686      30.656 -19.251  49.526  1.00 58.28           C  
+ATOM    111  C   THR A 686      29.838 -19.192  50.808  1.00 62.68           C  
+ATOM    112  O   THR A 686      28.806 -19.855  50.926  1.00 66.33           O  
+ATOM    113  CB  THR A 686      31.447 -20.581  49.535  1.00 63.51           C  
+ATOM    114  OG1 THR A 686      32.425 -20.559  50.583  1.00 67.12           O  
+ATOM    115  CG2 THR A 686      32.147 -20.796  48.205  1.00 67.37           C  
+ATOM    116  N   GLU A 687      30.316 -18.412  51.775  1.00 60.23           N  
+ATOM    117  CA  GLU A 687      29.646 -18.278  53.054  1.00 58.34           C  
+ATOM    118  C   GLU A 687      28.446 -17.321  53.054  1.00 64.79           C  
+ATOM    119  O   GLU A 687      27.706 -17.238  54.036  1.00 64.31           O  
+ATOM    120  CB  GLU A 687      30.646 -17.874  54.130  1.00 58.34           C  
+ATOM    121  CG  GLU A 687      31.562 -18.990  54.600  1.00 80.80           C  
+ATOM    122  CD  GLU A 687      32.437 -18.572  55.784  1.00 97.59           C  
+ATOM    123  OE1 GLU A 687      32.747 -17.356  55.913  1.00 75.67           O  
+ATOM    124  OE2 GLU A 687      32.808 -19.466  56.587  1.00 97.68           O  
+ATOM    125  N   PHE A 688      28.251 -16.580  51.975  1.00 64.31           N  
+ATOM    126  CA  PHE A 688      27.116 -15.684  51.945  1.00 67.98           C  
+ATOM    127  C   PHE A 688      26.294 -15.748  50.684  1.00 69.25           C  
+ATOM    128  O   PHE A 688      26.815 -15.813  49.583  1.00 68.74           O  
+ATOM    129  CB  PHE A 688      27.494 -14.240  52.322  1.00 70.10           C  
+ATOM    130  CG  PHE A 688      28.572 -13.633  51.481  1.00 58.86           C  
+ATOM    131  CD1 PHE A 688      28.279 -13.095  50.231  1.00 56.79           C  
+ATOM    132  CD2 PHE A 688      29.870 -13.533  51.970  1.00 55.85           C  
+ATOM    133  CE1 PHE A 688      29.266 -12.454  49.471  1.00 65.53           C  
+ATOM    134  CE2 PHE A 688      30.866 -12.899  51.228  1.00 72.14           C  
+ATOM    135  CZ  PHE A 688      30.562 -12.355  49.969  1.00 65.97           C  
+ATOM    136  N   LYS A 689      24.983 -15.763  50.878  1.00 80.77           N  
+ATOM    137  CA  LYS A 689      24.030 -15.845  49.785  1.00 91.79           C  
+ATOM    138  C   LYS A 689      23.388 -14.498  49.462  1.00 96.14           C  
+ATOM    139  O   LYS A 689      22.547 -14.029  50.231  1.00100.71           O  
+ATOM    140  CB  LYS A 689      22.945 -16.878  50.142  1.00 83.32           C  
+ATOM    141  CG  LYS A 689      23.489 -18.305  50.331  1.00100.98           C  
+ATOM    142  CD  LYS A 689      22.477 -19.245  50.999  1.00115.48           C  
+ATOM    143  CE  LYS A 689      23.006 -20.685  51.088  1.00116.29           C  
+ATOM    144  NZ  LYS A 689      24.379 -20.774  51.687  1.00116.57           N  
+ATOM    145  N   LYS A 690      23.804 -13.861  48.359  1.00 95.36           N  
+ATOM    146  CA  LYS A 690      23.202 -12.584  47.943  1.00 95.83           C  
+ATOM    147  C   LYS A 690      21.732 -12.882  47.677  1.00100.52           C  
+ATOM    148  O   LYS A 690      21.374 -14.028  47.393  1.00105.12           O  
+ATOM    149  CB  LYS A 690      23.821 -12.043  46.655  1.00 82.71           C  
+ATOM    150  CG  LYS A 690      25.275 -11.623  46.754  1.00100.02           C  
+ATOM    151  CD  LYS A 690      25.737 -10.992  45.442  1.00 99.11           C  
+ATOM    152  CE  LYS A 690      27.224 -10.673  45.442  1.00106.97           C  
+ATOM    153  NZ  LYS A 690      27.659 -10.051  44.153  1.00102.61           N  
+ATOM    154  N   ILE A 691      20.882 -11.864  47.738  1.00100.52           N  
+ATOM    155  CA  ILE A 691      19.458 -12.095  47.535  1.00103.05           C  
+ATOM    156  C   ILE A 691      18.717 -10.999  46.775  1.00101.59           C  
+ATOM    157  O   ILE A 691      17.699 -11.269  46.137  1.00102.59           O  
+ATOM    158  CB  ILE A 691      18.750 -12.447  48.894  1.00106.08           C  
+ATOM    159  CG1 ILE A 691      19.039 -13.922  49.260  1.00107.21           C  
+ATOM    160  CG2 ILE A 691      17.249 -12.126  48.836  1.00 99.67           C  
+ATOM    161  CD1 ILE A 691      18.389 -14.450  50.534  1.00 96.73           C  
+ATOM    162  N   LYS A 692      19.232  -9.775  46.820  1.00 98.47           N  
+ATOM    163  CA  LYS A 692      18.600  -8.669  46.111  1.00 99.96           C  
+ATOM    164  C   LYS A 692      19.409  -7.388  46.189  1.00 99.94           C  
+ATOM    165  O   LYS A 692      20.030  -7.092  47.206  1.00105.63           O  
+ATOM    166  CB  LYS A 692      17.181  -8.414  46.637  1.00103.26           C  
+ATOM    167  CG  LYS A 692      16.382  -7.413  45.792  1.00111.51           C  
+ATOM    168  CD  LYS A 692      14.918  -7.296  46.228  1.00111.95           C  
+ATOM    169  CE  LYS A 692      14.780  -6.664  47.611  1.00116.20           C  
+ATOM    170  NZ  LYS A 692      13.355  -6.525  48.042  1.00109.63           N  
+ATOM    171  N   VAL A 693      19.418  -6.644  45.092  1.00 97.62           N  
+ATOM    172  CA  VAL A 693      20.135  -5.382  45.039  1.00 97.34           C  
+ATOM    173  C   VAL A 693      19.298  -4.314  45.738  1.00 92.97           C  
+ATOM    174  O   VAL A 693      18.082  -4.249  45.558  1.00 92.20           O  
+ATOM    175  CB  VAL A 693      20.429  -4.968  43.570  1.00105.18           C  
+ATOM    176  CG1 VAL A 693      19.148  -5.003  42.744  1.00119.10           C  
+ATOM    177  CG2 VAL A 693      21.072  -3.579  43.511  1.00 97.02           C  
+ATOM    178  N   LEU A 694      19.948  -3.530  46.592  1.00 91.31           N  
+ATOM    179  CA  LEU A 694      19.280  -2.458  47.324  1.00 87.66           C  
+ATOM    180  C   LEU A 694      19.436  -1.120  46.591  1.00 87.83           C  
+ATOM    181  O   LEU A 694      18.608  -0.221  46.749  1.00 85.52           O  
+ATOM    182  CB  LEU A 694      19.836  -2.349  48.753  1.00 72.62           C  
+ATOM    183  CG  LEU A 694      19.623  -3.538  49.701  1.00 74.33           C  
+ATOM    184  CD1 LEU A 694      20.383  -3.331  51.001  1.00 66.02           C  
+ATOM    185  CD2 LEU A 694      18.159  -3.739  49.984  1.00 65.19           C  
+ATOM    186  N   GLY A 695      20.488  -0.999  45.783  1.00 87.25           N  
+ATOM    187  CA  GLY A 695      20.722   0.231  45.050  1.00 88.89           C  
+ATOM    188  C   GLY A 695      21.960   0.190  44.182  1.00 92.19           C  
+ATOM    189  O   GLY A 695      23.025  -0.204  44.642  1.00 93.06           O  
+ATOM    190  N   SER A 696      21.821   0.632  42.935  1.00 96.47           N  
+ATOM    191  CA  SER A 696      22.923   0.647  41.974  1.00101.62           C  
+ATOM    192  C   SER A 696      23.323   2.078  41.602  1.00104.11           C  
+ATOM    193  O   SER A 696      23.201   2.478  40.441  1.00108.43           O  
+ATOM    194  CB  SER A 696      22.521  -0.115  40.699  1.00108.42           C  
+ATOM    195  OG  SER A 696      22.151  -1.460  40.966  1.00108.36           O  
+ATOM    196  N   GLY A 697      23.823   2.838  42.573  1.00103.19           N  
+ATOM    197  CA  GLY A 697      24.214   4.215  42.311  1.00104.91           C  
+ATOM    198  C   GLY A 697      25.517   4.427  41.555  1.00108.96           C  
+ATOM    199  O   GLY A 697      26.128   3.482  41.054  1.00104.19           O  
+ATOM    200  N   ALA A 698      25.933   5.689  41.469  1.00114.52           N  
+ATOM    201  CA  ALA A 698      27.167   6.072  40.782  1.00117.16           C  
+ATOM    202  C   ALA A 698      28.370   5.871  41.706  1.00118.16           C  
+ATOM    203  O   ALA A 698      29.097   6.815  42.035  1.00119.72           O  
+ATOM    204  CB  ALA A 698      27.083   7.533  40.316  1.00115.19           C  
+ATOM    205  N   PHE A 699      28.558   4.623  42.122  1.00116.72           N  
+ATOM    206  CA  PHE A 699      29.645   4.231  43.015  1.00113.53           C  
+ATOM    207  C   PHE A 699      29.797   2.714  42.961  1.00109.26           C  
+ATOM    208  O   PHE A 699      30.824   2.165  43.355  1.00111.65           O  
+ATOM    209  CB  PHE A 699      29.338   4.667  44.456  1.00118.75           C  
+ATOM    210  CG  PHE A 699      28.004   4.176  44.973  1.00118.74           C  
+ATOM    211  CD1 PHE A 699      27.866   2.883  45.478  1.00111.76           C  
+ATOM    212  CD2 PHE A 699      26.885   5.006  44.943  1.00107.12           C  
+ATOM    213  CE1 PHE A 699      26.639   2.420  45.936  1.00 97.80           C  
+ATOM    214  CE2 PHE A 699      25.652   4.554  45.399  1.00106.02           C  
+ATOM    215  CZ  PHE A 699      25.529   3.258  45.898  1.00109.04           C  
+ATOM    216  N   GLY A 700      28.753   2.052  42.474  1.00104.85           N  
+ATOM    217  CA  GLY A 700      28.740   0.605  42.369  1.00 97.40           C  
+ATOM    218  C   GLY A 700      27.358   0.121  42.761  1.00 93.71           C  
+ATOM    219  O   GLY A 700      26.354   0.697  42.344  1.00 95.38           O  
+ATOM    220  N   THR A 701      27.296  -0.906  43.599  1.00 87.61           N  
+ATOM    221  CA  THR A 701      26.015  -1.440  44.039  1.00 86.49           C  
+ATOM    222  C   THR A 701      26.071  -1.916  45.491  1.00 82.66           C  
+ATOM    223  O   THR A 701      27.139  -2.237  46.011  1.00 85.92           O  
+ATOM    224  CB  THR A 701      25.567  -2.640  43.161  1.00 91.10           C  
+ATOM    225  OG1 THR A 701      26.550  -3.678  43.240  1.00102.39           O  
+ATOM    226  CG2 THR A 701      25.401  -2.229  41.702  1.00 98.64           C  
+ATOM    227  N   VAL A 702      24.908  -1.947  46.137  1.00 75.13           N  
+ATOM    228  CA  VAL A 702      24.783  -2.409  47.510  1.00 64.88           C  
+ATOM    229  C   VAL A 702      23.764  -3.539  47.482  1.00 61.79           C  
+ATOM    230  O   VAL A 702      22.630  -3.357  47.065  1.00 63.97           O  
+ATOM    231  CB  VAL A 702      24.297  -1.281  48.468  1.00 65.09           C  
+ATOM    232  CG1 VAL A 702      24.107  -1.820  49.880  1.00 43.16           C  
+ATOM    233  CG2 VAL A 702      25.304  -0.149  48.505  1.00 62.08           C  
+ATOM    234  N   TYR A 703      24.185  -4.718  47.903  1.00 60.53           N  
+ATOM    235  CA  TYR A 703      23.306  -5.870  47.920  1.00 63.58           C  
+ATOM    236  C   TYR A 703      22.822  -6.169  49.326  1.00 68.03           C  
+ATOM    237  O   TYR A 703      23.352  -5.659  50.309  1.00 66.69           O  
+ATOM    238  CB  TYR A 703      24.037  -7.108  47.396  1.00 68.72           C  
+ATOM    239  CG  TYR A 703      24.558  -6.999  45.981  1.00 79.26           C  
+ATOM    240  CD1 TYR A 703      25.779  -6.382  45.713  1.00 79.20           C  
+ATOM    241  CD2 TYR A 703      23.875  -7.599  44.920  1.00 88.24           C  
+ATOM    242  CE1 TYR A 703      26.314  -6.377  44.426  1.00 98.08           C  
+ATOM    243  CE2 TYR A 703      24.401  -7.601  43.628  1.00101.26           C  
+ATOM    244  CZ  TYR A 703      25.624  -6.994  43.388  1.00102.01           C  
+ATOM    245  OH  TYR A 703      26.174  -7.036  42.126  1.00103.20           O  
+ATOM    246  N   LYS A 704      21.853  -7.070  49.395  1.00 70.52           N  
+ATOM    247  CA  LYS A 704      21.250  -7.522  50.636  1.00 68.05           C  
+ATOM    248  C   LYS A 704      21.421  -9.039  50.616  1.00 68.08           C  
+ATOM    249  O   LYS A 704      21.176  -9.659  49.590  1.00 71.86           O  
+ATOM    250  CB  LYS A 704      19.771  -7.140  50.612  1.00 61.42           C  
+ATOM    251  CG  LYS A 704      18.866  -7.997  51.428  1.00 53.95           C  
+ATOM    252  CD  LYS A 704      17.435  -7.552  51.228  1.00 73.29           C  
+ATOM    253  CE  LYS A 704      16.456  -8.597  51.733  1.00 82.78           C  
+ATOM    254  NZ  LYS A 704      16.843  -9.136  53.079  1.00 85.34           N  
+ATOM    255  N   GLY A 705      21.871  -9.629  51.722  1.00 65.43           N  
+ATOM    256  CA  GLY A 705      22.056 -11.074  51.766  1.00 60.14           C  
+ATOM    257  C   GLY A 705      22.115 -11.706  53.149  1.00 58.50           C  
+ATOM    258  O   GLY A 705      21.702 -11.117  54.135  1.00 60.85           O  
+ATOM    259  N   LEU A 706      22.560 -12.952  53.207  1.00 58.10           N  
+ATOM    260  CA  LEU A 706      22.689 -13.658  54.471  1.00 57.06           C  
+ATOM    261  C   LEU A 706      24.086 -14.237  54.555  1.00 59.35           C  
+ATOM    262  O   LEU A 706      24.561 -14.837  53.603  1.00 56.80           O  
+ATOM    263  CB  LEU A 706      21.680 -14.794  54.588  1.00 60.00           C  
+ATOM    264  CG  LEU A 706      20.246 -14.533  55.056  1.00 64.85           C  
+ATOM    265  CD1 LEU A 706      19.525 -15.885  55.250  1.00 56.92           C  
+ATOM    266  CD2 LEU A 706      20.246 -13.752  56.365  1.00 57.72           C  
+ATOM    267  N   TRP A 707      24.749 -14.021  55.688  1.00 63.08           N  
+ATOM    268  CA  TRP A 707      26.094 -14.530  55.914  1.00 60.99           C  
+ATOM    269  C   TRP A 707      25.945 -15.759  56.789  1.00 60.81           C  
+ATOM    270  O   TRP A 707      25.425 -15.681  57.900  1.00 62.18           O  
+ATOM    271  CB  TRP A 707      26.990 -13.473  56.583  1.00 50.81           C  
+ATOM    272  CG  TRP A 707      28.365 -13.973  56.903  1.00 50.75           C  
+ATOM    273  CD1 TRP A 707      29.090 -14.906  56.203  1.00 55.14           C  
+ATOM    274  CD2 TRP A 707      29.161 -13.616  58.033  1.00 49.31           C  
+ATOM    275  NE1 TRP A 707      30.282 -15.157  56.841  1.00 53.37           N  
+ATOM    276  CE2 TRP A 707      30.351 -14.382  57.968  1.00 46.91           C  
+ATOM    277  CE3 TRP A 707      28.985 -12.728  59.100  1.00 51.20           C  
+ATOM    278  CZ2 TRP A 707      31.355 -14.291  58.938  1.00 52.60           C  
+ATOM    279  CZ3 TRP A 707      29.987 -12.637  60.065  1.00 55.46           C  
+ATOM    280  CH2 TRP A 707      31.156 -13.417  59.978  1.00 45.68           C  
+ATOM    281  N   ILE A 708      26.406 -16.893  56.275  1.00 64.37           N  
+ATOM    282  CA  ILE A 708      26.296 -18.158  56.984  1.00 63.69           C  
+ATOM    283  C   ILE A 708      27.651 -18.807  57.207  1.00 65.54           C  
+ATOM    284  O   ILE A 708      28.080 -19.639  56.414  1.00 68.53           O  
+ATOM    285  CB  ILE A 708      25.389 -19.127  56.190  1.00 65.24           C  
+ATOM    286  CG1 ILE A 708      24.110 -18.389  55.759  1.00 67.60           C  
+ATOM    287  CG2 ILE A 708      25.074 -20.368  57.028  1.00 60.81           C  
+ATOM    288  CD1 ILE A 708      23.233 -19.119  54.753  1.00 73.96           C  
+ATOM    289  N   PRO A 709      28.347 -18.433  58.294  1.00 72.97           N  
+ATOM    290  CA  PRO A 709      29.667 -18.997  58.615  1.00 78.60           C  
+ATOM    291  C   PRO A 709      29.562 -20.523  58.701  1.00 86.74           C  
+ATOM    292  O   PRO A 709      28.729 -21.041  59.450  1.00 88.69           O  
+ATOM    293  CB  PRO A 709      29.968 -18.396  59.983  1.00 70.40           C  
+ATOM    294  CG  PRO A 709      29.209 -17.122  59.977  1.00 73.76           C  
+ATOM    295  CD  PRO A 709      27.911 -17.494  59.339  1.00 78.48           C  
+ATOM    296  N   GLU A 710      30.407 -21.229  57.944  1.00 94.33           N  
+ATOM    297  CA  GLU A 710      30.396 -22.699  57.894  1.00100.22           C  
+ATOM    298  C   GLU A 710      30.231 -23.433  59.229  1.00 98.25           C  
+ATOM    299  O   GLU A 710      29.285 -24.211  59.404  1.00 95.41           O  
+ATOM    300  CB  GLU A 710      31.632 -23.234  57.151  1.00114.07           C  
+ATOM    301  CG  GLU A 710      31.685 -24.773  57.054  1.00118.28           C  
+ATOM    302  CD  GLU A 710      32.772 -25.295  56.119  1.00120.00           C  
+ATOM    303  OE1 GLU A 710      32.411 -25.917  55.093  1.00118.41           O  
+ATOM    304  OE2 GLU A 710      33.978 -25.102  56.416  1.00116.49           O  
+ATOM    305  N   GLY A 711      31.136 -23.172  60.164  1.00 95.50           N  
+ATOM    306  CA  GLY A 711      31.072 -23.831  61.454  1.00 97.93           C  
+ATOM    307  C   GLY A 711      29.738 -23.748  62.179  1.00102.52           C  
+ATOM    308  O   GLY A 711      29.006 -24.742  62.257  1.00 98.79           O  
+ATOM    309  N   GLU A 712      29.403 -22.545  62.649  1.00103.19           N  
+ATOM    310  CA  GLU A 712      28.181 -22.286  63.417  1.00100.94           C  
+ATOM    311  C   GLU A 712      26.840 -22.579  62.762  1.00 99.87           C  
+ATOM    312  O   GLU A 712      26.761 -23.060  61.625  1.00101.77           O  
+ATOM    313  CB  GLU A 712      28.167 -20.844  63.935  1.00104.15           C  
+ATOM    314  CG  GLU A 712      29.306 -20.503  64.869  1.00106.45           C  
+ATOM    315  CD  GLU A 712      30.641 -20.546  64.169  1.00 98.71           C  
+ATOM    316  OE1 GLU A 712      30.834 -19.763  63.218  1.00 91.79           O  
+ATOM    317  OE2 GLU A 712      31.487 -21.383  64.549  1.00118.28           O  
+ATOM    318  N   LYS A 713      25.785 -22.300  63.524  1.00 93.08           N  
+ATOM    319  CA  LYS A 713      24.415 -22.493  63.081  1.00 87.47           C  
+ATOM    320  C   LYS A 713      23.717 -21.153  63.290  1.00 83.58           C  
+ATOM    321  O   LYS A 713      22.860 -21.006  64.174  1.00 84.39           O  
+ATOM    322  CB  LYS A 713      23.735 -23.601  63.899  1.00 92.63           C  
+ATOM    323  CG  LYS A 713      22.389 -24.062  63.342  1.00 92.34           C  
+ATOM    324  CD  LYS A 713      22.530 -24.637  61.931  1.00101.82           C  
+ATOM    325  CE  LYS A 713      21.173 -24.861  61.270  1.00100.66           C  
+ATOM    326  NZ  LYS A 713      20.439 -23.579  61.055  1.00 99.01           N  
+ATOM    327  N   VAL A 714      24.136 -20.166  62.498  1.00 72.31           N  
+ATOM    328  CA  VAL A 714      23.588 -18.814  62.567  1.00 64.14           C  
+ATOM    329  C   VAL A 714      23.487 -18.202  61.172  1.00 59.62           C  
+ATOM    330  O   VAL A 714      24.342 -18.437  60.317  1.00 62.40           O  
+ATOM    331  CB  VAL A 714      24.491 -17.854  63.415  1.00 60.41           C  
+ATOM    332  CG1 VAL A 714      24.682 -18.366  64.832  1.00 42.26           C  
+ATOM    333  CG2 VAL A 714      25.840 -17.672  62.753  1.00 70.57           C  
+ATOM    334  N   LYS A 715      22.429 -17.436  60.939  1.00 53.20           N  
+ATOM    335  CA  LYS A 715      22.257 -16.754  59.662  1.00 56.88           C  
+ATOM    336  C   LYS A 715      22.248 -15.265  59.979  1.00 52.12           C  
+ATOM    337  O   LYS A 715      21.362 -14.786  60.671  1.00 55.66           O  
+ATOM    338  CB  LYS A 715      20.963 -17.176  58.979  1.00 59.13           C  
+ATOM    339  CG  LYS A 715      20.977 -18.618  58.545  1.00 70.74           C  
+ATOM    340  CD  LYS A 715      19.929 -18.876  57.482  1.00 70.42           C  
+ATOM    341  CE  LYS A 715      19.882 -20.345  57.096  1.00 64.16           C  
+ATOM    342  NZ  LYS A 715      18.868 -20.569  56.035  1.00 73.90           N  
+ATOM    343  N   ILE A 716      23.264 -14.553  59.499  1.00 49.01           N  
+ATOM    344  CA  ILE A 716      23.427 -13.130  59.763  1.00 43.48           C  
+ATOM    345  C   ILE A 716      23.045 -12.231  58.597  1.00 43.65           C  
+ATOM    346  O   ILE A 716      23.736 -12.184  57.578  1.00 44.86           O  
+ATOM    347  CB  ILE A 716      24.892 -12.832  60.184  1.00 46.06           C  
+ATOM    348  CG1 ILE A 716      25.302 -13.800  61.299  1.00 52.43           C  
+ATOM    349  CG2 ILE A 716      25.013 -11.389  60.712  1.00 42.87           C  
+ATOM    350  CD1 ILE A 716      26.775 -13.824  61.601  1.00 55.45           C  
+ATOM    351  N   PRO A 717      21.963 -11.461  58.752  1.00 39.57           N  
+ATOM    352  CA  PRO A 717      21.509 -10.555  57.687  1.00 37.70           C  
+ATOM    353  C   PRO A 717      22.577  -9.489  57.449  1.00 40.97           C  
+ATOM    354  O   PRO A 717      22.945  -8.754  58.365  1.00 49.37           O  
+ATOM    355  CB  PRO A 717      20.231  -9.960  58.271  1.00 24.14           C  
+ATOM    356  CG  PRO A 717      19.759 -11.009  59.229  1.00 42.85           C  
+ATOM    357  CD  PRO A 717      21.038 -11.449  59.891  1.00 42.06           C  
+ATOM    358  N   VAL A 718      23.067  -9.398  56.217  1.00 42.07           N  
+ATOM    359  CA  VAL A 718      24.124  -8.446  55.875  1.00 40.31           C  
+ATOM    360  C   VAL A 718      23.873  -7.627  54.603  1.00 45.06           C  
+ATOM    361  O   VAL A 718      22.966  -7.918  53.821  1.00 47.27           O  
+ATOM    362  CB  VAL A 718      25.467  -9.186  55.679  1.00 44.95           C  
+ATOM    363  CG1 VAL A 718      25.841  -9.940  56.936  1.00 55.08           C  
+ATOM    364  CG2 VAL A 718      25.366 -10.168  54.500  1.00 34.55           C  
+ATOM    365  N   ALA A 719      24.670  -6.577  54.437  1.00 43.24           N  
+ATOM    366  CA  ALA A 719      24.618  -5.715  53.268  1.00 47.68           C  
+ATOM    367  C   ALA A 719      26.002  -5.863  52.645  1.00 53.15           C  
+ATOM    368  O   ALA A 719      27.024  -5.858  53.349  1.00 52.60           O  
+ATOM    369  CB  ALA A 719      24.371  -4.263  53.658  1.00 36.19           C  
+ATOM    370  N   ILE A 720      26.019  -6.026  51.326  1.00 55.00           N  
+ATOM    371  CA  ILE A 720      27.254  -6.215  50.570  1.00 51.36           C  
+ATOM    372  C   ILE A 720      27.472  -5.053  49.592  1.00 50.84           C  
+ATOM    373  O   ILE A 720      26.635  -4.793  48.730  1.00 44.07           O  
+ATOM    374  CB  ILE A 720      27.164  -7.543  49.809  1.00 51.98           C  
+ATOM    375  CG1 ILE A 720      26.635  -8.615  50.754  1.00 45.10           C  
+ATOM    376  CG2 ILE A 720      28.518  -7.958  49.265  1.00 47.66           C  
+ATOM    377  CD1 ILE A 720      26.319  -9.897  50.086  1.00 45.86           C  
+ATOM    378  N   LYS A 721      28.581  -4.340  49.744  1.00 46.92           N  
+ATOM    379  CA  LYS A 721      28.881  -3.213  48.864  1.00 58.74           C  
+ATOM    380  C   LYS A 721      30.122  -3.469  47.984  1.00 68.19           C  
+ATOM    381  O   LYS A 721      31.195  -3.787  48.497  1.00 66.76           O  
+ATOM    382  CB  LYS A 721      29.079  -1.966  49.720  1.00 50.56           C  
+ATOM    383  CG  LYS A 721      29.406  -0.697  48.966  1.00 60.00           C  
+ATOM    384  CD  LYS A 721      29.725   0.401  49.960  1.00 57.60           C  
+ATOM    385  CE  LYS A 721      29.871   1.742  49.291  1.00 56.90           C  
+ATOM    386  NZ  LYS A 721      30.122   2.791  50.314  1.00 79.32           N  
+ATOM    387  N   GLU A 722      29.963  -3.329  46.666  1.00 78.88           N  
+ATOM    388  CA  GLU A 722      31.054  -3.527  45.691  1.00 89.59           C  
+ATOM    389  C   GLU A 722      30.942  -2.541  44.531  1.00 99.17           C  
+ATOM    390  O   GLU A 722      29.935  -1.842  44.390  1.00100.93           O  
+ATOM    391  CB  GLU A 722      31.025  -4.942  45.102  1.00 85.25           C  
+ATOM    392  CG  GLU A 722      29.753  -5.252  44.317  1.00 93.73           C  
+ATOM    393  CD  GLU A 722      29.906  -6.411  43.343  1.00107.08           C  
+ATOM    394  OE1 GLU A 722      30.087  -7.566  43.787  1.00108.14           O  
+ATOM    395  OE2 GLU A 722      29.827  -6.166  42.121  1.00114.47           O  
+ATOM    396  N   LEU A 723      31.961  -2.528  43.673  1.00109.61           N  
+ATOM    397  CA  LEU A 723      31.980  -1.644  42.502  1.00115.18           C  
+ATOM    398  C   LEU A 723      31.444  -2.353  41.252  1.00116.14           C  
+ATOM    399  O   LEU A 723      31.014  -3.508  41.318  1.00115.73           O  
+ATOM    400  CB  LEU A 723      33.402  -1.147  42.236  1.00117.55           C  
+ATOM    401  CG  LEU A 723      34.080  -0.347  43.351  1.00118.63           C  
+ATOM    402  CD1 LEU A 723      35.577  -0.251  43.073  1.00114.88           C  
+ATOM    403  CD2 LEU A 723      33.445   1.035  43.491  1.00 94.81           C  
+ATOM    404  N   ARG A 724      31.470  -1.653  40.118  1.00117.88           N  
+ATOM    405  CA  ARG A 724      30.997  -2.209  38.848  1.00118.87           C  
+ATOM    406  C   ARG A 724      31.902  -3.370  38.402  1.00117.77           C  
+ATOM    407  O   ARG A 724      33.056  -3.469  38.832  1.00116.51           O  
+ATOM    408  CB  ARG A 724      30.944  -1.110  37.771  1.00117.03           C  
+ATOM    409  CG  ARG A 724      30.270  -1.520  36.453  1.00120.00           C  
+ATOM    410  CD  ARG A 724      28.782  -1.820  36.650  1.00120.00           C  
+ATOM    411  NE  ARG A 724      28.180  -2.504  35.500  1.00120.00           N  
+ATOM    412  CZ  ARG A 724      27.313  -1.948  34.656  1.00118.30           C  
+ATOM    413  NH1 ARG A 724      26.940  -0.684  34.813  1.00119.88           N  
+ATOM    414  NH2 ARG A 724      26.785  -2.672  33.675  1.00113.01           N  
+ATOM    415  N   GLU A 725      31.367  -4.238  37.545  0.00118.05           N  
+ATOM    416  CA  GLU A 725      32.083  -5.411  37.038  0.00118.88           C  
+ATOM    417  C   GLU A 725      33.549  -5.195  36.652  0.00119.37           C  
+ATOM    418  O   GLU A 725      34.411  -5.990  37.028  0.00119.89           O  
+ATOM    419  CB  GLU A 725      31.310  -6.045  35.876  0.00118.16           C  
+ATOM    420  CG  GLU A 725      30.993  -5.100  34.726  0.00113.14           C  
+ATOM    421  CD  GLU A 725      30.112  -5.744  33.671  0.00116.04           C  
+ATOM    422  OE1 GLU A 725      28.932  -5.350  33.562  0.00115.61           O  
+ATOM    423  OE2 GLU A 725      30.598  -6.644  32.954  0.00110.87           O  
+ATOM    424  N   ALA A 726      33.829  -4.131  35.903  1.00119.87           N  
+ATOM    425  CA  ALA A 726      35.198  -3.828  35.494  1.00118.48           C  
+ATOM    426  C   ALA A 726      35.989  -3.278  36.683  1.00118.95           C  
+ATOM    427  O   ALA A 726      35.437  -2.589  37.549  1.00116.44           O  
+ATOM    428  CB  ALA A 726      35.204  -2.832  34.341  1.00119.45           C  
+ATOM    429  N   THR A 727      37.280  -3.601  36.724  1.00119.85           N  
+ATOM    430  CA  THR A 727      38.153  -3.156  37.807  1.00119.78           C  
+ATOM    431  C   THR A 727      38.641  -1.718  37.613  1.00120.00           C  
+ATOM    432  O   THR A 727      39.152  -1.357  36.544  1.00119.35           O  
+ATOM    433  CB  THR A 727      39.382  -4.091  37.970  1.00118.76           C  
+ATOM    434  OG1 THR A 727      38.940  -5.446  38.127  1.00111.10           O  
+ATOM    435  CG2 THR A 727      40.203  -3.688  39.202  1.00117.14           C  
+ATOM    436  N   SER A 728      38.446  -0.898  38.645  1.00120.00           N  
+ATOM    437  CA  SER A 728      38.878   0.497  38.624  1.00120.00           C  
+ATOM    438  C   SER A 728      40.155   0.604  39.469  1.00120.00           C  
+ATOM    439  O   SER A 728      40.294  -0.076  40.494  1.00119.72           O  
+ATOM    440  CB  SER A 728      37.775   1.415  39.174  1.00120.00           C  
+ATOM    441  OG  SER A 728      38.083   2.785  38.961  1.00112.66           O  
+ATOM    442  N   PRO A 729      41.123   1.424  39.016  1.00120.00           N  
+ATOM    443  CA  PRO A 729      42.419   1.659  39.676  1.00120.00           C  
+ATOM    444  C   PRO A 729      42.347   2.277  41.074  1.00119.43           C  
+ATOM    445  O   PRO A 729      42.668   1.626  42.071  1.00118.61           O  
+ATOM    446  CB  PRO A 729      43.135   2.598  38.695  1.00120.00           C  
+ATOM    447  CG  PRO A 729      42.535   2.225  37.361  1.00119.92           C  
+ATOM    448  CD  PRO A 729      41.074   2.112  37.712  1.00120.00           C  
+ATOM    449  N   LYS A 730      41.954   3.548  41.121  1.00120.00           N  
+ATOM    450  CA  LYS A 730      41.840   4.313  42.362  1.00119.21           C  
+ATOM    451  C   LYS A 730      40.632   3.936  43.225  1.00119.52           C  
+ATOM    452  O   LYS A 730      40.668   4.098  44.446  1.00119.71           O  
+ATOM    453  CB  LYS A 730      41.790   5.812  42.043  1.00115.30           C  
+ATOM    454  CG  LYS A 730      40.654   6.196  41.102  0.00111.42           C  
+ATOM    455  CD  LYS A 730      40.641   7.684  40.801  0.00112.24           C  
+ATOM    456  CE  LYS A 730      39.494   8.038  39.867  0.00115.68           C  
+ATOM    457  NZ  LYS A 730      39.456   9.492  39.551  0.00114.85           N  
+ATOM    458  N   ALA A 731      39.562   3.457  42.593  1.00118.99           N  
+ATOM    459  CA  ALA A 731      38.347   3.069  43.313  1.00115.58           C  
+ATOM    460  C   ALA A 731      38.589   1.846  44.192  1.00112.61           C  
+ATOM    461  O   ALA A 731      37.948   1.673  45.226  1.00111.65           O  
+ATOM    462  CB  ALA A 731      37.215   2.804  42.333  1.00113.88           C  
+ATOM    463  N   ASN A 732      39.530   1.011  43.771  1.00112.01           N  
+ATOM    464  CA  ASN A 732      39.888  -0.194  44.504  1.00110.60           C  
+ATOM    465  C   ASN A 732      40.576   0.162  45.817  1.00106.48           C  
+ATOM    466  O   ASN A 732      40.358  -0.486  46.836  1.00105.64           O  
+ATOM    467  CB  ASN A 732      40.809  -1.061  43.650  1.00118.92           C  
+ATOM    468  CG  ASN A 732      41.126  -2.384  44.303  1.00120.00           C  
+ATOM    469  OD1 ASN A 732      40.402  -3.374  44.118  1.00118.83           O  
+ATOM    470  ND2 ASN A 732      42.214  -2.416  45.079  1.00116.78           N  
+ATOM    471  N   LYS A 733      41.438   1.173  45.770  1.00103.25           N  
+ATOM    472  CA  LYS A 733      42.141   1.636  46.958  1.00102.13           C  
+ATOM    473  C   LYS A 733      41.124   2.239  47.918  1.00100.63           C  
+ATOM    474  O   LYS A 733      41.157   1.973  49.118  1.00104.56           O  
+ATOM    475  CB  LYS A 733      43.181   2.704  46.594  1.00 96.91           C  
+ATOM    476  CG  LYS A 733      43.850   3.336  47.808  1.00110.43           C  
+ATOM    477  CD  LYS A 733      44.779   4.473  47.439  1.00109.50           C  
+ATOM    478  CE  LYS A 733      45.463   5.014  48.686  1.00119.19           C  
+ATOM    479  NZ  LYS A 733      46.474   6.065  48.386  1.00120.00           N  
+ATOM    480  N   GLU A 734      40.201   3.021  47.363  1.00 95.90           N  
+ATOM    481  CA  GLU A 734      39.167   3.687  48.142  1.00 91.10           C  
+ATOM    482  C   GLU A 734      38.256   2.750  48.944  1.00 84.46           C  
+ATOM    483  O   GLU A 734      37.856   3.082  50.065  1.00 81.68           O  
+ATOM    484  CB  GLU A 734      38.366   4.647  47.253  1.00 95.48           C  
+ATOM    485  CG  GLU A 734      39.219   5.805  46.717  1.00102.59           C  
+ATOM    486  CD  GLU A 734      38.412   6.909  46.039  1.00106.44           C  
+ATOM    487  OE1 GLU A 734      37.289   6.637  45.552  1.00114.11           O  
+ATOM    488  OE2 GLU A 734      38.913   8.058  45.989  1.00101.90           O  
+ATOM    489  N   ILE A 735      37.938   1.580  48.396  1.00 76.67           N  
+ATOM    490  CA  ILE A 735      37.106   0.646  49.143  1.00 70.69           C  
+ATOM    491  C   ILE A 735      37.948   0.131  50.292  1.00 62.75           C  
+ATOM    492  O   ILE A 735      37.466  -0.007  51.413  1.00 60.57           O  
+ATOM    493  CB  ILE A 735      36.646  -0.578  48.329  1.00 71.12           C  
+ATOM    494  CG1 ILE A 735      35.780  -0.159  47.148  1.00 92.52           C  
+ATOM    495  CG2 ILE A 735      35.793  -1.478  49.207  1.00 71.12           C  
+ATOM    496  CD1 ILE A 735      35.185  -1.353  46.396  1.00 95.31           C  
+ATOM    497  N   LEU A 736      39.214  -0.150  50.013  1.00 55.25           N  
+ATOM    498  CA  LEU A 736      40.074  -0.653  51.061  1.00 50.87           C  
+ATOM    499  C   LEU A 736      40.323   0.404  52.134  1.00 50.02           C  
+ATOM    500  O   LEU A 736      40.451   0.062  53.305  1.00 55.00           O  
+ATOM    501  CB  LEU A 736      41.371  -1.240  50.490  1.00 57.16           C  
+ATOM    502  CG  LEU A 736      41.367  -2.704  49.997  1.00 63.08           C  
+ATOM    503  CD1 LEU A 736      40.552  -3.581  50.936  1.00 43.77           C  
+ATOM    504  CD2 LEU A 736      40.814  -2.819  48.598  1.00 67.56           C  
+ATOM    505  N   ASP A 737      40.350   1.682  51.751  1.00 46.92           N  
+ATOM    506  CA  ASP A 737      40.530   2.763  52.719  1.00 45.62           C  
+ATOM    507  C   ASP A 737      39.318   2.787  53.626  1.00 51.02           C  
+ATOM    508  O   ASP A 737      39.451   2.899  54.843  1.00 48.39           O  
+ATOM    509  CB  ASP A 737      40.635   4.121  52.046  1.00 44.18           C  
+ATOM    510  CG  ASP A 737      42.036   4.440  51.575  1.00 65.81           C  
+ATOM    511  OD1 ASP A 737      43.010   3.911  52.161  1.00 63.44           O  
+ATOM    512  OD2 ASP A 737      42.160   5.241  50.622  1.00 84.30           O  
+ATOM    513  N   GLU A 738      38.142   2.655  53.013  1.00 49.34           N  
+ATOM    514  CA  GLU A 738      36.880   2.649  53.726  1.00 47.77           C  
+ATOM    515  C   GLU A 738      36.775   1.436  54.641  1.00 52.97           C  
+ATOM    516  O   GLU A 738      36.191   1.524  55.732  1.00 60.99           O  
+ATOM    517  CB  GLU A 738      35.726   2.679  52.736  1.00 50.26           C  
+ATOM    518  CG  GLU A 738      34.346   2.698  53.361  1.00 59.40           C  
+ATOM    519  CD  GLU A 738      33.235   2.863  52.335  1.00 58.37           C  
+ATOM    520  OE1 GLU A 738      33.541   3.249  51.188  1.00 72.29           O  
+ATOM    521  OE2 GLU A 738      32.053   2.620  52.672  1.00 76.77           O  
+ATOM    522  N   ALA A 739      37.367   0.319  54.216  1.00 48.57           N  
+ATOM    523  CA  ALA A 739      37.364  -0.918  55.013  1.00 42.69           C  
+ATOM    524  C   ALA A 739      38.196  -0.701  56.255  1.00 40.88           C  
+ATOM    525  O   ALA A 739      37.799  -1.071  57.347  1.00 46.18           O  
+ATOM    526  CB  ALA A 739      37.934  -2.062  54.221  1.00 38.75           C  
+ATOM    527  N   TYR A 740      39.340  -0.050  56.069  1.00 43.89           N  
+ATOM    528  CA  TYR A 740      40.257   0.252  57.151  1.00 40.40           C  
+ATOM    529  C   TYR A 740      39.600   1.058  58.274  1.00 43.21           C  
+ATOM    530  O   TYR A 740      39.842   0.786  59.443  1.00 45.45           O  
+ATOM    531  CB  TYR A 740      41.481   1.018  56.617  1.00 30.08           C  
+ATOM    532  CG  TYR A 740      42.484   1.396  57.701  1.00 39.41           C  
+ATOM    533  CD1 TYR A 740      42.269   2.492  58.545  1.00 37.60           C  
+ATOM    534  CD2 TYR A 740      43.611   0.620  57.927  1.00 35.27           C  
+ATOM    535  CE1 TYR A 740      43.157   2.791  59.589  1.00 31.20           C  
+ATOM    536  CE2 TYR A 740      44.499   0.915  58.974  1.00 45.40           C  
+ATOM    537  CZ  TYR A 740      44.262   1.996  59.792  1.00 40.96           C  
+ATOM    538  OH  TYR A 740      45.143   2.279  60.799  1.00 51.29           O  
+ATOM    539  N   VAL A 741      38.805   2.068  57.927  1.00 46.94           N  
+ATOM    540  CA  VAL A 741      38.160   2.885  58.952  1.00 48.54           C  
+ATOM    541  C   VAL A 741      37.012   2.132  59.585  1.00 45.15           C  
+ATOM    542  O   VAL A 741      36.920   2.086  60.809  1.00 46.30           O  
+ATOM    543  CB  VAL A 741      37.656   4.248  58.420  1.00 51.92           C  
+ATOM    544  CG1 VAL A 741      38.800   5.053  57.849  1.00 39.01           C  
+ATOM    545  CG2 VAL A 741      36.639   4.037  57.363  1.00 76.92           C  
+ATOM    546  N   MET A 742      36.183   1.472  58.771  1.00 37.09           N  
+ATOM    547  CA  MET A 742      35.058   0.730  59.338  1.00 42.02           C  
+ATOM    548  C   MET A 742      35.466  -0.411  60.251  1.00 46.34           C  
+ATOM    549  O   MET A 742      34.734  -0.768  61.170  1.00 61.43           O  
+ATOM    550  CB  MET A 742      34.133   0.192  58.266  1.00 46.91           C  
+ATOM    551  CG  MET A 742      33.397   1.229  57.479  1.00 49.54           C  
+ATOM    552  SD  MET A 742      32.244   0.362  56.443  1.00 63.27           S  
+ATOM    553  CE  MET A 742      31.080  -0.114  57.631  1.00 46.43           C  
+ATOM    554  N   ALA A 743      36.621  -1.001  59.980  1.00 47.70           N  
+ATOM    555  CA  ALA A 743      37.125  -2.096  60.787  1.00 43.52           C  
+ATOM    556  C   ALA A 743      37.750  -1.558  62.066  1.00 36.10           C  
+ATOM    557  O   ALA A 743      38.013  -2.300  62.995  1.00 43.42           O  
+ATOM    558  CB  ALA A 743      38.155  -2.897  59.985  1.00 39.05           C  
+ATOM    559  N   SER A 744      37.973  -0.256  62.115  1.00 39.86           N  
+ATOM    560  CA  SER A 744      38.603   0.362  63.278  1.00 47.26           C  
+ATOM    561  C   SER A 744      37.661   1.072  64.251  1.00 50.31           C  
+ATOM    562  O   SER A 744      38.122   1.797  65.140  1.00 58.89           O  
+ATOM    563  CB  SER A 744      39.663   1.352  62.804  1.00 46.68           C  
+ATOM    564  OG  SER A 744      40.569   0.726  61.911  1.00 61.12           O  
+ATOM    565  N   VAL A 745      36.356   0.900  64.068  1.00 46.30           N  
+ATOM    566  CA  VAL A 745      35.376   1.538  64.945  1.00 44.52           C  
+ATOM    567  C   VAL A 745      34.450   0.491  65.530  1.00 47.41           C  
+ATOM    568  O   VAL A 745      33.999  -0.410  64.840  1.00 49.93           O  
+ATOM    569  CB  VAL A 745      34.499   2.560  64.193  1.00 42.20           C  
+ATOM    570  CG1 VAL A 745      35.345   3.713  63.637  1.00 27.99           C  
+ATOM    571  CG2 VAL A 745      33.726   1.853  63.081  1.00 37.55           C  
+ATOM    572  N   ASP A 746      34.159   0.623  66.811  1.00 45.95           N  
+ATOM    573  CA  ASP A 746      33.276  -0.307  67.482  1.00 42.74           C  
+ATOM    574  C   ASP A 746      32.422   0.512  68.475  1.00 43.17           C  
+ATOM    575  O   ASP A 746      32.898   0.954  69.530  1.00 42.31           O  
+ATOM    576  CB  ASP A 746      34.111  -1.401  68.178  1.00 29.82           C  
+ATOM    577  CG  ASP A 746      33.245  -2.457  68.879  1.00 55.09           C  
+ATOM    578  OD1 ASP A 746      32.043  -2.581  68.564  1.00 52.73           O  
+ATOM    579  OD2 ASP A 746      33.768  -3.173  69.758  1.00 74.69           O  
+ATOM    580  N   ASN A 747      31.189   0.794  68.063  1.00 35.56           N  
+ATOM    581  CA  ASN A 747      30.245   1.557  68.871  1.00 36.25           C  
+ATOM    582  C   ASN A 747      28.820   1.270  68.415  1.00 34.56           C  
+ATOM    583  O   ASN A 747      28.582   1.014  67.244  1.00 39.61           O  
+ATOM    584  CB  ASN A 747      30.552   3.054  68.774  1.00 40.50           C  
+ATOM    585  CG  ASN A 747      29.631   3.897  69.632  1.00 47.30           C  
+ATOM    586  OD1 ASN A 747      28.535   4.272  69.206  1.00 39.04           O  
+ATOM    587  ND2 ASN A 747      30.063   4.185  70.858  1.00 36.78           N  
+ATOM    588  N   PRO A 748      27.852   1.296  69.345  1.00 36.26           N  
+ATOM    589  CA  PRO A 748      26.438   1.036  69.033  1.00 26.39           C  
+ATOM    590  C   PRO A 748      25.799   2.004  68.052  1.00 29.08           C  
+ATOM    591  O   PRO A 748      24.785   1.704  67.440  1.00 34.03           O  
+ATOM    592  CB  PRO A 748      25.784   1.108  70.396  1.00 26.22           C  
+ATOM    593  CG  PRO A 748      26.891   0.586  71.335  1.00 20.21           C  
+ATOM    594  CD  PRO A 748      28.071   1.336  70.805  1.00 31.84           C  
+ATOM    595  N   HIS A 749      26.424   3.148  67.858  1.00 36.86           N  
+ATOM    596  CA  HIS A 749      25.886   4.143  66.949  1.00 40.75           C  
+ATOM    597  C   HIS A 749      26.748   4.411  65.732  1.00 43.31           C  
+ATOM    598  O   HIS A 749      26.611   5.439  65.049  1.00 42.41           O  
+ATOM    599  CB  HIS A 749      25.546   5.391  67.740  1.00 39.93           C  
+ATOM    600  CG  HIS A 749      24.555   5.110  68.819  1.00 49.23           C  
+ATOM    601  ND1 HIS A 749      23.249   4.765  68.545  1.00 41.45           N  
+ATOM    602  CD2 HIS A 749      24.713   4.955  70.153  1.00 33.26           C  
+ATOM    603  CE1 HIS A 749      22.650   4.397  69.664  1.00 46.00           C  
+ATOM    604  NE2 HIS A 749      23.517   4.502  70.655  1.00 34.86           N  
+ATOM    605  N   VAL A 750      27.644   3.463  65.467  1.00 45.15           N  
+ATOM    606  CA  VAL A 750      28.491   3.515  64.286  1.00 40.34           C  
+ATOM    607  C   VAL A 750      28.358   2.176  63.567  1.00 35.42           C  
+ATOM    608  O   VAL A 750      28.265   1.117  64.201  1.00 30.82           O  
+ATOM    609  CB  VAL A 750      29.939   3.823  64.645  1.00 34.23           C  
+ATOM    610  CG1 VAL A 750      30.804   3.742  63.421  1.00 44.91           C  
+ATOM    611  CG2 VAL A 750      30.017   5.244  65.201  1.00 34.34           C  
+ATOM    612  N  ACYS A 751      28.271   2.223  62.244  0.50 35.58           N  
+ATOM    613  N  BCYS A 751      28.282   2.243  62.246  0.50 37.41           N  
+ATOM    614  CA ACYS A 751      28.168   0.990  61.469  0.50 42.09           C  
+ATOM    615  CA BCYS A 751      28.150   1.062  61.389  0.50 45.23           C  
+ATOM    616  C  ACYS A 751      29.518   0.324  61.402  0.50 42.98           C  
+ATOM    617  C  BCYS A 751      29.496   0.320  61.313  0.50 44.85           C  
+ATOM    618  O  ACYS A 751      30.528   0.968  61.135  0.50 51.40           O  
+ATOM    619  O  BCYS A 751      30.500   0.925  60.946  0.50 52.45           O  
+ATOM    620  CB ACYS A 751      27.653   1.255  60.060  0.50 32.54           C  
+ATOM    621  CB BCYS A 751      27.681   1.539  60.003  0.50 41.91           C  
+ATOM    622  SG ACYS A 751      25.899   1.515  60.033  0.50 33.14           S  
+ATOM    623  SG BCYS A 751      27.776   0.394  58.620  0.50 52.82           S  
+ATOM    624  N   ARG A 752      29.530  -0.967  61.673  1.00 48.20           N  
+ATOM    625  CA  ARG A 752      30.785  -1.742  61.657  1.00 55.15           C  
+ATOM    626  C   ARG A 752      30.913  -2.768  60.519  1.00 54.92           C  
+ATOM    627  O   ARG A 752      29.924  -3.346  60.023  1.00 52.10           O  
+ATOM    628  CB  ARG A 752      30.976  -2.431  63.014  1.00 73.03           C  
+ATOM    629  CG  ARG A 752      32.335  -3.053  63.269  1.00 62.83           C  
+ATOM    630  CD  ARG A 752      32.250  -3.889  64.539  1.00 74.46           C  
+ATOM    631  NE  ARG A 752      33.423  -4.731  64.764  1.00 85.80           N  
+ATOM    632  CZ  ARG A 752      34.644  -4.269  65.025  1.00100.40           C  
+ATOM    633  NH1 ARG A 752      34.862  -2.962  65.089  1.00 94.64           N  
+ATOM    634  NH2 ARG A 752      35.646  -5.116  65.241  1.00108.37           N  
+ATOM    635  N   LEU A 753      32.156  -2.959  60.105  1.00 53.73           N  
+ATOM    636  CA  LEU A 753      32.503  -3.877  59.045  1.00 45.35           C  
+ATOM    637  C   LEU A 753      32.568  -5.290  59.601  1.00 45.62           C  
+ATOM    638  O   LEU A 753      33.214  -5.520  60.617  1.00 48.14           O  
+ATOM    639  CB  LEU A 753      33.875  -3.502  58.526  1.00 47.11           C  
+ATOM    640  CG  LEU A 753      34.385  -4.207  57.280  1.00 60.05           C  
+ATOM    641  CD1 LEU A 753      33.907  -3.452  56.049  1.00 48.93           C  
+ATOM    642  CD2 LEU A 753      35.903  -4.223  57.324  1.00 59.98           C  
+ATOM    643  N   LEU A 754      31.873  -6.228  58.969  1.00 45.61           N  
+ATOM    644  CA  LEU A 754      31.927  -7.616  59.405  1.00 47.72           C  
+ATOM    645  C   LEU A 754      33.143  -8.249  58.749  1.00 51.77           C  
+ATOM    646  O   LEU A 754      33.798  -9.112  59.334  1.00 51.52           O  
+ATOM    647  CB  LEU A 754      30.670  -8.368  59.006  1.00 41.87           C  
+ATOM    648  CG  LEU A 754      29.466  -7.844  59.777  1.00 50.79           C  
+ATOM    649  CD1 LEU A 754      28.185  -8.363  59.159  1.00 46.72           C  
+ATOM    650  CD2 LEU A 754      29.585  -8.257  61.233  1.00 41.91           C  
+ATOM    651  N   GLY A 755      33.474  -7.757  57.559  1.00 47.03           N  
+ATOM    652  CA  GLY A 755      34.617  -8.276  56.839  1.00 53.28           C  
+ATOM    653  C   GLY A 755      34.628  -7.921  55.365  1.00 48.72           C  
+ATOM    654  O   GLY A 755      33.825  -7.121  54.895  1.00 48.41           O  
+ATOM    655  N   ILE A 756      35.589  -8.478  54.643  1.00 47.20           N  
+ATOM    656  CA  ILE A 756      35.681  -8.242  53.214  1.00 48.14           C  
+ATOM    657  C   ILE A 756      35.803  -9.583  52.507  1.00 53.25           C  
+ATOM    658  O   ILE A 756      36.169 -10.607  53.119  1.00 49.03           O  
+ATOM    659  CB  ILE A 756      36.863  -7.303  52.836  1.00 51.35           C  
+ATOM    660  CG1 ILE A 756      38.199  -7.864  53.317  1.00 47.55           C  
+ATOM    661  CG2 ILE A 756      36.684  -5.931  53.466  1.00 45.34           C  
+ATOM    662  CD1 ILE A 756      39.389  -7.073  52.782  1.00 60.62           C  
+ATOM    663  N   CYS A 757      35.383  -9.589  51.247  1.00 56.20           N  
+ATOM    664  CA  CYS A 757      35.446 -10.779  50.407  1.00 60.93           C  
+ATOM    665  C   CYS A 757      36.230 -10.371  49.152  1.00 60.14           C  
+ATOM    666  O   CYS A 757      35.819  -9.471  48.415  1.00 52.96           O  
+ATOM    667  CB  CYS A 757      34.028 -11.270  50.060  1.00 64.83           C  
+ATOM    668  SG  CYS A 757      33.975 -12.858  49.158  1.00 73.09           S  
+ATOM    669  N   LEU A 758      37.393 -10.986  48.958  1.00 60.02           N  
+ATOM    670  CA  LEU A 758      38.247 -10.664  47.820  1.00 63.37           C  
+ATOM    671  C   LEU A 758      37.824 -11.392  46.550  1.00 66.93           C  
+ATOM    672  O   LEU A 758      38.251 -12.510  46.295  1.00 71.90           O  
+ATOM    673  CB  LEU A 758      39.710 -10.959  48.162  1.00 41.64           C  
+ATOM    674  CG  LEU A 758      40.290 -10.165  49.340  1.00 61.61           C  
+ATOM    675  CD1 LEU A 758      41.696 -10.655  49.616  1.00 67.38           C  
+ATOM    676  CD2 LEU A 758      40.294  -8.646  49.083  1.00 34.49           C  
+ATOM    677  N   THR A 759      36.977 -10.744  45.761  1.00 72.06           N  
+ATOM    678  CA  THR A 759      36.477 -11.320  44.519  1.00 83.08           C  
+ATOM    679  C   THR A 759      37.213 -10.638  43.367  1.00 86.16           C  
+ATOM    680  O   THR A 759      38.379 -10.283  43.507  1.00 94.75           O  
+ATOM    681  CB  THR A 759      34.949 -11.080  44.387  1.00 90.69           C  
+ATOM    682  OG1 THR A 759      34.313 -11.358  45.640  1.00 85.09           O  
+ATOM    683  CG2 THR A 759      34.342 -12.005  43.325  1.00 98.46           C  
+ATOM    684  N   SER A 760      36.553 -10.483  42.224  1.00 86.22           N  
+ATOM    685  CA  SER A 760      37.153  -9.809  41.083  1.00 91.65           C  
+ATOM    686  C   SER A 760      37.433  -8.400  41.602  1.00 95.98           C  
+ATOM    687  O   SER A 760      38.503  -7.829  41.375  1.00 98.69           O  
+ATOM    688  CB  SER A 760      36.148  -9.764  39.937  1.00 98.60           C  
+ATOM    689  OG  SER A 760      35.479 -11.009  39.818  1.00102.77           O  
+ATOM    690  N   THR A 761      36.442  -7.863  42.312  1.00100.97           N  
+ATOM    691  CA  THR A 761      36.518  -6.554  42.960  1.00 96.36           C  
+ATOM    692  C   THR A 761      36.211  -6.823  44.430  1.00 92.44           C  
+ATOM    693  O   THR A 761      35.461  -7.754  44.768  1.00 91.58           O  
+ATOM    694  CB  THR A 761      35.479  -5.533  42.415  1.00 95.81           C  
+ATOM    695  OG1 THR A 761      34.155  -6.078  42.515  1.00 99.68           O  
+ATOM    696  CG2 THR A 761      35.785  -5.165  40.963  1.00102.36           C  
+ATOM    697  N   VAL A 762      36.817  -6.032  45.302  1.00 84.88           N  
+ATOM    698  CA  VAL A 762      36.612  -6.190  46.729  1.00 82.79           C  
+ATOM    699  C   VAL A 762      35.181  -5.820  47.150  1.00 76.73           C  
+ATOM    700  O   VAL A 762      34.583  -4.896  46.603  1.00 81.53           O  
+ATOM    701  CB  VAL A 762      37.641  -5.358  47.511  1.00 84.24           C  
+ATOM    702  CG1 VAL A 762      37.561  -3.908  47.085  1.00 83.27           C  
+ATOM    703  CG2 VAL A 762      37.428  -5.511  49.011  1.00 86.10           C  
+ATOM    704  N   GLN A 763      34.627  -6.599  48.076  1.00 68.77           N  
+ATOM    705  CA  GLN A 763      33.279  -6.385  48.599  1.00 61.32           C  
+ATOM    706  C   GLN A 763      33.321  -6.106  50.101  1.00 52.68           C  
+ATOM    707  O   GLN A 763      33.977  -6.826  50.851  1.00 49.42           O  
+ATOM    708  CB  GLN A 763      32.401  -7.624  48.384  1.00 60.21           C  
+ATOM    709  CG  GLN A 763      32.276  -8.114  46.959  1.00 66.70           C  
+ATOM    710  CD  GLN A 763      31.331  -9.308  46.830  1.00 64.39           C  
+ATOM    711  OE1 GLN A 763      31.427 -10.288  47.577  1.00 69.45           O  
+ATOM    712  NE2 GLN A 763      30.409  -9.223  45.881  1.00 66.28           N  
+ATOM    713  N   LEU A 764      32.649  -5.043  50.531  1.00 51.46           N  
+ATOM    714  CA  LEU A 764      32.572  -4.721  51.952  1.00 48.10           C  
+ATOM    715  C   LEU A 764      31.303  -5.397  52.473  1.00 48.08           C  
+ATOM    716  O   LEU A 764      30.284  -5.395  51.782  1.00 49.33           O  
+ATOM    717  CB  LEU A 764      32.460  -3.224  52.158  1.00 46.76           C  
+ATOM    718  CG  LEU A 764      33.668  -2.358  51.827  1.00 69.78           C  
+ATOM    719  CD1 LEU A 764      33.274  -0.894  51.841  1.00 78.29           C  
+ATOM    720  CD2 LEU A 764      34.745  -2.600  52.834  1.00 72.54           C  
+ATOM    721  N   ILE A 765      31.388  -6.041  53.642  1.00 44.49           N  
+ATOM    722  CA  ILE A 765      30.234  -6.712  54.242  1.00 48.31           C  
+ATOM    723  C   ILE A 765      29.925  -6.093  55.607  1.00 52.32           C  
+ATOM    724  O   ILE A 765      30.805  -5.981  56.462  1.00 52.23           O  
+ATOM    725  CB  ILE A 765      30.460  -8.247  54.415  1.00 52.95           C  
+ATOM    726  CG1 ILE A 765      30.676  -8.917  53.059  1.00 51.87           C  
+ATOM    727  CG2 ILE A 765      29.234  -8.904  55.027  1.00 47.03           C  
+ATOM    728  CD1 ILE A 765      32.075  -8.866  52.606  1.00 56.56           C  
+ATOM    729  N   THR A 766      28.690  -5.637  55.789  1.00 44.63           N  
+ATOM    730  CA  THR A 766      28.297  -5.044  57.053  1.00 44.23           C  
+ATOM    731  C   THR A 766      26.947  -5.541  57.452  1.00 42.35           C  
+ATOM    732  O   THR A 766      26.311  -6.242  56.692  1.00 41.20           O  
+ATOM    733  CB  THR A 766      28.203  -3.507  57.003  1.00 38.85           C  
+ATOM    734  OG1 THR A 766      27.403  -3.109  55.889  1.00 44.72           O  
+ATOM    735  CG2 THR A 766      29.559  -2.884  56.910  1.00 58.58           C  
+ATOM    736  N   GLN A 767      26.525  -5.165  58.659  1.00 41.76           N  
+ATOM    737  CA  GLN A 767      25.224  -5.535  59.181  1.00 40.27           C  
+ATOM    738  C   GLN A 767      24.127  -4.831  58.384  1.00 44.44           C  
+ATOM    739  O   GLN A 767      24.253  -3.657  58.017  1.00 38.81           O  
+ATOM    740  CB  GLN A 767      25.105  -5.121  60.639  1.00 31.22           C  
+ATOM    741  CG  GLN A 767      23.684  -5.080  61.168  1.00 39.37           C  
+ATOM    742  CD  GLN A 767      23.601  -4.560  62.595  1.00 48.51           C  
+ATOM    743  OE1 GLN A 767      24.134  -3.495  62.922  1.00 55.48           O  
+ATOM    744  NE2 GLN A 767      22.920  -5.303  63.446  1.00 42.62           N  
+ATOM    745  N   LEU A 768      23.062  -5.574  58.100  1.00 43.01           N  
+ATOM    746  CA  LEU A 768      21.930  -5.035  57.378  1.00 42.60           C  
+ATOM    747  C   LEU A 768      21.127  -4.065  58.259  1.00 41.70           C  
+ATOM    748  O   LEU A 768      20.777  -4.374  59.401  1.00 41.93           O  
+ATOM    749  CB  LEU A 768      21.019  -6.172  56.932  1.00 38.39           C  
+ATOM    750  CG  LEU A 768      19.813  -5.742  56.110  1.00 42.83           C  
+ATOM    751  CD1 LEU A 768      20.318  -5.188  54.806  1.00 35.06           C  
+ATOM    752  CD2 LEU A 768      18.862  -6.903  55.888  1.00 37.08           C  
+ATOM    753  N   MET A 769      20.898  -2.866  57.744  1.00 45.02           N  
+ATOM    754  CA  MET A 769      20.091  -1.872  58.436  1.00 41.73           C  
+ATOM    755  C   MET A 769      18.783  -1.873  57.605  1.00 41.95           C  
+ATOM    756  O   MET A 769      18.565  -1.027  56.748  1.00 32.59           O  
+ATOM    757  CB  MET A 769      20.818  -0.533  58.411  1.00 40.44           C  
+ATOM    758  CG  MET A 769      22.197  -0.579  59.047  1.00 36.98           C  
+ATOM    759  SD  MET A 769      22.196  -1.163  60.774  1.00 44.95           S  
+ATOM    760  CE  MET A 769      21.937   0.370  61.588  1.00 41.08           C  
+ATOM    761  N   PRO A 770      17.864  -2.795  57.929  1.00 39.46           N  
+ATOM    762  CA  PRO A 770      16.570  -3.027  57.284  1.00 46.88           C  
+ATOM    763  C   PRO A 770      15.737  -1.836  56.847  1.00 50.74           C  
+ATOM    764  O   PRO A 770      15.103  -1.888  55.798  1.00 54.51           O  
+ATOM    765  CB  PRO A 770      15.805  -3.864  58.324  1.00 46.88           C  
+ATOM    766  CG  PRO A 770      16.870  -4.471  59.171  1.00 37.04           C  
+ATOM    767  CD  PRO A 770      17.843  -3.349  59.295  1.00 39.01           C  
+ATOM    768  N   PHE A 771      15.718  -0.780  57.650  1.00 49.47           N  
+ATOM    769  CA  PHE A 771      14.896   0.377  57.343  1.00 45.08           C  
+ATOM    770  C   PHE A 771      15.564   1.455  56.499  1.00 49.13           C  
+ATOM    771  O   PHE A 771      15.018   2.560  56.337  1.00 45.92           O  
+ATOM    772  CB  PHE A 771      14.330   0.938  58.643  1.00 39.19           C  
+ATOM    773  CG  PHE A 771      13.423  -0.022  59.350  1.00 54.15           C  
+ATOM    774  CD1 PHE A 771      13.932  -0.915  60.284  1.00 42.10           C  
+ATOM    775  CD2 PHE A 771      12.059  -0.069  59.047  1.00 49.19           C  
+ATOM    776  CE1 PHE A 771      13.101  -1.852  60.913  1.00 40.02           C  
+ATOM    777  CE2 PHE A 771      11.223  -0.993  59.663  1.00 48.79           C  
+ATOM    778  CZ  PHE A 771      11.747  -1.888  60.601  1.00 45.29           C  
+ATOM    779  N   GLY A 772      16.741   1.120  55.964  1.00 42.45           N  
+ATOM    780  CA  GLY A 772      17.489   2.033  55.119  1.00 42.54           C  
+ATOM    781  C   GLY A 772      17.961   3.315  55.768  1.00 43.91           C  
+ATOM    782  O   GLY A 772      17.986   3.412  56.992  1.00 54.66           O  
+ATOM    783  N   CYS A 773      18.316   4.305  54.947  1.00 45.01           N  
+ATOM    784  CA  CYS A 773      18.810   5.587  55.443  1.00 48.25           C  
+ATOM    785  C   CYS A 773      17.716   6.453  56.069  1.00 48.24           C  
+ATOM    786  O   CYS A 773      16.572   6.447  55.616  1.00 53.93           O  
+ATOM    787  CB  CYS A 773      19.566   6.358  54.350  1.00 49.39           C  
+ATOM    788  SG  CYS A 773      18.542   7.150  53.121  1.00 64.70           S  
+ATOM    789  N   LEU A 774      18.110   7.204  57.099  1.00 45.51           N  
+ATOM    790  CA  LEU A 774      17.238   8.075  57.877  1.00 45.93           C  
+ATOM    791  C   LEU A 774      16.503   9.156  57.090  1.00 42.62           C  
+ATOM    792  O   LEU A 774      15.345   9.434  57.379  1.00 44.08           O  
+ATOM    793  CB  LEU A 774      18.028   8.701  59.035  1.00 37.86           C  
+ATOM    794  CG  LEU A 774      17.224   9.366  60.153  1.00 42.91           C  
+ATOM    795  CD1 LEU A 774      16.227   8.375  60.729  1.00 38.44           C  
+ATOM    796  CD2 LEU A 774      18.153   9.886  61.235  1.00 47.66           C  
+ATOM    797  N   LEU A 775      17.179   9.768  56.121  1.00 44.71           N  
+ATOM    798  CA  LEU A 775      16.583  10.797  55.273  1.00 45.97           C  
+ATOM    799  C   LEU A 775      15.309  10.283  54.631  1.00 52.57           C  
+ATOM    800  O   LEU A 775      14.226  10.821  54.880  1.00 59.37           O  
+ATOM    801  CB  LEU A 775      17.543  11.226  54.166  1.00 41.57           C  
+ATOM    802  CG  LEU A 775      17.033  12.336  53.239  1.00 59.61           C  
+ATOM    803  CD1 LEU A 775      16.790  13.618  54.043  1.00 51.15           C  
+ATOM    804  CD2 LEU A 775      18.051  12.595  52.119  1.00 44.66           C  
+ATOM    805  N   ASP A 776      15.419   9.232  53.825  1.00 47.02           N  
+ATOM    806  CA  ASP A 776      14.224   8.698  53.191  1.00 54.22           C  
+ATOM    807  C   ASP A 776      13.247   8.165  54.195  1.00 51.83           C  
+ATOM    808  O   ASP A 776      12.045   8.153  53.936  1.00 54.00           O  
+ATOM    809  CB  ASP A 776      14.544   7.621  52.157  1.00 63.93           C  
+ATOM    810  CG  ASP A 776      15.193   8.192  50.919  1.00 78.52           C  
+ATOM    811  OD1 ASP A 776      16.228   7.634  50.489  1.00 91.07           O  
+ATOM    812  OD2 ASP A 776      14.676   9.209  50.391  1.00 90.46           O  
+ATOM    813  N   TYR A 777      13.746   7.736  55.349  1.00 47.56           N  
+ATOM    814  CA  TYR A 777      12.849   7.220  56.374  1.00 51.27           C  
+ATOM    815  C   TYR A 777      11.915   8.325  56.909  1.00 53.80           C  
+ATOM    816  O   TYR A 777      10.698   8.130  56.987  1.00 51.44           O  
+ATOM    817  CB  TYR A 777      13.631   6.552  57.508  1.00 52.40           C  
+ATOM    818  CG  TYR A 777      12.740   5.855  58.502  1.00 47.33           C  
+ATOM    819  CD1 TYR A 777      12.351   4.540  58.306  1.00 42.51           C  
+ATOM    820  CD2 TYR A 777      12.245   6.533  59.620  1.00 50.30           C  
+ATOM    821  CE1 TYR A 777      11.483   3.907  59.195  1.00 47.64           C  
+ATOM    822  CE2 TYR A 777      11.380   5.917  60.513  1.00 40.37           C  
+ATOM    823  CZ  TYR A 777      10.998   4.601  60.295  1.00 58.35           C  
+ATOM    824  OH  TYR A 777      10.119   3.984  61.160  1.00 61.78           O  
+ATOM    825  N   VAL A 778      12.463   9.497  57.227  1.00 50.37           N  
+ATOM    826  CA  VAL A 778      11.612  10.569  57.729  1.00 57.80           C  
+ATOM    827  C   VAL A 778      10.652  11.051  56.646  1.00 61.51           C  
+ATOM    828  O   VAL A 778       9.542  11.486  56.945  1.00 63.01           O  
+ATOM    829  CB  VAL A 778      12.399  11.767  58.330  1.00 44.85           C  
+ATOM    830  CG1 VAL A 778      13.212  11.319  59.516  1.00 36.50           C  
+ATOM    831  CG2 VAL A 778      13.268  12.433  57.293  1.00 31.46           C  
+ATOM    832  N   ARG A 779      11.068  10.934  55.387  1.00 60.95           N  
+ATOM    833  CA  ARG A 779      10.221  11.346  54.275  1.00 56.05           C  
+ATOM    834  C   ARG A 779       8.988  10.449  54.107  1.00 56.04           C  
+ATOM    835  O   ARG A 779       7.855  10.934  54.054  1.00 61.52           O  
+ATOM    836  CB  ARG A 779      11.017  11.398  52.979  1.00 45.27           C  
+ATOM    837  CG  ARG A 779      11.913  12.607  52.844  1.00 33.64           C  
+ATOM    838  CD  ARG A 779      12.778  12.486  51.598  1.00 34.97           C  
+ATOM    839  NE  ARG A 779      13.648  13.643  51.403  1.00 36.19           N  
+ATOM    840  CZ  ARG A 779      14.596  13.716  50.468  1.00 55.14           C  
+ATOM    841  NH1 ARG A 779      14.788  12.685  49.647  1.00 56.28           N  
+ATOM    842  NH2 ARG A 779      15.356  14.814  50.349  1.00 34.22           N  
+ATOM    843  N   GLU A 780       9.183   9.145  54.059  1.00 51.97           N  
+ATOM    844  CA  GLU A 780       8.027   8.300  53.897  1.00 60.68           C  
+ATOM    845  C   GLU A 780       7.336   7.921  55.198  1.00 62.37           C  
+ATOM    846  O   GLU A 780       6.592   6.941  55.245  1.00 74.01           O  
+ATOM    847  CB  GLU A 780       8.329   7.075  53.015  1.00 71.86           C  
+ATOM    848  CG  GLU A 780       8.824   5.833  53.726  1.00 76.77           C  
+ATOM    849  CD  GLU A 780       8.651   4.577  52.874  1.00104.17           C  
+ATOM    850  OE1 GLU A 780       9.176   4.549  51.735  1.00112.27           O  
+ATOM    851  OE2 GLU A 780       7.979   3.625  53.339  1.00100.28           O  
+ATOM    852  N   HIS A 781       7.572   8.684  56.259  1.00 61.36           N  
+ATOM    853  CA  HIS A 781       6.900   8.397  57.528  1.00 58.52           C  
+ATOM    854  C   HIS A 781       6.506   9.666  58.306  1.00 57.06           C  
+ATOM    855  O   HIS A 781       6.030   9.559  59.433  1.00 53.86           O  
+ATOM    856  CB  HIS A 781       7.734   7.452  58.423  1.00 55.60           C  
+ATOM    857  CG  HIS A 781       7.904   6.062  57.880  1.00 64.59           C  
+ATOM    858  ND1 HIS A 781       9.013   5.669  57.160  1.00 58.35           N  
+ATOM    859  CD2 HIS A 781       7.109   4.965  57.966  1.00 64.03           C  
+ATOM    860  CE1 HIS A 781       8.894   4.395  56.824  1.00 61.92           C  
+ATOM    861  NE2 HIS A 781       7.747   3.946  57.301  1.00 56.37           N  
+ATOM    862  N   LYS A 782       6.663  10.848  57.690  1.00 55.91           N  
+ATOM    863  CA  LYS A 782       6.326  12.144  58.320  1.00 63.44           C  
+ATOM    864  C   LYS A 782       5.097  12.098  59.232  1.00 71.56           C  
+ATOM    865  O   LYS A 782       5.121  12.598  60.358  1.00 82.57           O  
+ATOM    866  CB  LYS A 782       6.010  13.241  57.285  1.00 64.38           C  
+ATOM    867  CG  LYS A 782       6.653  13.152  55.915  1.00 84.37           C  
+ATOM    868  CD  LYS A 782       5.941  14.098  54.933  1.00 86.64           C  
+ATOM    869  CE  LYS A 782       6.654  14.195  53.573  1.00 92.68           C  
+ATOM    870  NZ  LYS A 782       7.919  15.015  53.619  1.00 93.68           N  
+ATOM    871  N   ASP A 783       4.011  11.529  58.717  1.00 70.30           N  
+ATOM    872  CA  ASP A 783       2.746  11.453  59.441  1.00 73.87           C  
+ATOM    873  C   ASP A 783       2.715  10.520  60.648  1.00 67.87           C  
+ATOM    874  O   ASP A 783       1.674  10.372  61.287  1.00 74.14           O  
+ATOM    875  CB  ASP A 783       1.604  11.092  58.472  1.00 82.36           C  
+ATOM    876  CG  ASP A 783       1.507  12.049  57.278  1.00 81.42           C  
+ATOM    877  OD1 ASP A 783       1.768  13.263  57.440  1.00 86.89           O  
+ATOM    878  OD2 ASP A 783       1.167  11.582  56.168  1.00 86.70           O  
+ATOM    879  N   ASN A 784       3.843   9.896  60.961  1.00 62.82           N  
+ATOM    880  CA  ASN A 784       3.915   8.974  62.091  1.00 69.72           C  
+ATOM    881  C   ASN A 784       5.193   9.144  62.910  1.00 71.25           C  
+ATOM    882  O   ASN A 784       5.564   8.250  63.681  1.00 76.82           O  
+ATOM    883  CB  ASN A 784       3.832   7.512  61.616  1.00 90.63           C  
+ATOM    884  CG  ASN A 784       2.446   7.119  61.138  1.00107.35           C  
+ATOM    885  OD1 ASN A 784       1.608   6.669  61.926  1.00105.06           O  
+ATOM    886  ND2 ASN A 784       2.205   7.261  59.837  1.00103.68           N  
+ATOM    887  N   ILE A 785       5.882  10.267  62.734  1.00 61.17           N  
+ATOM    888  CA  ILE A 785       7.112  10.496  63.475  1.00 55.69           C  
+ATOM    889  C   ILE A 785       6.895  11.507  64.590  1.00 53.27           C  
+ATOM    890  O   ILE A 785       6.709  12.700  64.349  1.00 51.26           O  
+ATOM    891  CB  ILE A 785       8.250  10.919  62.533  1.00 59.66           C  
+ATOM    892  CG1 ILE A 785       8.606   9.748  61.607  1.00 53.69           C  
+ATOM    893  CG2 ILE A 785       9.466  11.321  63.330  1.00 42.75           C  
+ATOM    894  CD1 ILE A 785       9.490  10.135  60.435  1.00 38.87           C  
+ATOM    895  N   GLY A 786       6.879  11.000  65.816  1.00 52.36           N  
+ATOM    896  CA  GLY A 786       6.673  11.848  66.973  1.00 48.87           C  
+ATOM    897  C   GLY A 786       7.954  12.390  67.568  1.00 52.55           C  
+ATOM    898  O   GLY A 786       9.018  11.785  67.435  1.00 57.72           O  
+ATOM    899  N   SER A 787       7.820  13.493  68.300  1.00 49.41           N  
+ATOM    900  CA  SER A 787       8.932  14.186  68.935  1.00 46.89           C  
+ATOM    901  C   SER A 787       9.927  13.323  69.710  1.00 44.61           C  
+ATOM    902  O   SER A 787      11.097  13.669  69.793  1.00 45.04           O  
+ATOM    903  CB  SER A 787       8.397  15.290  69.840  1.00 42.00           C  
+ATOM    904  OG  SER A 787       7.544  14.743  70.825  1.00 47.09           O  
+ATOM    905  N   GLN A 788       9.465  12.223  70.295  1.00 38.92           N  
+ATOM    906  CA  GLN A 788      10.360  11.363  71.045  1.00 47.50           C  
+ATOM    907  C   GLN A 788      11.384  10.692  70.127  1.00 49.03           C  
+ATOM    908  O   GLN A 788      12.556  10.538  70.488  1.00 50.47           O  
+ATOM    909  CB  GLN A 788       9.579  10.305  71.798  1.00 35.97           C  
+ATOM    910  CG  GLN A 788      10.434   9.463  72.716  1.00 41.45           C  
+ATOM    911  CD  GLN A 788      11.013  10.269  73.861  1.00 66.83           C  
+ATOM    912  OE1 GLN A 788      10.393  10.386  74.922  1.00 81.93           O  
+ATOM    913  NE2 GLN A 788      12.207  10.833  73.656  1.00 64.85           N  
+ATOM    914  N   TYR A 789      10.931  10.294  68.946  1.00 45.79           N  
+ATOM    915  CA  TYR A 789      11.806   9.658  67.986  1.00 41.58           C  
+ATOM    916  C   TYR A 789      12.807  10.654  67.428  1.00 41.47           C  
+ATOM    917  O   TYR A 789      14.010  10.362  67.353  1.00 41.43           O  
+ATOM    918  CB  TYR A 789      11.001   8.993  66.880  1.00 44.50           C  
+ATOM    919  CG  TYR A 789      10.392   7.671  67.290  1.00 41.58           C  
+ATOM    920  CD1 TYR A 789       9.295   7.610  68.142  1.00 60.46           C  
+ATOM    921  CD2 TYR A 789      10.902   6.482  66.804  1.00 62.73           C  
+ATOM    922  CE1 TYR A 789       8.723   6.389  68.493  1.00 59.32           C  
+ATOM    923  CE2 TYR A 789      10.344   5.261  67.148  1.00 64.34           C  
+ATOM    924  CZ  TYR A 789       9.259   5.218  67.989  1.00 68.15           C  
+ATOM    925  OH  TYR A 789       8.732   3.989  68.321  1.00 79.92           O  
+ATOM    926  N   LEU A 790      12.339  11.851  67.093  1.00 40.35           N  
+ATOM    927  CA  LEU A 790      13.255  12.869  66.579  1.00 37.27           C  
+ATOM    928  C   LEU A 790      14.393  13.182  67.555  1.00 36.86           C  
+ATOM    929  O   LEU A 790      15.572  13.142  67.178  1.00 41.71           O  
+ATOM    930  CB  LEU A 790      12.508  14.141  66.222  1.00 34.87           C  
+ATOM    931  CG  LEU A 790      11.669  14.039  64.944  1.00 50.24           C  
+ATOM    932  CD1 LEU A 790      10.695  15.208  64.816  1.00 49.40           C  
+ATOM    933  CD2 LEU A 790      12.611  14.011  63.755  1.00 45.56           C  
+ATOM    934  N   LEU A 791      14.047  13.426  68.818  1.00 35.56           N  
+ATOM    935  CA  LEU A 791      15.044  13.755  69.839  1.00 37.69           C  
+ATOM    936  C   LEU A 791      15.975  12.598  70.185  1.00 34.67           C  
+ATOM    937  O   LEU A 791      17.150  12.831  70.435  1.00 40.14           O  
+ATOM    938  CB  LEU A 791      14.382  14.340  71.091  1.00 39.36           C  
+ATOM    939  CG  LEU A 791      13.677  15.661  70.770  1.00 36.13           C  
+ATOM    940  CD1 LEU A 791      12.700  16.007  71.870  1.00 41.31           C  
+ATOM    941  CD2 LEU A 791      14.679  16.797  70.527  1.00 37.25           C  
+ATOM    942  N   ASN A 792      15.458  11.370  70.235  1.00 30.38           N  
+ATOM    943  CA  ASN A 792      16.315  10.202  70.489  1.00 38.22           C  
+ATOM    944  C   ASN A 792      17.323  10.028  69.332  1.00 38.88           C  
+ATOM    945  O   ASN A 792      18.470   9.664  69.571  1.00 41.61           O  
+ATOM    946  CB  ASN A 792      15.507   8.905  70.660  1.00 34.49           C  
+ATOM    947  CG  ASN A 792      14.829   8.794  72.036  1.00 63.91           C  
+ATOM    948  OD1 ASN A 792      15.047   9.615  72.931  1.00 55.49           O  
+ATOM    949  ND2 ASN A 792      14.019   7.752  72.208  1.00 50.57           N  
+ATOM    950  N   TRP A 793      16.917  10.300  68.087  1.00 33.17           N  
+ATOM    951  CA  TRP A 793      17.867  10.174  66.978  1.00 33.22           C  
+ATOM    952  C   TRP A 793      18.986  11.198  67.131  1.00 29.40           C  
+ATOM    953  O   TRP A 793      20.143  10.866  66.921  1.00 40.35           O  
+ATOM    954  CB  TRP A 793      17.196  10.306  65.604  1.00 28.42           C  
+ATOM    955  CG  TRP A 793      16.246   9.195  65.314  1.00 28.39           C  
+ATOM    956  CD1 TRP A 793      16.295   7.929  65.818  1.00 24.44           C  
+ATOM    957  CD2 TRP A 793      15.072   9.253  64.485  1.00 21.75           C  
+ATOM    958  NE1 TRP A 793      15.217   7.187  65.357  1.00 27.89           N  
+ATOM    959  CE2 TRP A 793      14.459   7.976  64.533  1.00 22.72           C  
+ATOM    960  CE3 TRP A 793      14.482  10.252  63.709  1.00 26.78           C  
+ATOM    961  CZ2 TRP A 793      13.289   7.677  63.829  1.00 31.94           C  
+ATOM    962  CZ3 TRP A 793      13.309   9.954  63.005  1.00 26.47           C  
+ATOM    963  CH2 TRP A 793      12.732   8.678  63.070  1.00 24.30           C  
+ATOM    964  N   CYS A 794      18.656  12.420  67.557  1.00 34.46           N  
+ATOM    965  CA  CYS A 794      19.671  13.454  67.761  1.00 29.94           C  
+ATOM    966  C   CYS A 794      20.667  13.036  68.849  1.00 36.44           C  
+ATOM    967  O   CYS A 794      21.868  13.279  68.724  1.00 43.89           O  
+ATOM    968  CB  CYS A 794      19.030  14.778  68.127  1.00 35.59           C  
+ATOM    969  SG  CYS A 794      18.079  15.523  66.796  1.00 34.86           S  
+ATOM    970  N   VAL A 795      20.174  12.370  69.888  1.00 33.82           N  
+ATOM    971  CA  VAL A 795      21.039  11.899  70.968  1.00 36.82           C  
+ATOM    972  C   VAL A 795      21.974  10.804  70.433  1.00 39.85           C  
+ATOM    973  O   VAL A 795      23.185  10.868  70.626  1.00 36.93           O  
+ATOM    974  CB  VAL A 795      20.207  11.329  72.173  1.00 32.68           C  
+ATOM    975  CG1 VAL A 795      21.099  10.583  73.129  1.00 22.10           C  
+ATOM    976  CG2 VAL A 795      19.544  12.458  72.936  1.00 31.09           C  
+ATOM    977  N   GLN A 796      21.391   9.806  69.769  1.00 41.72           N  
+ATOM    978  CA  GLN A 796      22.124   8.679  69.197  1.00 33.94           C  
+ATOM    979  C   GLN A 796      23.180   9.109  68.195  1.00 41.14           C  
+ATOM    980  O   GLN A 796      24.333   8.636  68.242  1.00 31.84           O  
+ATOM    981  CB  GLN A 796      21.145   7.704  68.562  1.00 34.71           C  
+ATOM    982  CG  GLN A 796      20.380   6.910  69.622  1.00 35.30           C  
+ATOM    983  CD  GLN A 796      19.397   5.936  69.035  1.00 39.76           C  
+ATOM    984  OE1 GLN A 796      19.566   5.463  67.910  1.00 56.49           O  
+ATOM    985  NE2 GLN A 796      18.360   5.622  69.790  1.00 47.78           N  
+ATOM    986  N   ILE A 797      22.804  10.025  67.302  1.00 33.81           N  
+ATOM    987  CA  ILE A 797      23.754  10.501  66.317  1.00 34.05           C  
+ATOM    988  C   ILE A 797      24.864  11.244  67.060  1.00 39.39           C  
+ATOM    989  O   ILE A 797      26.021  11.106  66.709  1.00 41.02           O  
+ATOM    990  CB  ILE A 797      23.096  11.422  65.272  1.00 37.63           C  
+ATOM    991  CG1 ILE A 797      22.082  10.634  64.450  1.00 22.87           C  
+ATOM    992  CG2 ILE A 797      24.174  12.076  64.368  1.00 19.73           C  
+ATOM    993  CD1 ILE A 797      21.257  11.506  63.506  1.00 33.35           C  
+ATOM    994  N   ALA A 798      24.520  12.004  68.102  1.00 41.25           N  
+ATOM    995  CA  ALA A 798      25.530  12.733  68.873  1.00 38.55           C  
+ATOM    996  C   ALA A 798      26.474  11.784  69.623  1.00 41.17           C  
+ATOM    997  O   ALA A 798      27.667  12.066  69.761  1.00 41.95           O  
+ATOM    998  CB  ALA A 798      24.882  13.696  69.831  1.00 24.12           C  
+ATOM    999  N   LYS A 799      25.945  10.662  70.099  1.00 36.30           N  
+ATOM   1000  CA  LYS A 799      26.766   9.678  70.787  1.00 30.80           C  
+ATOM   1001  C   LYS A 799      27.768   9.052  69.823  1.00 37.84           C  
+ATOM   1002  O   LYS A 799      28.948   8.934  70.149  1.00 43.91           O  
+ATOM   1003  CB  LYS A 799      25.908   8.577  71.371  1.00 23.13           C  
+ATOM   1004  CG  LYS A 799      25.154   8.978  72.581  1.00 35.42           C  
+ATOM   1005  CD  LYS A 799      24.384   7.804  73.169  1.00 25.21           C  
+ATOM   1006  CE  LYS A 799      23.772   8.278  74.495  1.00 38.54           C  
+ATOM   1007  NZ  LYS A 799      23.067   7.230  75.242  1.00 39.23           N  
+ATOM   1008  N   GLY A 800      27.280   8.631  68.650  1.00 39.67           N  
+ATOM   1009  CA  GLY A 800      28.136   8.037  67.637  1.00 24.71           C  
+ATOM   1010  C   GLY A 800      29.265   8.986  67.264  1.00 43.88           C  
+ATOM   1011  O   GLY A 800      30.439   8.592  67.210  1.00 48.37           O  
+ATOM   1012  N   MET A 801      28.920  10.253  67.061  1.00 37.65           N  
+ATOM   1013  CA  MET A 801      29.900  11.252  66.684  1.00 40.81           C  
+ATOM   1014  C   MET A 801      30.933  11.512  67.781  1.00 40.95           C  
+ATOM   1015  O   MET A 801      32.118  11.707  67.483  1.00 35.77           O  
+ATOM   1016  CB  MET A 801      29.216  12.558  66.277  1.00 28.88           C  
+ATOM   1017  CG  MET A 801      28.439  12.450  65.002  1.00 43.04           C  
+ATOM   1018  SD  MET A 801      29.361  11.787  63.564  1.00 39.80           S  
+ATOM   1019  CE  MET A 801      30.593  13.030  63.460  1.00 26.65           C  
+ATOM   1020  N   ASN A 802      30.488  11.546  69.039  1.00 41.67           N  
+ATOM   1021  CA  ASN A 802      31.397  11.781  70.168  1.00 38.89           C  
+ATOM   1022  C   ASN A 802      32.385  10.623  70.197  1.00 38.51           C  
+ATOM   1023  O   ASN A 802      33.570  10.831  70.432  1.00 36.70           O  
+ATOM   1024  CB  ASN A 802      30.634  11.867  71.498  1.00 31.21           C  
+ATOM   1025  CG  ASN A 802      31.562  11.946  72.722  1.00 38.28           C  
+ATOM   1026  OD1 ASN A 802      32.309  12.913  72.899  1.00 48.15           O  
+ATOM   1027  ND2 ASN A 802      31.501  10.932  73.575  1.00 30.97           N  
+ATOM   1028  N   TYR A 803      31.896   9.421  69.888  1.00 39.61           N  
+ATOM   1029  CA  TYR A 803      32.737   8.235  69.849  1.00 40.41           C  
+ATOM   1030  C   TYR A 803      33.800   8.433  68.778  1.00 43.10           C  
+ATOM   1031  O   TYR A 803      34.993   8.283  69.055  1.00 40.86           O  
+ATOM   1032  CB  TYR A 803      31.924   6.976  69.556  1.00 38.80           C  
+ATOM   1033  CG  TYR A 803      32.803   5.768  69.290  1.00 51.05           C  
+ATOM   1034  CD1 TYR A 803      33.389   5.058  70.341  1.00 40.82           C  
+ATOM   1035  CD2 TYR A 803      33.097   5.372  67.984  1.00 41.58           C  
+ATOM   1036  CE1 TYR A 803      34.247   3.989  70.098  1.00 33.20           C  
+ATOM   1037  CE2 TYR A 803      33.955   4.304  67.727  1.00 43.12           C  
+ATOM   1038  CZ  TYR A 803      34.524   3.618  68.781  1.00 51.70           C  
+ATOM   1039  OH  TYR A 803      35.357   2.563  68.503  1.00 52.98           O  
+ATOM   1040  N   LEU A 804      33.367   8.790  67.569  1.00 36.41           N  
+ATOM   1041  CA  LEU A 804      34.305   9.033  66.481  1.00 37.21           C  
+ATOM   1042  C   LEU A 804      35.352  10.039  66.903  1.00 42.76           C  
+ATOM   1043  O   LEU A 804      36.517   9.849  66.610  1.00 48.28           O  
+ATOM   1044  CB  LEU A 804      33.600   9.520  65.210  1.00 26.16           C  
+ATOM   1045  CG  LEU A 804      32.777   8.438  64.508  1.00 32.34           C  
+ATOM   1046  CD1 LEU A 804      32.304   8.975  63.201  1.00 33.22           C  
+ATOM   1047  CD2 LEU A 804      33.613   7.173  64.286  1.00 22.83           C  
+ATOM   1048  N   GLU A 805      34.949  11.078  67.637  1.00 48.63           N  
+ATOM   1049  CA  GLU A 805      35.894  12.103  68.091  1.00 45.78           C  
+ATOM   1050  C   GLU A 805      36.916  11.506  69.060  1.00 46.23           C  
+ATOM   1051  O   GLU A 805      38.102  11.821  69.002  1.00 49.92           O  
+ATOM   1052  CB  GLU A 805      35.173  13.282  68.739  1.00 38.63           C  
+ATOM   1053  CG  GLU A 805      36.136  14.387  69.171  1.00 48.99           C  
+ATOM   1054  CD  GLU A 805      35.468  15.702  69.557  1.00 53.77           C  
+ATOM   1055  OE1 GLU A 805      34.248  15.865  69.349  1.00 61.76           O  
+ATOM   1056  OE2 GLU A 805      36.182  16.592  70.064  1.00 69.17           O  
+ATOM   1057  N   ASP A 806      36.450  10.633  69.940  1.00 43.87           N  
+ATOM   1058  CA  ASP A 806      37.326   9.969  70.882  1.00 42.71           C  
+ATOM   1059  C   ASP A 806      38.347   9.122  70.109  1.00 47.19           C  
+ATOM   1060  O   ASP A 806      39.509   9.032  70.486  1.00 48.32           O  
+ATOM   1061  CB  ASP A 806      36.504   9.064  71.805  1.00 45.74           C  
+ATOM   1062  CG  ASP A 806      35.943   9.801  73.009  1.00 55.06           C  
+ATOM   1063  OD1 ASP A 806      36.425  10.915  73.305  1.00 65.72           O  
+ATOM   1064  OD2 ASP A 806      35.035   9.255  73.675  1.00 59.34           O  
+ATOM   1065  N   ARG A 807      37.915   8.556  68.990  1.00 45.21           N  
+ATOM   1066  CA  ARG A 807      38.774   7.703  68.186  1.00 47.26           C  
+ATOM   1067  C   ARG A 807      39.634   8.571  67.281  1.00 50.53           C  
+ATOM   1068  O   ARG A 807      40.458   8.074  66.523  1.00 56.70           O  
+ATOM   1069  CB  ARG A 807      37.890   6.740  67.376  1.00 36.57           C  
+ATOM   1070  CG  ARG A 807      38.601   5.639  66.634  1.00 74.03           C  
+ATOM   1071  CD  ARG A 807      39.130   4.547  67.552  1.00 85.23           C  
+ATOM   1072  NE  ARG A 807      39.844   3.522  66.792  1.00 80.58           N  
+ATOM   1073  CZ  ARG A 807      40.957   3.740  66.088  1.00 88.96           C  
+ATOM   1074  NH1 ARG A 807      41.502   4.948  66.033  1.00 71.64           N  
+ATOM   1075  NH2 ARG A 807      41.550   2.737  65.459  1.00 89.67           N  
+ATOM   1076  N   ARG A 808      39.467   9.882  67.414  1.00 48.61           N  
+ATOM   1077  CA  ARG A 808      40.186  10.860  66.604  1.00 47.56           C  
+ATOM   1078  C   ARG A 808      39.818  10.788  65.131  1.00 45.27           C  
+ATOM   1079  O   ARG A 808      40.637  11.061  64.266  1.00 50.55           O  
+ATOM   1080  CB  ARG A 808      41.702  10.729  66.782  1.00 52.89           C  
+ATOM   1081  CG  ARG A 808      42.196  11.179  68.144  1.00 69.77           C  
+ATOM   1082  CD  ARG A 808      43.713  11.261  68.220  1.00 69.15           C  
+ATOM   1083  NE  ARG A 808      44.099  11.842  69.500  1.00 94.06           N  
+ATOM   1084  CZ  ARG A 808      44.409  13.122  69.683  1.00100.61           C  
+ATOM   1085  NH1 ARG A 808      44.399  13.965  68.655  1.00 92.39           N  
+ATOM   1086  NH2 ARG A 808      44.662  13.571  70.908  1.00105.11           N  
+ATOM   1087  N   LEU A 809      38.565  10.467  64.849  1.00 43.95           N  
+ATOM   1088  CA  LEU A 809      38.110  10.376  63.473  1.00 45.44           C  
+ATOM   1089  C   LEU A 809      37.174  11.523  63.054  1.00 37.65           C  
+ATOM   1090  O   LEU A 809      36.206  11.803  63.733  1.00 50.68           O  
+ATOM   1091  CB  LEU A 809      37.406   9.049  63.268  1.00 43.62           C  
+ATOM   1092  CG  LEU A 809      37.172   8.774  61.796  1.00 61.18           C  
+ATOM   1093  CD1 LEU A 809      38.510   8.410  61.181  1.00 79.13           C  
+ATOM   1094  CD2 LEU A 809      36.186   7.647  61.617  1.00 79.36           C  
+ATOM   1095  N   VAL A 810      37.473  12.166  61.933  1.00 33.61           N  
+ATOM   1096  CA  VAL A 810      36.674  13.254  61.405  1.00 33.29           C  
+ATOM   1097  C   VAL A 810      35.856  12.732  60.204  1.00 43.06           C  
+ATOM   1098  O   VAL A 810      36.368  12.615  59.105  1.00 60.59           O  
+ATOM   1099  CB  VAL A 810      37.598  14.456  61.002  1.00 44.36           C  
+ATOM   1100  CG1 VAL A 810      36.851  15.494  60.205  1.00 33.29           C  
+ATOM   1101  CG2 VAL A 810      38.180  15.114  62.237  1.00 32.62           C  
+ATOM   1102  N   HIS A 811      34.667  12.326  60.533  1.00 44.15           N  
+ATOM   1103  CA  HIS A 811      33.711  11.967  59.538  1.00 42.88           C  
+ATOM   1104  C   HIS A 811      33.869  12.518  58.168  1.00 50.87           C  
+ATOM   1105  O   HIS A 811      34.642  11.883  57.384  1.00 79.26           O  
+ATOM   1106  CB  HIS A 811      32.399  11.429  59.969  1.00 29.72           C  
+ATOM   1107  CG  HIS A 811      31.482  10.742  59.051  1.00 26.61           C  
+ATOM   1108  ND1 HIS A 811      30.777  11.308  58.034  1.00 26.25           N  
+ATOM   1109  CD2 HIS A 811      31.041   9.439  59.073  1.00 26.55           C  
+ATOM   1110  CE1 HIS A 811      30.038  10.434  57.399  1.00 25.30           C  
+ATOM   1111  NE2 HIS A 811      30.158   9.279  58.040  1.00 29.81           N  
+ATOM   1112  N   ARG A 812      33.654  13.795  57.914  1.00 43.22           N  
+ATOM   1113  CA  ARG A 812      33.687  14.489  56.673  1.00 40.79           C  
+ATOM   1114  C   ARG A 812      32.524  14.338  55.738  1.00 38.63           C  
+ATOM   1115  O   ARG A 812      32.283  15.152  54.804  1.00 39.36           O  
+ATOM   1116  CB  ARG A 812      34.999  14.790  56.040  1.00 48.30           C  
+ATOM   1117  CG  ARG A 812      36.186  15.234  56.822  1.00 46.56           C  
+ATOM   1118  CD  ARG A 812      37.458  15.150  56.006  1.00 59.48           C  
+ATOM   1119  NE  ARG A 812      37.521  15.981  54.832  1.00 53.74           N  
+ATOM   1120  CZ  ARG A 812      37.711  15.608  53.579  1.00 68.23           C  
+ATOM   1121  NH1 ARG A 812      37.825  14.340  53.240  1.00 50.67           N  
+ATOM   1122  NH2 ARG A 812      37.776  16.537  52.627  1.00 64.39           N  
+ATOM   1123  N   ASP A 813      31.466  13.574  56.067  1.00 33.31           N  
+ATOM   1124  CA  ASP A 813      30.284  13.508  55.232  1.00 36.43           C  
+ATOM   1125  C   ASP A 813      29.051  13.099  56.051  1.00 44.24           C  
+ATOM   1126  O   ASP A 813      28.286  12.201  55.672  1.00 38.40           O  
+ATOM   1127  CB  ASP A 813      30.529  12.559  54.046  1.00 33.59           C  
+ATOM   1128  CG  ASP A 813      29.416  12.603  53.004  1.00 46.44           C  
+ATOM   1129  OD1 ASP A 813      28.721  13.633  52.893  1.00 58.19           O  
+ATOM   1130  OD2 ASP A 813      29.230  11.599  52.290  1.00 53.78           O  
+ATOM   1131  N   LEU A 814      28.860  13.785  57.173  1.00 44.31           N  
+ATOM   1132  CA  LEU A 814      27.734  13.515  58.055  1.00 38.77           C  
+ATOM   1133  C   LEU A 814      26.515  14.207  57.486  1.00 36.03           C  
+ATOM   1134  O   LEU A 814      26.532  15.412  57.294  1.00 27.43           O  
+ATOM   1135  CB  LEU A 814      28.015  14.060  59.462  1.00 47.33           C  
+ATOM   1136  CG  LEU A 814      26.903  13.902  60.512  1.00 47.51           C  
+ATOM   1137  CD1 LEU A 814      26.356  12.463  60.541  1.00 36.48           C  
+ATOM   1138  CD2 LEU A 814      27.450  14.300  61.868  1.00 36.58           C  
+ATOM   1139  N   ALA A 815      25.433  13.454  57.320  1.00 31.91           N  
+ATOM   1140  CA  ALA A 815      24.198  13.990  56.774  1.00 30.48           C  
+ATOM   1141  C   ALA A 815      23.151  12.900  56.943  1.00 38.98           C  
+ATOM   1142  O   ALA A 815      23.513  11.738  57.146  1.00 39.49           O  
+ATOM   1143  CB  ALA A 815      24.393  14.318  55.326  1.00 26.08           C  
+ATOM   1144  N   ALA A 816      21.864  13.254  56.880  1.00 36.62           N  
+ATOM   1145  CA  ALA A 816      20.812  12.244  57.062  1.00 36.89           C  
+ATOM   1146  C   ALA A 816      20.942  11.013  56.161  1.00 34.00           C  
+ATOM   1147  O   ALA A 816      20.623   9.898  56.579  1.00 45.11           O  
+ATOM   1148  CB  ALA A 816      19.402  12.875  56.927  1.00 29.81           C  
+ATOM   1149  N   ARG A 817      21.429  11.206  54.935  1.00 45.25           N  
+ATOM   1150  CA  ARG A 817      21.578  10.086  53.999  1.00 48.10           C  
+ATOM   1151  C   ARG A 817      22.586   9.048  54.494  1.00 44.86           C  
+ATOM   1152  O   ARG A 817      22.506   7.886  54.116  1.00 47.75           O  
+ATOM   1153  CB  ARG A 817      21.986  10.579  52.598  1.00 34.72           C  
+ATOM   1154  CG  ARG A 817      23.366  11.192  52.520  1.00 44.13           C  
+ATOM   1155  CD  ARG A 817      23.628  11.823  51.138  1.00 41.71           C  
+ATOM   1156  NE  ARG A 817      24.198  13.163  51.290  1.00 44.49           N  
+ATOM   1157  CZ  ARG A 817      25.471  13.403  51.581  1.00 57.10           C  
+ATOM   1158  NH1 ARG A 817      26.327  12.396  51.723  1.00 70.85           N  
+ATOM   1159  NH2 ARG A 817      25.861  14.638  51.848  1.00 48.19           N  
+ATOM   1160  N   ASN A 818      23.484   9.475  55.379  1.00 38.66           N  
+ATOM   1161  CA  ASN A 818      24.535   8.632  55.917  1.00 40.52           C  
+ATOM   1162  C   ASN A 818      24.264   8.145  57.349  1.00 43.40           C  
+ATOM   1163  O   ASN A 818      25.191   7.939  58.145  1.00 41.83           O  
+ATOM   1164  CB  ASN A 818      25.885   9.370  55.840  1.00 29.76           C  
+ATOM   1165  CG  ASN A 818      26.331   9.642  54.406  1.00 40.76           C  
+ATOM   1166  OD1 ASN A 818      25.942   8.931  53.475  1.00 41.82           O  
+ATOM   1167  ND2 ASN A 818      27.163  10.679  54.223  1.00 29.10           N  
+ATOM   1168  N   VAL A 819      22.992   8.022  57.696  1.00 33.68           N  
+ATOM   1169  CA  VAL A 819      22.628   7.511  59.007  1.00 36.69           C  
+ATOM   1170  C   VAL A 819      21.658   6.416  58.630  1.00 42.20           C  
+ATOM   1171  O   VAL A 819      20.719   6.665  57.867  1.00 39.63           O  
+ATOM   1172  CB  VAL A 819      21.939   8.582  59.912  1.00 39.03           C  
+ATOM   1173  CG1 VAL A 819      21.390   7.942  61.180  1.00 32.60           C  
+ATOM   1174  CG2 VAL A 819      22.929   9.666  60.302  1.00 31.20           C  
+ATOM   1175  N   LEU A 820      21.942   5.194  59.079  1.00 38.89           N  
+ATOM   1176  CA  LEU A 820      21.098   4.056  58.748  1.00 40.83           C  
+ATOM   1177  C   LEU A 820      20.188   3.713  59.905  1.00 42.46           C  
+ATOM   1178  O   LEU A 820      20.485   4.047  61.049  1.00 41.65           O  
+ATOM   1179  CB  LEU A 820      21.959   2.858  58.309  1.00 47.49           C  
+ATOM   1180  CG  LEU A 820      22.793   3.129  57.035  1.00 42.68           C  
+ATOM   1181  CD1 LEU A 820      23.654   1.948  56.676  1.00 44.67           C  
+ATOM   1182  CD2 LEU A 820      21.887   3.463  55.869  1.00 30.23           C  
+ATOM   1183  N   VAL A 821      19.067   3.070  59.598  1.00 36.86           N  
+ATOM   1184  CA  VAL A 821      18.083   2.707  60.604  1.00 32.03           C  
+ATOM   1185  C   VAL A 821      18.030   1.187  60.862  1.00 36.99           C  
+ATOM   1186  O   VAL A 821      17.669   0.411  59.974  1.00 41.63           O  
+ATOM   1187  CB  VAL A 821      16.683   3.201  60.156  1.00 42.85           C  
+ATOM   1188  CG1 VAL A 821      15.654   2.955  61.246  1.00 29.15           C  
+ATOM   1189  CG2 VAL A 821      16.729   4.678  59.763  1.00 25.63           C  
+ATOM   1190  N   LYS A 822      18.441   0.753  62.051  1.00 34.10           N  
+ATOM   1191  CA  LYS A 822      18.403  -0.678  62.395  1.00 43.02           C  
+ATOM   1192  C   LYS A 822      16.955  -1.007  62.747  1.00 41.79           C  
+ATOM   1193  O   LYS A 822      16.413  -2.027  62.320  1.00 40.06           O  
+ATOM   1194  CB  LYS A 822      19.320  -1.002  63.590  1.00 43.66           C  
+ATOM   1195  CG  LYS A 822      18.994  -2.347  64.244  1.00 36.78           C  
+ATOM   1196  CD  LYS A 822      20.245  -3.112  64.610  1.00 43.51           C  
+ATOM   1197  CE  LYS A 822      20.591  -2.972  66.057  1.00 47.74           C  
+ATOM   1198  NZ  LYS A 822      20.226  -4.214  66.760  1.00 52.69           N  
+ATOM   1199  N   THR A 823      16.376  -0.104  63.539  1.00 45.11           N  
+ATOM   1200  CA  THR A 823      14.993  -0.112  64.008  1.00 49.31           C  
+ATOM   1201  C   THR A 823      14.647   1.369  64.185  1.00 50.51           C  
+ATOM   1202  O   THR A 823      15.542   2.210  64.313  1.00 48.71           O  
+ATOM   1203  CB  THR A 823      14.831  -0.764  65.402  1.00 47.80           C  
+ATOM   1204  OG1 THR A 823      15.463   0.050  66.393  1.00 60.85           O  
+ATOM   1205  CG2 THR A 823      15.433  -2.153  65.432  1.00 43.68           C  
+ATOM   1206  N   PRO A 824      13.350   1.711  64.200  1.00 51.63           N  
+ATOM   1207  CA  PRO A 824      12.948   3.112  64.373  1.00 48.88           C  
+ATOM   1208  C   PRO A 824      13.548   3.725  65.654  1.00 47.85           C  
+ATOM   1209  O   PRO A 824      13.749   4.939  65.732  1.00 51.00           O  
+ATOM   1210  CB  PRO A 824      11.430   3.010  64.443  1.00 52.73           C  
+ATOM   1211  CG  PRO A 824      11.149   1.840  63.524  1.00 57.21           C  
+ATOM   1212  CD  PRO A 824      12.176   0.847  63.993  1.00 48.93           C  
+ATOM   1213  N   GLN A 825      13.867   2.877  66.631  1.00 38.49           N  
+ATOM   1214  CA  GLN A 825      14.466   3.330  67.877  1.00 45.07           C  
+ATOM   1215  C   GLN A 825      16.005   3.176  67.972  1.00 48.24           C  
+ATOM   1216  O   GLN A 825      16.610   3.470  69.008  1.00 48.28           O  
+ATOM   1217  CB  GLN A 825      13.778   2.678  69.096  1.00 42.30           C  
+ATOM   1218  CG  GLN A 825      13.343   1.226  68.957  1.00 66.86           C  
+ATOM   1219  CD  GLN A 825      11.994   1.054  68.244  1.00 70.98           C  
+ATOM   1220  OE1 GLN A 825      11.879   0.264  67.315  1.00 69.95           O  
+ATOM   1221  NE2 GLN A 825      10.972   1.778  68.699  1.00 76.17           N  
+ATOM   1222  N   HIS A 826      16.651   2.801  66.876  1.00 38.77           N  
+ATOM   1223  CA  HIS A 826      18.096   2.613  66.912  1.00 42.02           C  
+ATOM   1224  C   HIS A 826      18.764   2.910  65.560  1.00 39.66           C  
+ATOM   1225  O   HIS A 826      18.636   2.128  64.615  1.00 42.04           O  
+ATOM   1226  CB  HIS A 826      18.406   1.172  67.368  1.00 23.62           C  
+ATOM   1227  CG  HIS A 826      19.854   0.918  67.659  1.00 37.86           C  
+ATOM   1228  ND1 HIS A 826      20.308  -0.253  68.226  1.00 39.94           N  
+ATOM   1229  CD2 HIS A 826      20.956   1.690  67.474  1.00 39.90           C  
+ATOM   1230  CE1 HIS A 826      21.619  -0.195  68.380  1.00 36.12           C  
+ATOM   1231  NE2 HIS A 826      22.035   0.976  67.932  1.00 38.38           N  
+ATOM   1232  N   VAL A 827      19.464   4.037  65.472  1.00 32.91           N  
+ATOM   1233  CA  VAL A 827      20.161   4.417  64.239  1.00 35.49           C  
+ATOM   1234  C   VAL A 827      21.686   4.429  64.440  1.00 40.79           C  
+ATOM   1235  O   VAL A 827      22.166   4.458  65.582  1.00 38.18           O  
+ATOM   1236  CB  VAL A 827      19.711   5.805  63.711  1.00 34.84           C  
+ATOM   1237  CG1 VAL A 827      18.201   5.828  63.522  1.00 44.64           C  
+ATOM   1238  CG2 VAL A 827      20.159   6.925  64.657  1.00 24.65           C  
+ATOM   1239  N   LYS A 828      22.431   4.401  63.327  1.00 43.74           N  
+ATOM   1240  CA  LYS A 828      23.905   4.400  63.329  1.00 36.35           C  
+ATOM   1241  C   LYS A 828      24.485   5.185  62.164  1.00 35.34           C  
+ATOM   1242  O   LYS A 828      23.919   5.220  61.070  1.00 43.44           O  
+ATOM   1243  CB  LYS A 828      24.458   2.980  63.219  1.00 42.12           C  
+ATOM   1244  CG  LYS A 828      23.916   1.974  64.210  1.00 47.39           C  
+ATOM   1245  CD  LYS A 828      24.681   0.680  64.073  1.00 48.36           C  
+ATOM   1246  CE  LYS A 828      23.978  -0.468  64.761  1.00 34.76           C  
+ATOM   1247  NZ  LYS A 828      24.835  -1.702  64.709  1.00 40.58           N  
+ATOM   1248  N   ILE A 829      25.655   5.762  62.387  1.00 30.08           N  
+ATOM   1249  CA  ILE A 829      26.341   6.538  61.360  1.00 38.70           C  
+ATOM   1250  C   ILE A 829      27.096   5.598  60.396  1.00 41.13           C  
+ATOM   1251  O   ILE A 829      27.615   4.564  60.805  1.00 46.09           O  
+ATOM   1252  CB  ILE A 829      27.335   7.502  62.007  1.00 38.85           C  
+ATOM   1253  CG1 ILE A 829      26.610   8.449  62.960  1.00 38.83           C  
+ATOM   1254  CG2 ILE A 829      28.042   8.301  60.959  1.00 34.04           C  
+ATOM   1255  CD1 ILE A 829      27.569   9.284  63.764  1.00 34.00           C  
+ATOM   1256  N   THR A 830      27.187   5.976  59.128  1.00 35.80           N  
+ATOM   1257  CA  THR A 830      27.862   5.143  58.157  1.00 40.58           C  
+ATOM   1258  C   THR A 830      28.557   5.994  57.099  1.00 46.89           C  
+ATOM   1259  O   THR A 830      28.742   7.210  57.293  1.00 46.28           O  
+ATOM   1260  CB  THR A 830      26.857   4.149  57.520  1.00 45.84           C  
+ATOM   1261  OG1 THR A 830      27.557   3.072  56.887  1.00 55.49           O  
+ATOM   1262  CG2 THR A 830      25.974   4.851  56.529  1.00 54.15           C  
+ATOM   1263  N  AASP A 831      28.952   5.339  56.003  0.50 46.16           N  
+ATOM   1264  N  BASP A 831      28.946   5.352  55.998  0.50 48.15           N  
+ATOM   1265  CA AASP A 831      29.643   5.954  54.868  0.50 41.99           C  
+ATOM   1266  CA BASP A 831      29.642   5.987  54.876  0.50 45.50           C  
+ATOM   1267  C  AASP A 831      30.901   6.726  55.228  0.50 39.76           C  
+ATOM   1268  C  BASP A 831      30.902   6.732  55.268  0.50 41.60           C  
+ATOM   1269  O  AASP A 831      30.893   7.946  55.282  0.50 40.46           O  
+ATOM   1270  O  BASP A 831      30.895   7.948  55.395  0.50 45.22           O  
+ATOM   1271  CB AASP A 831      28.683   6.812  54.040  0.50 36.83           C  
+ATOM   1272  CB BASP A 831      28.733   6.925  54.078  0.50 49.73           C  
+ATOM   1273  CG AASP A 831      27.943   6.002  52.979  0.50 38.86           C  
+ATOM   1274  CG BASP A 831      29.347   7.321  52.742  0.50 58.97           C  
+ATOM   1275  OD1AASP A 831      28.489   5.849  51.866  0.50 64.02           O  
+ATOM   1276  OD1BASP A 831      29.092   6.606  51.755  0.50 72.85           O  
+ATOM   1277  OD2AASP A 831      26.827   5.510  53.247  0.50 35.84           O  
+ATOM   1278  OD2BASP A 831      30.096   8.321  52.675  0.50 62.80           O  
+ATOM   1279  N   PHE A 832      31.996   5.996  55.411  1.00 44.92           N  
+ATOM   1280  CA  PHE A 832      33.281   6.583  55.779  1.00 43.17           C  
+ATOM   1281  C   PHE A 832      34.200   6.881  54.604  1.00 46.94           C  
+ATOM   1282  O   PHE A 832      35.402   7.100  54.784  1.00 45.58           O  
+ATOM   1283  CB  PHE A 832      33.974   5.683  56.794  1.00 39.91           C  
+ATOM   1284  CG  PHE A 832      33.245   5.605  58.109  1.00 50.66           C  
+ATOM   1285  CD1 PHE A 832      32.296   4.619  58.336  1.00 49.56           C  
+ATOM   1286  CD2 PHE A 832      33.443   6.573  59.084  1.00 48.51           C  
+ATOM   1287  CE1 PHE A 832      31.548   4.610  59.510  1.00 49.07           C  
+ATOM   1288  CE2 PHE A 832      32.701   6.568  60.258  1.00 28.64           C  
+ATOM   1289  CZ  PHE A 832      31.754   5.591  60.472  1.00 38.59           C  
+ATOM   1290  N   GLY A 833      33.602   6.987  53.417  1.00 48.67           N  
+ATOM   1291  CA  GLY A 833      34.361   7.265  52.207  1.00 44.97           C  
+ATOM   1292  C   GLY A 833      35.294   8.457  52.253  1.00 45.44           C  
+ATOM   1293  O   GLY A 833      36.305   8.478  51.570  1.00 58.13           O  
+ATOM   1294  N   LEU A 834      34.991   9.440  53.087  1.00 45.82           N  
+ATOM   1295  CA  LEU A 834      35.820  10.628  53.168  1.00 36.57           C  
+ATOM   1296  C   LEU A 834      36.482  10.795  54.529  1.00 41.93           C  
+ATOM   1297  O   LEU A 834      37.194  11.791  54.762  1.00 39.29           O  
+ATOM   1298  CB  LEU A 834      34.963  11.856  52.845  1.00 47.53           C  
+ATOM   1299  CG  LEU A 834      34.528  12.161  51.399  1.00 55.51           C  
+ATOM   1300  CD1 LEU A 834      34.028  10.951  50.650  1.00 80.50           C  
+ATOM   1301  CD2 LEU A 834      33.437  13.218  51.422  1.00 66.67           C  
+ATOM   1302  N   ALA A 835      36.274   9.822  55.420  1.00 38.33           N  
+ATOM   1303  CA  ALA A 835      36.821   9.896  56.783  1.00 44.47           C  
+ATOM   1304  C   ALA A 835      38.338   9.874  56.859  1.00 50.84           C  
+ATOM   1305  O   ALA A 835      38.983   9.091  56.169  1.00 64.89           O  
+ATOM   1306  CB  ALA A 835      36.243   8.774  57.643  1.00 42.10           C  
+ATOM   1307  N   LYS A 836      38.904  10.723  57.712  1.00 50.08           N  
+ATOM   1308  CA  LYS A 836      40.355  10.801  57.893  1.00 49.52           C  
+ATOM   1309  C   LYS A 836      40.717  10.723  59.374  1.00 54.11           C  
+ATOM   1310  O   LYS A 836      40.073  11.369  60.193  1.00 62.01           O  
+ATOM   1311  CB  LYS A 836      40.897  12.125  57.334  1.00 45.56           C  
+ATOM   1312  CG  LYS A 836      40.660  12.360  55.828  1.00 58.47           C  
+ATOM   1313  CD  LYS A 836      41.473  11.395  54.978  1.00 61.89           C  
+ATOM   1314  CE  LYS A 836      41.264  11.604  53.479  1.00 71.39           C  
+ATOM   1315  NZ  LYS A 836      39.915  11.144  53.014  1.00 79.33           N  
+ATOM   1316  N   LEU A 837      41.716   9.909  59.726  1.00 59.41           N  
+ATOM   1317  CA  LEU A 837      42.172   9.804  61.119  1.00 63.16           C  
+ATOM   1318  C   LEU A 837      43.249  10.865  61.352  1.00 64.99           C  
+ATOM   1319  O   LEU A 837      44.182  10.982  60.560  1.00 75.83           O  
+ATOM   1320  CB  LEU A 837      42.749   8.418  61.423  1.00 65.59           C  
+ATOM   1321  CG  LEU A 837      41.804   7.239  61.190  1.00 81.66           C  
+ATOM   1322  CD1 LEU A 837      41.731   6.954  59.696  1.00 92.32           C  
+ATOM   1323  CD2 LEU A 837      42.271   5.998  61.937  1.00 80.11           C  
+ATOM   1324  N   LEU A 838      43.111  11.656  62.411  1.00 61.87           N  
+ATOM   1325  CA  LEU A 838      44.081  12.701  62.701  1.00 62.05           C  
+ATOM   1326  C   LEU A 838      45.183  12.173  63.595  1.00 72.70           C  
+ATOM   1327  O   LEU A 838      44.956  11.266  64.396  1.00 76.57           O  
+ATOM   1328  CB  LEU A 838      43.421  13.882  63.401  1.00 57.41           C  
+ATOM   1329  CG  LEU A 838      42.195  14.552  62.785  1.00 64.73           C  
+ATOM   1330  CD1 LEU A 838      41.809  15.776  63.636  1.00 43.22           C  
+ATOM   1331  CD2 LEU A 838      42.460  14.953  61.351  1.00 53.73           C  
+ATOM   1332  N   GLY A 839      46.368  12.768  63.476  1.00 75.85           N  
+ATOM   1333  CA  GLY A 839      47.498  12.363  64.293  1.00 76.63           C  
+ATOM   1334  C   GLY A 839      47.292  12.628  65.775  1.00 80.92           C  
+ATOM   1335  O   GLY A 839      46.178  12.903  66.229  1.00 82.23           O  
+ATOM   1336  N   ALA A 840      48.365  12.506  66.545  1.00 86.34           N  
+ATOM   1337  CA  ALA A 840      48.281  12.736  67.978  1.00 95.21           C  
+ATOM   1338  C   ALA A 840      48.291  14.228  68.251  1.00 98.27           C  
+ATOM   1339  O   ALA A 840      47.475  14.733  69.018  1.00102.27           O  
+ATOM   1340  CB  ALA A 840      49.444  12.061  68.694  1.00108.61           C  
+ATOM   1341  N   GLU A 841      49.226  14.928  67.622  1.00 98.92           N  
+ATOM   1342  CA  GLU A 841      49.341  16.366  67.806  1.00105.76           C  
+ATOM   1343  C   GLU A 841      48.789  17.096  66.586  1.00106.30           C  
+ATOM   1344  O   GLU A 841      49.109  18.263  66.345  1.00107.09           O  
+ATOM   1345  CB  GLU A 841      50.808  16.756  68.051  1.00113.03           C  
+ATOM   1346  CG  GLU A 841      51.495  16.014  69.208  1.00113.21           C  
+ATOM   1347  CD  GLU A 841      50.746  16.141  70.533  1.00119.82           C  
+ATOM   1348  OE1 GLU A 841      50.266  15.101  71.042  1.00118.11           O  
+ATOM   1349  OE2 GLU A 841      50.642  17.272  71.066  1.00101.46           O  
+ATOM   1350  N   GLU A 842      47.973  16.388  65.809  1.00105.18           N  
+ATOM   1351  CA  GLU A 842      47.358  16.946  64.609  1.00104.00           C  
+ATOM   1352  C   GLU A 842      45.977  17.497  64.994  1.00102.97           C  
+ATOM   1353  O   GLU A 842      45.166  16.795  65.603  1.00105.99           O  
+ATOM   1354  CB  GLU A 842      47.240  15.859  63.541  1.00100.30           C  
+ATOM   1355  CG  GLU A 842      47.102  16.360  62.118  1.00101.00           C  
+ATOM   1356  CD  GLU A 842      46.873  15.227  61.128  1.00103.69           C  
+ATOM   1357  OE1 GLU A 842      47.821  14.467  60.841  1.00104.94           O  
+ATOM   1358  OE2 GLU A 842      45.736  15.091  60.639  1.00110.90           O  
+ATOM   1359  N   LYS A 843      45.722  18.756  64.646  1.00100.06           N  
+ATOM   1360  CA  LYS A 843      44.462  19.415  64.990  1.00 93.63           C  
+ATOM   1361  C   LYS A 843      43.456  19.483  63.855  1.00 85.63           C  
+ATOM   1362  O   LYS A 843      42.260  19.590  64.095  1.00 80.69           O  
+ATOM   1363  CB  LYS A 843      44.741  20.840  65.476  1.00103.45           C  
+ATOM   1364  CG  LYS A 843      45.401  21.720  64.409  1.00103.41           C  
+ATOM   1365  CD  LYS A 843      45.764  23.105  64.929  1.00109.38           C  
+ATOM   1366  CE  LYS A 843      46.384  23.972  63.824  1.00109.40           C  
+ATOM   1367  NZ  LYS A 843      47.620  23.386  63.209  1.00 97.57           N  
+ATOM   1368  N   GLU A 844      43.939  19.454  62.619  1.00 82.73           N  
+ATOM   1369  CA  GLU A 844      43.045  19.547  61.475  1.00 78.81           C  
+ATOM   1370  C   GLU A 844      43.560  18.863  60.229  1.00 74.67           C  
+ATOM   1371  O   GLU A 844      44.760  18.658  60.066  1.00 83.49           O  
+ATOM   1372  CB  GLU A 844      42.742  21.018  61.159  1.00 81.67           C  
+ATOM   1373  CG  GLU A 844      43.967  21.890  60.919  1.00 78.85           C  
+ATOM   1374  CD  GLU A 844      43.650  23.386  60.944  1.00 92.66           C  
+ATOM   1375  OE1 GLU A 844      42.942  23.834  61.878  1.00107.61           O  
+ATOM   1376  OE2 GLU A 844      44.121  24.115  60.039  1.00 85.28           O  
+ATOM   1377  N   TYR A 845      42.630  18.516  59.351  1.00 62.83           N  
+ATOM   1378  CA  TYR A 845      42.957  17.871  58.102  1.00 62.12           C  
+ATOM   1379  C   TYR A 845      42.804  18.855  56.955  1.00 68.06           C  
+ATOM   1380  O   TYR A 845      41.799  19.552  56.852  1.00 65.92           O  
+ATOM   1381  CB  TYR A 845      42.060  16.656  57.872  1.00 60.32           C  
+ATOM   1382  CG  TYR A 845      42.157  16.108  56.467  1.00 59.62           C  
+ATOM   1383  CD1 TYR A 845      43.211  15.270  56.088  1.00 65.72           C  
+ATOM   1384  CD2 TYR A 845      41.208  16.456  55.503  1.00 62.42           C  
+ATOM   1385  CE1 TYR A 845      43.315  14.793  54.773  1.00 68.26           C  
+ATOM   1386  CE2 TYR A 845      41.298  15.989  54.198  1.00 60.79           C  
+ATOM   1387  CZ  TYR A 845      42.352  15.160  53.838  1.00 77.11           C  
+ATOM   1388  OH  TYR A 845      42.430  14.705  52.546  1.00 71.74           O  
+ATOM   1389  N   HIS A 846      43.799  18.865  56.071  1.00 79.11           N  
+ATOM   1390  CA  HIS A 846      43.816  19.744  54.911  1.00 82.38           C  
+ATOM   1391  C   HIS A 846      43.508  18.900  53.689  1.00 84.19           C  
+ATOM   1392  O   HIS A 846      44.308  18.058  53.296  1.00 91.80           O  
+ATOM   1393  CB  HIS A 846      45.193  20.398  54.788  1.00 94.00           C  
+ATOM   1394  CG  HIS A 846      45.676  21.018  56.066  1.00 99.87           C  
+ATOM   1395  ND1 HIS A 846      45.670  22.380  56.282  1.00110.18           N  
+ATOM   1396  CD2 HIS A 846      46.136  20.457  57.211  1.00104.37           C  
+ATOM   1397  CE1 HIS A 846      46.101  22.632  57.506  1.00113.99           C  
+ATOM   1398  NE2 HIS A 846      46.390  21.482  58.091  1.00109.21           N  
+ATOM   1399  N   ALA A 847      42.335  19.120  53.105  1.00 86.91           N  
+ATOM   1400  CA  ALA A 847      41.881  18.363  51.942  1.00 87.82           C  
+ATOM   1401  C   ALA A 847      42.546  18.739  50.628  1.00 92.21           C  
+ATOM   1402  O   ALA A 847      43.412  19.612  50.583  1.00 90.71           O  
+ATOM   1403  CB  ALA A 847      40.378  18.465  51.813  1.00 79.99           C  
+ATOM   1404  N   GLU A 848      42.105  18.083  49.557  1.00 95.57           N  
+ATOM   1405  CA  GLU A 848      42.645  18.304  48.224  1.00100.88           C  
+ATOM   1406  C   GLU A 848      41.553  18.516  47.170  1.00105.24           C  
+ATOM   1407  O   GLU A 848      41.116  19.643  46.944  1.00107.38           O  
+ATOM   1408  CB  GLU A 848      43.583  17.142  47.833  1.00107.92           C  
+ATOM   1409  CG  GLU A 848      42.957  15.722  47.817  1.00115.49           C  
+ATOM   1410  CD  GLU A 848      42.469  15.231  49.189  1.00120.00           C  
+ATOM   1411  OE1 GLU A 848      41.279  14.853  49.320  1.00120.00           O  
+ATOM   1412  OE2 GLU A 848      43.284  15.215  50.136  1.00120.00           O  
+ATOM   1413  N   GLY A 849      41.097  17.429  46.555  1.00110.25           N  
+ATOM   1414  CA  GLY A 849      40.077  17.507  45.523  1.00115.58           C  
+ATOM   1415  C   GLY A 849      38.689  17.950  45.948  1.00119.73           C  
+ATOM   1416  O   GLY A 849      38.325  17.901  47.130  1.00120.00           O  
+ATOM   1417  N   GLY A 850      37.909  18.378  44.958  1.00120.00           N  
+ATOM   1418  CA  GLY A 850      36.552  18.838  45.201  1.00120.00           C  
+ATOM   1419  C   GLY A 850      35.496  17.778  44.941  1.00118.42           C  
+ATOM   1420  O   GLY A 850      34.973  17.650  43.830  1.00117.29           O  
+ATOM   1421  N   LYS A 851      35.169  17.024  45.981  1.00114.16           N  
+ATOM   1422  CA  LYS A 851      34.171  15.977  45.870  1.00112.90           C  
+ATOM   1423  C   LYS A 851      33.323  15.911  47.136  1.00107.97           C  
+ATOM   1424  O   LYS A 851      32.656  14.907  47.398  1.00109.24           O  
+ATOM   1425  CB  LYS A 851      34.854  14.629  45.610  1.00120.00           C  
+ATOM   1426  CG  LYS A 851      35.925  14.245  46.636  1.00120.00           C  
+ATOM   1427  CD  LYS A 851      36.394  12.806  46.430  1.00113.74           C  
+ATOM   1428  CE  LYS A 851      37.438  12.397  47.466  1.00115.06           C  
+ATOM   1429  NZ  LYS A 851      37.725  10.929  47.416  1.00112.80           N  
+ATOM   1430  N   VAL A 852      33.343  16.993  47.908  1.00101.57           N  
+ATOM   1431  CA  VAL A 852      32.586  17.062  49.154  1.00 98.14           C  
+ATOM   1432  C   VAL A 852      31.280  17.848  48.979  1.00 93.01           C  
+ATOM   1433  O   VAL A 852      31.240  18.832  48.242  1.00 91.35           O  
+ATOM   1434  CB  VAL A 852      33.439  17.710  50.280  1.00 94.32           C  
+ATOM   1435  CG1 VAL A 852      32.775  17.525  51.639  1.00 98.15           C  
+ATOM   1436  CG2 VAL A 852      34.826  17.104  50.300  1.00 93.53           C  
+ATOM   1437  N   PRO A 853      30.176  17.365  49.584  1.00 90.04           N  
+ATOM   1438  CA  PRO A 853      28.871  18.032  49.499  1.00 85.54           C  
+ATOM   1439  C   PRO A 853      28.928  19.353  50.271  1.00 80.38           C  
+ATOM   1440  O   PRO A 853      29.103  19.388  51.494  1.00 78.49           O  
+ATOM   1441  CB  PRO A 853      27.926  17.012  50.129  1.00 86.88           C  
+ATOM   1442  CG  PRO A 853      28.798  16.288  51.081  1.00 83.40           C  
+ATOM   1443  CD  PRO A 853      30.046  16.079  50.285  1.00 91.17           C  
+ATOM   1444  N   ILE A 854      28.788  20.432  49.514  1.00 72.97           N  
+ATOM   1445  CA  ILE A 854      28.884  21.795  50.008  1.00 67.30           C  
+ATOM   1446  C   ILE A 854      27.862  22.255  51.036  1.00 62.17           C  
+ATOM   1447  O   ILE A 854      28.216  22.946  51.999  1.00 47.84           O  
+ATOM   1448  CB  ILE A 854      28.918  22.777  48.808  1.00 69.55           C  
+ATOM   1449  CG1 ILE A 854      30.055  22.362  47.858  1.00 85.91           C  
+ATOM   1450  CG2 ILE A 854      29.173  24.211  49.294  1.00 56.17           C  
+ATOM   1451  CD1 ILE A 854      29.760  22.535  46.374  1.00 94.34           C  
+ATOM   1452  N   LYS A 855      26.611  21.845  50.854  1.00 55.72           N  
+ATOM   1453  CA  LYS A 855      25.547  22.256  51.748  1.00 56.79           C  
+ATOM   1454  C   LYS A 855      25.541  21.690  53.171  1.00 62.88           C  
+ATOM   1455  O   LYS A 855      24.616  21.959  53.944  1.00 65.29           O  
+ATOM   1456  CB  LYS A 855      24.203  22.075  51.064  1.00 45.78           C  
+ATOM   1457  CG  LYS A 855      24.028  23.035  49.880  1.00 49.88           C  
+ATOM   1458  CD  LYS A 855      22.685  22.822  49.216  1.00 55.16           C  
+ATOM   1459  CE  LYS A 855      22.546  23.641  47.953  1.00 56.75           C  
+ATOM   1460  NZ  LYS A 855      21.251  23.329  47.259  1.00 64.81           N  
+ATOM   1461  N   TRP A 856      26.568  20.912  53.514  1.00 56.13           N  
+ATOM   1462  CA  TRP A 856      26.697  20.351  54.848  1.00 37.60           C  
+ATOM   1463  C   TRP A 856      28.013  20.733  55.478  1.00 41.96           C  
+ATOM   1464  O   TRP A 856      28.292  20.331  56.608  1.00 40.21           O  
+ATOM   1465  CB  TRP A 856      26.628  18.840  54.819  1.00 36.34           C  
+ATOM   1466  CG  TRP A 856      25.284  18.299  54.737  1.00 34.65           C  
+ATOM   1467  CD1 TRP A 856      24.567  17.791  55.764  1.00 32.37           C  
+ATOM   1468  CD2 TRP A 856      24.467  18.167  53.557  1.00 29.13           C  
+ATOM   1469  NE1 TRP A 856      23.338  17.345  55.309  1.00 44.21           N  
+ATOM   1470  CE2 TRP A 856      23.250  17.568  53.959  1.00 33.03           C  
+ATOM   1471  CE3 TRP A 856      24.652  18.477  52.203  1.00 46.84           C  
+ATOM   1472  CZ2 TRP A 856      22.211  17.278  53.056  1.00 39.80           C  
+ATOM   1473  CZ3 TRP A 856      23.613  18.178  51.290  1.00 37.32           C  
+ATOM   1474  CH2 TRP A 856      22.411  17.589  51.730  1.00 45.88           C  
+ATOM   1475  N   MET A 857      28.828  21.511  54.775  1.00 42.56           N  
+ATOM   1476  CA  MET A 857      30.119  21.864  55.327  1.00 50.23           C  
+ATOM   1477  C   MET A 857      30.305  23.203  55.994  1.00 52.17           C  
+ATOM   1478  O   MET A 857      29.684  24.194  55.629  1.00 56.89           O  
+ATOM   1479  CB  MET A 857      31.246  21.586  54.318  1.00 59.84           C  
+ATOM   1480  CG  MET A 857      30.973  21.963  52.865  1.00 76.16           C  
+ATOM   1481  SD  MET A 857      31.919  20.907  51.685  1.00 66.94           S  
+ATOM   1482  CE  MET A 857      33.580  21.533  51.907  1.00 36.00           C  
+ATOM   1483  N   ALA A 858      31.156  23.204  57.013  1.00 51.20           N  
+ATOM   1484  CA  ALA A 858      31.478  24.410  57.752  1.00 54.29           C  
+ATOM   1485  C   ALA A 858      31.986  25.425  56.748  1.00 58.76           C  
+ATOM   1486  O   ALA A 858      32.401  25.049  55.664  1.00 51.68           O  
+ATOM   1487  CB  ALA A 858      32.556  24.122  58.780  1.00 40.54           C  
+ATOM   1488  N   LEU A 859      31.929  26.707  57.106  1.00 69.17           N  
+ATOM   1489  CA  LEU A 859      32.389  27.780  56.228  1.00 65.10           C  
+ATOM   1490  C   LEU A 859      33.886  27.641  55.982  1.00 64.58           C  
+ATOM   1491  O   LEU A 859      34.337  27.707  54.844  1.00 61.58           O  
+ATOM   1492  CB  LEU A 859      32.107  29.142  56.855  1.00 62.30           C  
+ATOM   1493  CG  LEU A 859      32.456  30.359  55.991  1.00 68.90           C  
+ATOM   1494  CD1 LEU A 859      31.554  30.404  54.751  1.00 53.78           C  
+ATOM   1495  CD2 LEU A 859      32.309  31.635  56.823  1.00 59.88           C  
+ATOM   1496  N   GLU A 860      34.646  27.419  57.055  1.00 63.16           N  
+ATOM   1497  CA  GLU A 860      36.095  27.270  56.960  1.00 61.85           C  
+ATOM   1498  C   GLU A 860      36.492  26.083  56.073  1.00 66.86           C  
+ATOM   1499  O   GLU A 860      37.603  26.037  55.550  1.00 69.54           O  
+ATOM   1500  CB  GLU A 860      36.739  27.151  58.350  1.00 52.67           C  
+ATOM   1501  CG  GLU A 860      36.441  25.865  59.123  1.00 69.29           C  
+ATOM   1502  CD  GLU A 860      35.135  25.897  59.928  1.00 68.29           C  
+ATOM   1503  OE1 GLU A 860      34.298  26.807  59.730  1.00 57.68           O  
+ATOM   1504  OE2 GLU A 860      34.943  24.981  60.758  1.00 57.06           O  
+ATOM   1505  N   SER A 861      35.587  25.129  55.899  1.00 59.99           N  
+ATOM   1506  CA  SER A 861      35.883  24.000  55.053  1.00 60.83           C  
+ATOM   1507  C   SER A 861      35.855  24.457  53.605  1.00 65.66           C  
+ATOM   1508  O   SER A 861      36.765  24.153  52.836  1.00 70.82           O  
+ATOM   1509  CB  SER A 861      34.865  22.871  55.269  1.00 63.62           C  
+ATOM   1510  OG  SER A 861      34.996  22.298  56.568  1.00 51.51           O  
+ATOM   1511  N   ILE A 862      34.824  25.220  53.250  1.00 70.95           N  
+ATOM   1512  CA  ILE A 862      34.630  25.715  51.883  1.00 72.41           C  
+ATOM   1513  C   ILE A 862      35.659  26.759  51.485  1.00 73.84           C  
+ATOM   1514  O   ILE A 862      36.031  26.876  50.319  1.00 75.38           O  
+ATOM   1515  CB  ILE A 862      33.230  26.355  51.713  1.00 75.86           C  
+ATOM   1516  CG1 ILE A 862      32.133  25.347  52.056  1.00 82.33           C  
+ATOM   1517  CG2 ILE A 862      33.040  26.865  50.291  1.00 61.00           C  
+ATOM   1518  CD1 ILE A 862      30.735  25.939  51.995  1.00 78.19           C  
+ATOM   1519  N   LEU A 863      36.102  27.525  52.467  1.00 74.09           N  
+ATOM   1520  CA  LEU A 863      37.060  28.578  52.224  1.00 80.31           C  
+ATOM   1521  C   LEU A 863      38.516  28.147  52.330  1.00 81.76           C  
+ATOM   1522  O   LEU A 863      39.358  28.638  51.574  1.00 87.29           O  
+ATOM   1523  CB  LEU A 863      36.780  29.768  53.156  1.00 87.79           C  
+ATOM   1524  CG  LEU A 863      35.675  30.769  52.770  1.00 90.84           C  
+ATOM   1525  CD1 LEU A 863      36.089  31.539  51.532  1.00106.44           C  
+ATOM   1526  CD2 LEU A 863      34.350  30.083  52.526  1.00 97.61           C  
+ATOM   1527  N   HIS A 864      38.822  27.239  53.252  1.00 75.77           N  
+ATOM   1528  CA  HIS A 864      40.204  26.802  53.439  1.00 77.04           C  
+ATOM   1529  C   HIS A 864      40.456  25.294  53.349  1.00 74.54           C  
+ATOM   1530  O   HIS A 864      41.584  24.841  53.556  1.00 71.29           O  
+ATOM   1531  CB  HIS A 864      40.731  27.306  54.790  1.00 89.06           C  
+ATOM   1532  CG  HIS A 864      40.632  28.790  54.976  1.00101.33           C  
+ATOM   1533  ND1 HIS A 864      40.171  29.641  53.996  1.00 96.56           N  
+ATOM   1534  CD2 HIS A 864      40.944  29.575  56.038  1.00104.71           C  
+ATOM   1535  CE1 HIS A 864      40.203  30.884  54.441  1.00 97.95           C  
+ATOM   1536  NE2 HIS A 864      40.669  30.871  55.678  1.00 94.10           N  
+ATOM   1537  N   ARG A 865      39.425  24.520  53.029  1.00 76.08           N  
+ATOM   1538  CA  ARG A 865      39.548  23.063  52.953  1.00 79.92           C  
+ATOM   1539  C   ARG A 865      40.019  22.465  54.290  1.00 80.59           C  
+ATOM   1540  O   ARG A 865      40.646  21.400  54.311  1.00 79.96           O  
+ATOM   1541  CB  ARG A 865      40.503  22.632  51.830  1.00 85.88           C  
+ATOM   1542  CG  ARG A 865      40.006  22.875  50.408  1.00 95.58           C  
+ATOM   1543  CD  ARG A 865      41.088  22.482  49.404  1.00100.32           C  
+ATOM   1544  NE  ARG A 865      40.771  22.860  48.026  1.00105.35           N  
+ATOM   1545  CZ  ARG A 865      41.672  22.983  47.052  1.00 88.91           C  
+ATOM   1546  NH1 ARG A 865      42.958  22.762  47.288  1.00 84.44           N  
+ATOM   1547  NH2 ARG A 865      41.284  23.331  45.834  1.00 91.45           N  
+ATOM   1548  N   ILE A 866      39.763  23.176  55.391  1.00 72.57           N  
+ATOM   1549  CA  ILE A 866      40.127  22.702  56.728  1.00 68.39           C  
+ATOM   1550  C   ILE A 866      38.942  21.905  57.324  1.00 67.59           C  
+ATOM   1551  O   ILE A 866      37.771  22.271  57.145  1.00 68.97           O  
+ATOM   1552  CB  ILE A 866      40.456  23.875  57.684  1.00 73.75           C  
+ATOM   1553  CG1 ILE A 866      41.594  24.729  57.132  1.00 79.37           C  
+ATOM   1554  CG2 ILE A 866      40.829  23.346  59.058  1.00 69.39           C  
+ATOM   1555  CD1 ILE A 866      42.917  24.046  57.154  1.00 85.39           C  
+ATOM   1556  N   TYR A 867      39.249  20.795  57.993  1.00 57.78           N  
+ATOM   1557  CA  TYR A 867      38.228  19.957  58.613  1.00 46.91           C  
+ATOM   1558  C   TYR A 867      38.616  19.575  60.025  1.00 47.40           C  
+ATOM   1559  O   TYR A 867      39.766  19.275  60.311  1.00 50.13           O  
+ATOM   1560  CB  TYR A 867      37.986  18.711  57.792  1.00 36.27           C  
+ATOM   1561  CG  TYR A 867      37.416  19.008  56.441  1.00 48.68           C  
+ATOM   1562  CD1 TYR A 867      38.216  19.562  55.438  1.00 48.05           C  
+ATOM   1563  CD2 TYR A 867      36.095  18.697  56.139  1.00 30.60           C  
+ATOM   1564  CE1 TYR A 867      37.723  19.796  54.172  1.00 42.98           C  
+ATOM   1565  CE2 TYR A 867      35.585  18.922  54.853  1.00 46.74           C  
+ATOM   1566  CZ  TYR A 867      36.416  19.475  53.877  1.00 45.09           C  
+ATOM   1567  OH  TYR A 867      35.955  19.699  52.606  1.00 48.35           O  
+ATOM   1568  N   THR A 868      37.648  19.590  60.923  1.00 44.34           N  
+ATOM   1569  CA  THR A 868      37.935  19.277  62.309  1.00 45.71           C  
+ATOM   1570  C   THR A 868      36.722  18.587  62.884  1.00 47.69           C  
+ATOM   1571  O   THR A 868      35.730  18.376  62.181  1.00 54.68           O  
+ATOM   1572  CB  THR A 868      38.154  20.581  63.084  1.00 57.55           C  
+ATOM   1573  OG1 THR A 868      37.068  21.473  62.787  1.00 67.06           O  
+ATOM   1574  CG2 THR A 868      39.475  21.266  62.675  1.00 49.57           C  
+ATOM   1575  N   HIS A 869      36.818  18.174  64.141  1.00 46.30           N  
+ATOM   1576  CA  HIS A 869      35.671  17.568  64.807  1.00 46.04           C  
+ATOM   1577  C   HIS A 869      34.575  18.653  64.836  1.00 44.36           C  
+ATOM   1578  O   HIS A 869      33.411  18.364  64.540  1.00 39.31           O  
+ATOM   1579  CB  HIS A 869      36.030  17.131  66.237  1.00 38.94           C  
+ATOM   1580  CG  HIS A 869      37.044  16.031  66.291  1.00 55.49           C  
+ATOM   1581  ND1 HIS A 869      36.982  14.919  65.481  1.00 60.18           N  
+ATOM   1582  CD2 HIS A 869      38.150  15.872  67.058  1.00 55.80           C  
+ATOM   1583  CE1 HIS A 869      38.003  14.123  65.744  1.00 42.39           C  
+ATOM   1584  NE2 HIS A 869      38.725  14.680  66.699  1.00 53.12           N  
+ATOM   1585  N   GLN A 870      34.989  19.903  65.097  1.00 38.13           N  
+ATOM   1586  CA  GLN A 870      34.080  21.047  65.145  1.00 47.26           C  
+ATOM   1587  C   GLN A 870      33.450  21.328  63.784  1.00 46.64           C  
+ATOM   1588  O   GLN A 870      32.377  21.920  63.680  1.00 48.50           O  
+ATOM   1589  CB  GLN A 870      34.787  22.295  65.687  1.00 43.21           C  
+ATOM   1590  CG  GLN A 870      35.165  22.207  67.173  1.00 44.89           C  
+ATOM   1591  CD  GLN A 870      34.014  21.704  68.049  1.00 55.93           C  
+ATOM   1592  OE1 GLN A 870      34.075  20.605  68.609  1.00 52.78           O  
+ATOM   1593  NE2 GLN A 870      32.949  22.498  68.147  1.00 51.09           N  
+ATOM   1594  N   SER A 871      34.114  20.866  62.738  1.00 45.92           N  
+ATOM   1595  CA  SER A 871      33.612  21.035  61.382  1.00 41.71           C  
+ATOM   1596  C   SER A 871      32.472  20.044  61.236  1.00 39.62           C  
+ATOM   1597  O   SER A 871      31.515  20.274  60.496  1.00 40.23           O  
+ATOM   1598  CB  SER A 871      34.718  20.707  60.368  1.00 49.46           C  
+ATOM   1599  OG  SER A 871      34.226  20.813  59.047  1.00 65.84           O  
+ATOM   1600  N   ASP A 872      32.602  18.919  61.935  1.00 36.76           N  
+ATOM   1601  CA  ASP A 872      31.585  17.884  61.894  1.00 42.07           C  
+ATOM   1602  C   ASP A 872      30.323  18.351  62.617  1.00 44.13           C  
+ATOM   1603  O   ASP A 872      29.205  17.969  62.239  1.00 42.71           O  
+ATOM   1604  CB  ASP A 872      32.124  16.566  62.485  1.00 43.22           C  
+ATOM   1605  CG  ASP A 872      32.855  15.701  61.441  1.00 52.71           C  
+ATOM   1606  OD1 ASP A 872      32.890  16.079  60.244  1.00 44.74           O  
+ATOM   1607  OD2 ASP A 872      33.376  14.621  61.811  1.00 43.46           O  
+ATOM   1608  N   VAL A 873      30.505  19.186  63.644  1.00 38.62           N  
+ATOM   1609  CA  VAL A 873      29.377  19.715  64.385  1.00 43.88           C  
+ATOM   1610  C   VAL A 873      28.464  20.528  63.461  1.00 44.53           C  
+ATOM   1611  O   VAL A 873      27.242  20.346  63.492  1.00 47.58           O  
+ATOM   1612  CB  VAL A 873      29.824  20.530  65.583  1.00 52.01           C  
+ATOM   1613  CG1 VAL A 873      28.595  21.135  66.279  1.00 43.88           C  
+ATOM   1614  CG2 VAL A 873      30.607  19.632  66.546  1.00 24.92           C  
+ATOM   1615  N   TRP A 874      29.052  21.366  62.602  1.00 34.94           N  
+ATOM   1616  CA  TRP A 874      28.261  22.137  61.636  1.00 39.19           C  
+ATOM   1617  C   TRP A 874      27.383  21.169  60.862  1.00 42.81           C  
+ATOM   1618  O   TRP A 874      26.182  21.369  60.725  1.00 51.78           O  
+ATOM   1619  CB  TRP A 874      29.156  22.865  60.634  1.00 37.85           C  
+ATOM   1620  CG  TRP A 874      28.400  23.745  59.647  1.00 37.55           C  
+ATOM   1621  CD1 TRP A 874      27.470  23.349  58.716  1.00 31.62           C  
+ATOM   1622  CD2 TRP A 874      28.516  25.168  59.511  1.00 26.63           C  
+ATOM   1623  NE1 TRP A 874      27.005  24.440  58.016  1.00 36.13           N  
+ATOM   1624  CE2 TRP A 874      27.629  25.567  58.495  1.00 37.51           C  
+ATOM   1625  CE3 TRP A 874      29.283  26.143  60.161  1.00 42.94           C  
+ATOM   1626  CZ2 TRP A 874      27.483  26.903  58.120  1.00 32.52           C  
+ATOM   1627  CZ3 TRP A 874      29.141  27.463  59.786  1.00 32.60           C  
+ATOM   1628  CH2 TRP A 874      28.249  27.832  58.780  1.00 36.94           C  
+ATOM   1629  N   SER A 875      27.996  20.110  60.352  1.00 47.84           N  
+ATOM   1630  CA  SER A 875      27.266  19.113  59.593  1.00 40.55           C  
+ATOM   1631  C   SER A 875      26.225  18.457  60.465  1.00 40.22           C  
+ATOM   1632  O   SER A 875      25.149  18.096  59.968  1.00 37.79           O  
+ATOM   1633  CB  SER A 875      28.217  18.070  59.010  1.00 45.99           C  
+ATOM   1634  OG  SER A 875      29.320  18.711  58.377  1.00 54.72           O  
+ATOM   1635  N   TYR A 876      26.540  18.267  61.753  1.00 32.94           N  
+ATOM   1636  CA  TYR A 876      25.555  17.676  62.659  1.00 35.18           C  
+ATOM   1637  C   TYR A 876      24.318  18.606  62.727  1.00 39.79           C  
+ATOM   1638  O   TYR A 876      23.183  18.131  62.698  1.00 34.33           O  
+ATOM   1639  CB  TYR A 876      26.139  17.444  64.053  1.00 36.03           C  
+ATOM   1640  CG  TYR A 876      25.119  16.961  65.086  1.00 41.88           C  
+ATOM   1641  CD1 TYR A 876      24.888  15.602  65.288  1.00 35.74           C  
+ATOM   1642  CD2 TYR A 876      24.418  17.874  65.892  1.00 42.01           C  
+ATOM   1643  CE1 TYR A 876      23.995  15.153  66.267  1.00 38.92           C  
+ATOM   1644  CE2 TYR A 876      23.515  17.435  66.872  1.00 31.92           C  
+ATOM   1645  CZ  TYR A 876      23.312  16.074  67.049  1.00 39.35           C  
+ATOM   1646  OH  TYR A 876      22.417  15.629  67.988  1.00 34.93           O  
+ATOM   1647  N   GLY A 877      24.552  19.921  62.773  1.00 35.22           N  
+ATOM   1648  CA  GLY A 877      23.458  20.882  62.807  1.00 41.84           C  
+ATOM   1649  C   GLY A 877      22.541  20.743  61.604  1.00 44.84           C  
+ATOM   1650  O   GLY A 877      21.300  20.674  61.741  1.00 48.16           O  
+ATOM   1651  N   VAL A 878      23.148  20.697  60.420  1.00 38.89           N  
+ATOM   1652  CA  VAL A 878      22.393  20.545  59.183  1.00 34.99           C  
+ATOM   1653  C   VAL A 878      21.618  19.228  59.181  1.00 32.91           C  
+ATOM   1654  O   VAL A 878      20.448  19.178  58.779  1.00 36.20           O  
+ATOM   1655  CB  VAL A 878      23.312  20.589  57.965  1.00 43.75           C  
+ATOM   1656  CG1 VAL A 878      22.499  20.390  56.706  1.00 32.58           C  
+ATOM   1657  CG2 VAL A 878      24.045  21.908  57.927  1.00 20.51           C  
+ATOM   1658  N   THR A 879      22.271  18.164  59.644  1.00 30.85           N  
+ATOM   1659  CA  THR A 879      21.638  16.849  59.729  1.00 35.42           C  
+ATOM   1660  C   THR A 879      20.404  16.938  60.620  1.00 37.48           C  
+ATOM   1661  O   THR A 879      19.390  16.317  60.336  1.00 44.60           O  
+ATOM   1662  CB  THR A 879      22.595  15.789  60.311  1.00 40.57           C  
+ATOM   1663  OG1 THR A 879      23.794  15.756  59.532  1.00 41.23           O  
+ATOM   1664  CG2 THR A 879      21.949  14.413  60.279  1.00 22.48           C  
+ATOM   1665  N   VAL A 880      20.517  17.690  61.716  1.00 37.92           N  
+ATOM   1666  CA  VAL A 880      19.417  17.902  62.648  1.00 37.92           C  
+ATOM   1667  C   VAL A 880      18.284  18.636  61.907  1.00 42.69           C  
+ATOM   1668  O   VAL A 880      17.119  18.246  61.993  1.00 41.81           O  
+ATOM   1669  CB  VAL A 880      19.903  18.709  63.870  1.00 39.09           C  
+ATOM   1670  CG1 VAL A 880      18.728  19.275  64.641  1.00 32.28           C  
+ATOM   1671  CG2 VAL A 880      20.731  17.798  64.794  1.00 27.65           C  
+ATOM   1672  N   TRP A 881      18.643  19.651  61.124  1.00 38.52           N  
+ATOM   1673  CA  TRP A 881      17.663  20.406  60.338  1.00 34.16           C  
+ATOM   1674  C   TRP A 881      16.880  19.487  59.382  1.00 42.10           C  
+ATOM   1675  O   TRP A 881      15.653  19.571  59.280  1.00 42.01           O  
+ATOM   1676  CB  TRP A 881      18.396  21.474  59.547  1.00 41.93           C  
+ATOM   1677  CG  TRP A 881      17.528  22.465  58.907  1.00 54.28           C  
+ATOM   1678  CD1 TRP A 881      17.127  23.658  59.431  1.00 45.14           C  
+ATOM   1679  CD2 TRP A 881      16.929  22.369  57.612  1.00 58.96           C  
+ATOM   1680  NE1 TRP A 881      16.304  24.305  58.549  1.00 45.48           N  
+ATOM   1681  CE2 TRP A 881      16.162  23.540  57.422  1.00 55.71           C  
+ATOM   1682  CE3 TRP A 881      16.965  21.411  56.592  1.00 55.70           C  
+ATOM   1683  CZ2 TRP A 881      15.433  23.782  56.249  1.00 56.85           C  
+ATOM   1684  CZ3 TRP A 881      16.237  21.655  55.421  1.00 67.37           C  
+ATOM   1685  CH2 TRP A 881      15.483  22.833  55.264  1.00 46.32           C  
+ATOM   1686  N   GLU A 882      17.583  18.593  58.690  1.00 44.93           N  
+ATOM   1687  CA  GLU A 882      16.914  17.675  57.776  1.00 38.96           C  
+ATOM   1688  C   GLU A 882      15.853  16.864  58.507  1.00 47.67           C  
+ATOM   1689  O   GLU A 882      14.744  16.671  58.000  1.00 52.57           O  
+ATOM   1690  CB  GLU A 882      17.910  16.718  57.147  1.00 41.57           C  
+ATOM   1691  CG  GLU A 882      18.897  17.351  56.190  1.00 42.00           C  
+ATOM   1692  CD  GLU A 882      19.960  16.364  55.770  1.00 54.77           C  
+ATOM   1693  OE1 GLU A 882      19.658  15.471  54.944  1.00 64.48           O  
+ATOM   1694  OE2 GLU A 882      21.098  16.473  56.283  1.00 50.07           O  
+ATOM   1695  N   LEU A 883      16.194  16.387  59.699  1.00 42.41           N  
+ATOM   1696  CA  LEU A 883      15.262  15.603  60.486  1.00 43.89           C  
+ATOM   1697  C   LEU A 883      14.038  16.413  60.944  1.00 46.61           C  
+ATOM   1698  O   LEU A 883      12.905  15.985  60.725  1.00 41.35           O  
+ATOM   1699  CB  LEU A 883      15.979  15.006  61.686  1.00 47.94           C  
+ATOM   1700  CG  LEU A 883      17.207  14.147  61.384  1.00 40.44           C  
+ATOM   1701  CD1 LEU A 883      17.792  13.664  62.702  1.00 22.45           C  
+ATOM   1702  CD2 LEU A 883      16.808  12.974  60.504  1.00 27.80           C  
+ATOM   1703  N   MET A 884      14.260  17.585  61.549  1.00 51.07           N  
+ATOM   1704  CA  MET A 884      13.153  18.429  62.042  1.00 54.93           C  
+ATOM   1705  C   MET A 884      12.197  18.891  60.946  1.00 53.65           C  
+ATOM   1706  O   MET A 884      11.016  19.117  61.213  1.00 47.38           O  
+ATOM   1707  CB  MET A 884      13.666  19.640  62.826  1.00 47.94           C  
+ATOM   1708  CG  MET A 884      14.515  19.295  64.047  1.00 40.93           C  
+ATOM   1709  SD  MET A 884      13.765  18.040  65.105  1.00 43.08           S  
+ATOM   1710  CE  MET A 884      15.132  17.661  66.291  1.00 40.50           C  
+ATOM   1711  N   THR A 885      12.717  19.032  59.724  1.00 56.12           N  
+ATOM   1712  CA  THR A 885      11.915  19.437  58.560  1.00 50.40           C  
+ATOM   1713  C   THR A 885      11.350  18.219  57.820  1.00 51.58           C  
+ATOM   1714  O   THR A 885      10.750  18.367  56.767  1.00 52.15           O  
+ATOM   1715  CB  THR A 885      12.740  20.210  57.542  1.00 42.22           C  
+ATOM   1716  OG1 THR A 885      13.864  19.414  57.145  1.00 44.04           O  
+ATOM   1717  CG2 THR A 885      13.231  21.507  58.124  1.00 37.23           C  
+ATOM   1718  N   PHE A 886      11.574  17.024  58.371  1.00 52.60           N  
+ATOM   1719  CA  PHE A 886      11.117  15.758  57.795  1.00 48.48           C  
+ATOM   1720  C   PHE A 886      11.711  15.385  56.428  1.00 47.47           C  
+ATOM   1721  O   PHE A 886      11.082  14.680  55.643  1.00 54.64           O  
+ATOM   1722  CB  PHE A 886       9.588  15.683  57.763  1.00 49.37           C  
+ATOM   1723  CG  PHE A 886       8.959  15.801  59.111  1.00 51.23           C  
+ATOM   1724  CD1 PHE A 886       8.910  14.712  59.960  1.00 43.11           C  
+ATOM   1725  CD2 PHE A 886       8.476  17.027  59.562  1.00 43.45           C  
+ATOM   1726  CE1 PHE A 886       8.391  14.836  61.269  1.00 45.93           C  
+ATOM   1727  CE2 PHE A 886       7.962  17.166  60.852  1.00 43.47           C  
+ATOM   1728  CZ  PHE A 886       7.919  16.066  61.712  1.00 44.23           C  
+ATOM   1729  N   GLY A 887      12.930  15.839  56.157  1.00 43.49           N  
+ATOM   1730  CA  GLY A 887      13.576  15.486  54.908  1.00 49.02           C  
+ATOM   1731  C   GLY A 887      13.732  16.535  53.831  1.00 55.35           C  
+ATOM   1732  O   GLY A 887      13.879  16.190  52.665  1.00 60.81           O  
+ATOM   1733  N   SER A 888      13.742  17.806  54.202  1.00 54.70           N  
+ATOM   1734  CA  SER A 888      13.876  18.863  53.209  1.00 57.45           C  
+ATOM   1735  C   SER A 888      15.311  19.029  52.734  1.00 63.69           C  
+ATOM   1736  O   SER A 888      16.261  18.685  53.440  1.00 68.90           O  
+ATOM   1737  CB  SER A 888      13.342  20.189  53.757  1.00 55.72           C  
+ATOM   1738  OG  SER A 888      11.958  20.080  54.045  1.00 59.11           O  
+ATOM   1739  N   LYS A 889      15.460  19.537  51.516  1.00 63.91           N  
+ATOM   1740  CA  LYS A 889      16.776  19.754  50.937  1.00 59.47           C  
+ATOM   1741  C   LYS A 889      17.256  21.113  51.418  1.00 57.20           C  
+ATOM   1742  O   LYS A 889      16.566  22.114  51.257  1.00 63.58           O  
+ATOM   1743  CB  LYS A 889      16.689  19.703  49.399  1.00 60.28           C  
+ATOM   1744  CG  LYS A 889      16.109  18.379  48.843  1.00 76.31           C  
+ATOM   1745  CD  LYS A 889      15.484  18.517  47.440  1.00 79.63           C  
+ATOM   1746  CE  LYS A 889      16.498  19.012  46.399  1.00100.56           C  
+ATOM   1747  NZ  LYS A 889      15.908  19.336  45.056  1.00 96.73           N  
+ATOM   1748  N   PRO A 890      18.404  21.150  52.099  1.00 53.44           N  
+ATOM   1749  CA  PRO A 890      18.929  22.424  52.595  1.00 56.97           C  
+ATOM   1750  C   PRO A 890      19.215  23.404  51.470  1.00 63.42           C  
+ATOM   1751  O   PRO A 890      19.933  23.087  50.525  1.00 69.89           O  
+ATOM   1752  CB  PRO A 890      20.193  22.013  53.364  1.00 50.25           C  
+ATOM   1753  CG  PRO A 890      20.553  20.663  52.767  1.00 54.14           C  
+ATOM   1754  CD  PRO A 890      19.220  20.017  52.556  1.00 46.07           C  
+ATOM   1755  N   TYR A 891      18.649  24.605  51.600  1.00 70.10           N  
+ATOM   1756  CA  TYR A 891      18.781  25.682  50.616  1.00 64.39           C  
+ATOM   1757  C   TYR A 891      18.258  25.157  49.280  1.00 65.48           C  
+ATOM   1758  O   TYR A 891      18.945  25.258  48.268  1.00 63.83           O  
+ATOM   1759  CB  TYR A 891      20.241  26.125  50.459  1.00 53.66           C  
+ATOM   1760  CG  TYR A 891      21.053  26.175  51.735  1.00 54.86           C  
+ATOM   1761  CD1 TYR A 891      21.034  27.295  52.560  1.00 35.95           C  
+ATOM   1762  CD2 TYR A 891      21.889  25.116  52.086  1.00 53.10           C  
+ATOM   1763  CE1 TYR A 891      21.842  27.363  53.708  1.00 46.08           C  
+ATOM   1764  CE2 TYR A 891      22.697  25.171  53.227  1.00 45.68           C  
+ATOM   1765  CZ  TYR A 891      22.677  26.289  54.030  1.00 46.76           C  
+ATOM   1766  OH  TYR A 891      23.519  26.334  55.127  1.00 42.39           O  
+ATOM   1767  N   ASP A 892      17.036  24.616  49.293  1.00 68.49           N  
+ATOM   1768  CA  ASP A 892      16.402  24.020  48.110  1.00 76.56           C  
+ATOM   1769  C   ASP A 892      16.600  24.734  46.784  1.00 81.31           C  
+ATOM   1770  O   ASP A 892      16.719  24.081  45.744  1.00 81.13           O  
+ATOM   1771  CB  ASP A 892      14.908  23.787  48.342  1.00 88.49           C  
+ATOM   1772  CG  ASP A 892      14.225  23.143  47.142  1.00 91.77           C  
+ATOM   1773  OD1 ASP A 892      14.429  21.929  46.905  1.00 78.82           O  
+ATOM   1774  OD2 ASP A 892      13.495  23.864  46.425  1.00102.90           O  
+ATOM   1775  N   GLY A 893      16.593  26.063  46.806  1.00 80.64           N  
+ATOM   1776  CA  GLY A 893      16.799  26.799  45.575  1.00 84.75           C  
+ATOM   1777  C   GLY A 893      18.280  26.886  45.254  1.00 86.86           C  
+ATOM   1778  O   GLY A 893      18.814  26.120  44.448  1.00 86.53           O  
+ATOM   1779  N   ILE A 894      18.938  27.807  45.944  1.00 89.25           N  
+ATOM   1780  CA  ILE A 894      20.361  28.090  45.815  1.00 90.31           C  
+ATOM   1781  C   ILE A 894      21.240  26.930  45.342  1.00 93.65           C  
+ATOM   1782  O   ILE A 894      21.094  25.806  45.809  1.00 96.52           O  
+ATOM   1783  CB  ILE A 894      20.895  28.616  47.161  1.00 85.72           C  
+ATOM   1784  CG1 ILE A 894      20.037  29.796  47.628  1.00 92.35           C  
+ATOM   1785  CG2 ILE A 894      22.336  29.050  47.030  1.00 88.26           C  
+ATOM   1786  CD1 ILE A 894      20.482  30.422  48.937  1.00100.49           C  
+ATOM   1787  N   PRO A 895      22.095  27.176  44.333  1.00100.33           N  
+ATOM   1788  CA  PRO A 895      23.005  26.165  43.785  1.00100.58           C  
+ATOM   1789  C   PRO A 895      24.327  26.218  44.547  1.00 96.08           C  
+ATOM   1790  O   PRO A 895      24.775  27.288  44.968  1.00 92.76           O  
+ATOM   1791  CB  PRO A 895      23.176  26.618  42.340  1.00102.05           C  
+ATOM   1792  CG  PRO A 895      23.223  28.103  42.489  1.00105.36           C  
+ATOM   1793  CD  PRO A 895      22.078  28.373  43.469  1.00112.44           C  
+ATOM   1794  N   ALA A 896      24.954  25.059  44.687  1.00 94.51           N  
+ATOM   1795  CA  ALA A 896      26.210  24.905  45.415  1.00 90.41           C  
+ATOM   1796  C   ALA A 896      27.224  26.042  45.316  1.00 87.90           C  
+ATOM   1797  O   ALA A 896      27.946  26.324  46.275  1.00 81.76           O  
+ATOM   1798  CB  ALA A 896      26.862  23.594  45.023  1.00 95.34           C  
+ATOM   1799  N   SER A 897      27.266  26.698  44.163  1.00 92.28           N  
+ATOM   1800  CA  SER A 897      28.211  27.789  43.926  1.00 97.61           C  
+ATOM   1801  C   SER A 897      27.975  29.018  44.792  1.00 98.57           C  
+ATOM   1802  O   SER A 897      28.926  29.717  45.159  1.00101.07           O  
+ATOM   1803  CB  SER A 897      28.176  28.211  42.455  1.00100.16           C  
+ATOM   1804  OG  SER A 897      28.393  27.103  41.603  1.00108.85           O  
+ATOM   1805  N   GLU A 898      26.710  29.276  45.115  1.00 97.19           N  
+ATOM   1806  CA  GLU A 898      26.340  30.445  45.907  1.00 91.79           C  
+ATOM   1807  C   GLU A 898      26.438  30.277  47.415  1.00 83.70           C  
+ATOM   1808  O   GLU A 898      26.700  31.256  48.123  1.00 81.80           O  
+ATOM   1809  CB  GLU A 898      24.931  30.911  45.538  1.00 93.24           C  
+ATOM   1810  CG  GLU A 898      24.753  31.241  44.069  1.00 94.50           C  
+ATOM   1811  CD  GLU A 898      23.444  31.948  43.783  1.00111.25           C  
+ATOM   1812  OE1 GLU A 898      22.410  31.589  44.391  1.00111.91           O  
+ATOM   1813  OE2 GLU A 898      23.450  32.872  42.943  1.00120.00           O  
+ATOM   1814  N   ILE A 899      26.271  29.037  47.883  1.00 75.33           N  
+ATOM   1815  CA  ILE A 899      26.304  28.691  49.313  1.00 65.80           C  
+ATOM   1816  C   ILE A 899      27.361  29.406  50.139  1.00 64.64           C  
+ATOM   1817  O   ILE A 899      27.068  29.912  51.219  1.00 70.05           O  
+ATOM   1818  CB  ILE A 899      26.450  27.173  49.529  1.00 43.47           C  
+ATOM   1819  CG1 ILE A 899      25.308  26.427  48.835  1.00 62.40           C  
+ATOM   1820  CG2 ILE A 899      26.475  26.843  51.002  1.00 56.71           C  
+ATOM   1821  CD1 ILE A 899      23.909  26.883  49.223  1.00 60.09           C  
+ATOM   1822  N   SER A 900      28.581  29.470  49.629  1.00 66.88           N  
+ATOM   1823  CA  SER A 900      29.654  30.137  50.352  1.00 67.29           C  
+ATOM   1824  C   SER A 900      29.289  31.585  50.662  1.00 67.66           C  
+ATOM   1825  O   SER A 900      29.486  32.048  51.779  1.00 66.68           O  
+ATOM   1826  CB  SER A 900      30.954  30.093  49.538  1.00 66.04           C  
+ATOM   1827  OG  SER A 900      32.009  30.772  50.207  1.00 66.03           O  
+ATOM   1828  N   SER A 901      28.727  32.277  49.675  1.00 69.06           N  
+ATOM   1829  CA  SER A 901      28.360  33.682  49.819  1.00 73.94           C  
+ATOM   1830  C   SER A 901      27.170  33.959  50.732  1.00 70.98           C  
+ATOM   1831  O   SER A 901      27.201  34.900  51.537  1.00 66.69           O  
+ATOM   1832  CB  SER A 901      28.138  34.320  48.444  1.00 79.40           C  
+ATOM   1833  OG  SER A 901      29.358  34.390  47.724  1.00 96.62           O  
+ATOM   1834  N   ILE A 902      26.113  33.168  50.599  1.00 63.68           N  
+ATOM   1835  CA  ILE A 902      24.968  33.378  51.452  1.00 65.54           C  
+ATOM   1836  C   ILE A 902      25.427  33.166  52.896  1.00 69.07           C  
+ATOM   1837  O   ILE A 902      25.009  33.891  53.796  1.00 77.10           O  
+ATOM   1838  CB  ILE A 902      23.798  32.434  51.110  1.00 74.17           C  
+ATOM   1839  CG1 ILE A 902      24.059  31.035  51.646  1.00 66.26           C  
+ATOM   1840  CG2 ILE A 902      23.546  32.417  49.607  1.00 58.72           C  
+ATOM   1841  CD1 ILE A 902      22.809  30.210  51.746  1.00 92.86           C  
+ATOM   1842  N   LEU A 903      26.352  32.227  53.098  1.00 65.02           N  
+ATOM   1843  CA  LEU A 903      26.870  31.953  54.430  1.00 59.17           C  
+ATOM   1844  C   LEU A 903      27.761  33.073  54.928  1.00 59.34           C  
+ATOM   1845  O   LEU A 903      27.798  33.353  56.115  1.00 64.13           O  
+ATOM   1846  CB  LEU A 903      27.614  30.619  54.471  1.00 64.94           C  
+ATOM   1847  CG  LEU A 903      26.769  29.341  54.317  1.00 62.45           C  
+ATOM   1848  CD1 LEU A 903      27.669  28.119  54.316  1.00 47.66           C  
+ATOM   1849  CD2 LEU A 903      25.754  29.235  55.428  1.00 56.42           C  
+ATOM   1850  N   GLU A 904      28.465  33.732  54.016  1.00 73.27           N  
+ATOM   1851  CA  GLU A 904      29.349  34.837  54.384  1.00 74.37           C  
+ATOM   1852  C   GLU A 904      28.517  36.044  54.824  1.00 72.34           C  
+ATOM   1853  O   GLU A 904      28.928  36.798  55.710  1.00 69.86           O  
+ATOM   1854  CB  GLU A 904      30.283  35.196  53.217  1.00 80.24           C  
+ATOM   1855  CG  GLU A 904      31.300  34.101  52.873  1.00 87.87           C  
+ATOM   1856  CD  GLU A 904      32.208  34.455  51.692  1.00 97.84           C  
+ATOM   1857  OE1 GLU A 904      33.278  35.068  51.919  1.00 83.56           O  
+ATOM   1858  OE2 GLU A 904      31.861  34.098  50.540  1.00100.45           O  
+ATOM   1859  N   LYS A 905      27.330  36.190  54.231  1.00 72.48           N  
+ATOM   1860  CA  LYS A 905      26.406  37.283  54.562  1.00 75.62           C  
+ATOM   1861  C   LYS A 905      25.697  37.042  55.901  1.00 73.77           C  
+ATOM   1862  O   LYS A 905      24.869  37.846  56.315  1.00 70.63           O  
+ATOM   1863  CB  LYS A 905      25.334  37.453  53.477  1.00 84.87           C  
+ATOM   1864  CG  LYS A 905      25.798  38.010  52.134  1.00 89.24           C  
+ATOM   1865  CD  LYS A 905      24.648  37.914  51.121  1.00100.50           C  
+ATOM   1866  CE  LYS A 905      24.997  38.483  49.745  1.00102.05           C  
+ATOM   1867  NZ  LYS A 905      24.964  39.973  49.704  1.00103.54           N  
+ATOM   1868  N   GLY A 906      25.980  35.907  56.540  1.00 72.04           N  
+ATOM   1869  CA  GLY A 906      25.379  35.602  57.827  1.00 62.99           C  
+ATOM   1870  C   GLY A 906      24.072  34.838  57.756  1.00 63.01           C  
+ATOM   1871  O   GLY A 906      23.455  34.556  58.781  1.00 62.79           O  
+ATOM   1872  N   GLU A 907      23.626  34.519  56.549  1.00 55.28           N  
+ATOM   1873  CA  GLU A 907      22.388  33.768  56.393  1.00 53.60           C  
+ATOM   1874  C   GLU A 907      22.580  32.320  56.883  1.00 59.27           C  
+ATOM   1875  O   GLU A 907      23.708  31.787  56.860  1.00 58.09           O  
+ATOM   1876  CB  GLU A 907      21.969  33.797  54.929  1.00 46.36           C  
+ATOM   1877  CG  GLU A 907      20.601  33.181  54.598  1.00 54.18           C  
+ATOM   1878  CD  GLU A 907      20.147  33.563  53.199  1.00 71.70           C  
+ATOM   1879  OE1 GLU A 907      20.750  34.496  52.618  1.00 68.71           O  
+ATOM   1880  OE2 GLU A 907      19.199  32.937  52.675  1.00 88.46           O  
+ATOM   1881  N   ARG A 908      21.491  31.704  57.352  1.00 48.00           N  
+ATOM   1882  CA  ARG A 908      21.528  30.338  57.847  1.00 40.97           C  
+ATOM   1883  C   ARG A 908      20.252  29.618  57.515  1.00 38.02           C  
+ATOM   1884  O   ARG A 908      19.362  30.198  56.938  1.00 46.84           O  
+ATOM   1885  CB  ARG A 908      21.752  30.313  59.356  1.00 44.56           C  
+ATOM   1886  CG  ARG A 908      23.137  30.772  59.789  1.00 48.20           C  
+ATOM   1887  CD  ARG A 908      24.252  29.854  59.273  1.00 38.82           C  
+ATOM   1888  NE  ARG A 908      25.547  30.254  59.832  1.00 42.22           N  
+ATOM   1889  CZ  ARG A 908      26.303  31.243  59.356  1.00 40.71           C  
+ATOM   1890  NH1 ARG A 908      25.931  31.949  58.289  1.00 32.91           N  
+ATOM   1891  NH2 ARG A 908      27.386  31.599  60.014  1.00 42.84           N  
+ATOM   1892  N   LEU A 909      20.169  28.336  57.852  1.00 46.82           N  
+ATOM   1893  CA  LEU A 909      18.967  27.573  57.552  1.00 50.32           C  
+ATOM   1894  C   LEU A 909      17.854  28.115  58.422  1.00 55.51           C  
+ATOM   1895  O   LEU A 909      18.109  28.615  59.515  1.00 60.61           O  
+ATOM   1896  CB  LEU A 909      19.190  26.069  57.774  1.00 52.53           C  
+ATOM   1897  CG  LEU A 909      20.062  25.393  56.698  1.00 54.68           C  
+ATOM   1898  CD1 LEU A 909      20.346  23.927  57.021  1.00 44.35           C  
+ATOM   1899  CD2 LEU A 909      19.360  25.494  55.356  1.00 46.03           C  
+ATOM   1900  N   PRO A 910      16.614  28.091  57.918  1.00 57.86           N  
+ATOM   1901  CA  PRO A 910      15.462  28.597  58.668  1.00 56.33           C  
+ATOM   1902  C   PRO A 910      14.984  27.694  59.817  1.00 57.65           C  
+ATOM   1903  O   PRO A 910      15.282  26.508  59.852  1.00 58.73           O  
+ATOM   1904  CB  PRO A 910      14.409  28.753  57.573  1.00 53.42           C  
+ATOM   1905  CG  PRO A 910      14.703  27.576  56.684  1.00 55.12           C  
+ATOM   1906  CD  PRO A 910      16.211  27.640  56.570  1.00 47.03           C  
+ATOM   1907  N   GLN A 911      14.242  28.284  60.753  1.00 55.96           N  
+ATOM   1908  CA  GLN A 911      13.697  27.585  61.908  1.00 46.66           C  
+ATOM   1909  C   GLN A 911      12.567  26.662  61.445  1.00 45.18           C  
+ATOM   1910  O   GLN A 911      11.588  27.106  60.876  1.00 55.50           O  
+ATOM   1911  CB  GLN A 911      13.212  28.616  62.956  1.00 40.07           C  
+ATOM   1912  CG  GLN A 911      12.588  28.034  64.242  1.00 35.29           C  
+ATOM   1913  CD  GLN A 911      12.434  29.055  65.415  1.00 53.57           C  
+ATOM   1914  OE1 GLN A 911      12.804  30.240  65.324  1.00 44.84           O  
+ATOM   1915  NE2 GLN A 911      11.891  28.569  66.525  1.00 46.47           N  
+ATOM   1916  N   PRO A 912      12.747  25.344  61.584  1.00 51.11           N  
+ATOM   1917  CA  PRO A 912      11.715  24.388  61.167  1.00 49.52           C  
+ATOM   1918  C   PRO A 912      10.461  24.669  61.973  1.00 54.69           C  
+ATOM   1919  O   PRO A 912      10.545  24.912  63.179  1.00 56.20           O  
+ATOM   1920  CB  PRO A 912      12.316  23.035  61.581  1.00 40.64           C  
+ATOM   1921  CG  PRO A 912      13.777  23.269  61.485  1.00 45.74           C  
+ATOM   1922  CD  PRO A 912      13.936  24.642  62.098  1.00 50.93           C  
+ATOM   1923  N   PRO A 913       9.290  24.685  61.319  1.00 55.41           N  
+ATOM   1924  CA  PRO A 913       8.011  24.942  61.980  1.00 54.44           C  
+ATOM   1925  C   PRO A 913       7.736  24.197  63.271  1.00 50.72           C  
+ATOM   1926  O   PRO A 913       7.132  24.763  64.174  1.00 56.73           O  
+ATOM   1927  CB  PRO A 913       6.973  24.611  60.898  1.00 52.36           C  
+ATOM   1928  CG  PRO A 913       7.762  24.119  59.720  1.00 52.87           C  
+ATOM   1929  CD  PRO A 913       9.108  24.761  59.868  1.00 57.55           C  
+ATOM   1930  N   ILE A 914       8.208  22.961  63.392  1.00 51.85           N  
+ATOM   1931  CA  ILE A 914       7.963  22.189  64.616  1.00 39.36           C  
+ATOM   1932  C   ILE A 914       8.942  22.498  65.746  1.00 35.86           C  
+ATOM   1933  O   ILE A 914       8.796  21.988  66.879  1.00 34.47           O  
+ATOM   1934  CB  ILE A 914       8.021  20.667  64.350  1.00 46.49           C  
+ATOM   1935  CG1 ILE A 914       9.463  20.221  64.142  1.00 41.22           C  
+ATOM   1936  CG2 ILE A 914       7.183  20.294  63.127  1.00 36.42           C  
+ATOM   1937  CD1 ILE A 914       9.629  18.713  64.185  1.00 34.65           C  
+ATOM   1938  N   CYS A 915       9.890  23.388  65.456  1.00 34.44           N  
+ATOM   1939  CA  CYS A 915      10.947  23.727  66.403  1.00 43.79           C  
+ATOM   1940  C   CYS A 915      10.785  24.842  67.394  1.00 47.38           C  
+ATOM   1941  O   CYS A 915      10.647  26.002  67.013  1.00 52.88           O  
+ATOM   1942  CB  CYS A 915      12.254  23.995  65.659  1.00 59.03           C  
+ATOM   1943  SG  CYS A 915      13.108  22.535  65.086  1.00 45.18           S  
+ATOM   1944  N   THR A 916      10.901  24.502  68.673  1.00 43.25           N  
+ATOM   1945  CA  THR A 916      10.841  25.522  69.697  1.00 41.83           C  
+ATOM   1946  C   THR A 916      12.155  26.259  69.542  1.00 40.20           C  
+ATOM   1947  O   THR A 916      13.109  25.725  68.980  1.00 50.55           O  
+ATOM   1948  CB  THR A 916      10.784  24.946  71.120  1.00 42.07           C  
+ATOM   1949  OG1 THR A 916      11.865  24.033  71.312  1.00 48.03           O  
+ATOM   1950  CG2 THR A 916       9.463  24.247  71.379  1.00 42.97           C  
+ATOM   1951  N   ILE A 917      12.209  27.485  70.040  1.00 44.16           N  
+ATOM   1952  CA  ILE A 917      13.423  28.276  69.949  1.00 42.89           C  
+ATOM   1953  C   ILE A 917      14.598  27.564  70.643  1.00 38.64           C  
+ATOM   1954  O   ILE A 917      15.731  27.744  70.247  1.00 38.32           O  
+ATOM   1955  CB  ILE A 917      13.217  29.703  70.547  1.00 44.79           C  
+ATOM   1956  CG1 ILE A 917      14.450  30.564  70.242  1.00 44.21           C  
+ATOM   1957  CG2 ILE A 917      12.880  29.627  72.049  1.00 33.40           C  
+ATOM   1958  CD1 ILE A 917      14.499  31.900  70.920  1.00 50.48           C  
+ATOM   1959  N   ASP A 918      14.303  26.758  71.664  1.00 34.19           N  
+ATOM   1960  CA  ASP A 918      15.291  26.011  72.428  1.00 33.48           C  
+ATOM   1961  C   ASP A 918      16.088  25.078  71.504  1.00 44.55           C  
+ATOM   1962  O   ASP A 918      17.318  25.016  71.566  1.00 41.25           O  
+ATOM   1963  CB  ASP A 918      14.581  25.147  73.474  1.00 34.30           C  
+ATOM   1964  CG  ASP A 918      13.876  25.964  74.533  1.00 50.76           C  
+ATOM   1965  OD1 ASP A 918      12.719  26.387  74.308  1.00 43.90           O  
+ATOM   1966  OD2 ASP A 918      14.466  26.154  75.612  1.00 49.86           O  
+ATOM   1967  N   VAL A 919      15.369  24.312  70.687  1.00 41.36           N  
+ATOM   1968  CA  VAL A 919      15.988  23.379  69.761  1.00 37.02           C  
+ATOM   1969  C   VAL A 919      16.719  24.117  68.642  1.00 44.27           C  
+ATOM   1970  O   VAL A 919      17.839  23.766  68.298  1.00 51.26           O  
+ATOM   1971  CB  VAL A 919      14.936  22.420  69.140  1.00 32.63           C  
+ATOM   1972  CG1 VAL A 919      15.531  21.657  67.948  1.00 26.21           C  
+ATOM   1973  CG2 VAL A 919      14.459  21.420  70.182  1.00 28.40           C  
+ATOM   1974  N   TYR A 920      16.075  25.129  68.068  1.00 44.12           N  
+ATOM   1975  CA  TYR A 920      16.666  25.884  66.979  1.00 40.48           C  
+ATOM   1976  C   TYR A 920      17.936  26.617  67.388  1.00 43.47           C  
+ATOM   1977  O   TYR A 920      18.829  26.842  66.572  1.00 51.05           O  
+ATOM   1978  CB  TYR A 920      15.654  26.866  66.404  1.00 43.40           C  
+ATOM   1979  CG  TYR A 920      16.181  27.634  65.221  1.00 40.15           C  
+ATOM   1980  CD1 TYR A 920      16.713  26.979  64.116  1.00 47.09           C  
+ATOM   1981  CD2 TYR A 920      16.123  29.015  65.194  1.00 50.61           C  
+ATOM   1982  CE1 TYR A 920      17.174  27.697  63.006  1.00 58.98           C  
+ATOM   1983  CE2 TYR A 920      16.574  29.739  64.097  1.00 48.19           C  
+ATOM   1984  CZ  TYR A 920      17.099  29.078  63.014  1.00 53.26           C  
+ATOM   1985  OH  TYR A 920      17.590  29.816  61.971  1.00 45.81           O  
+ATOM   1986  N   MET A 921      18.022  26.970  68.659  1.00 44.36           N  
+ATOM   1987  CA  MET A 921      19.189  27.656  69.185  1.00 45.93           C  
+ATOM   1988  C   MET A 921      20.383  26.682  69.183  1.00 47.62           C  
+ATOM   1989  O   MET A 921      21.546  27.110  69.162  1.00 40.44           O  
+ATOM   1990  CB  MET A 921      18.901  28.107  70.610  1.00 45.87           C  
+ATOM   1991  CG  MET A 921      19.877  29.101  71.158  1.00 57.18           C  
+ATOM   1992  SD  MET A 921      19.133  30.691  71.032  1.00 80.91           S  
+ATOM   1993  CE  MET A 921      20.355  31.474  70.081  1.00 82.49           C  
+ATOM   1994  N   ILE A 922      20.089  25.383  69.283  1.00 40.48           N  
+ATOM   1995  CA  ILE A 922      21.139  24.364  69.263  1.00 49.52           C  
+ATOM   1996  C   ILE A 922      21.713  24.299  67.839  1.00 46.88           C  
+ATOM   1997  O   ILE A 922      22.927  24.342  67.661  1.00 47.97           O  
+ATOM   1998  CB  ILE A 922      20.622  22.946  69.653  1.00 56.34           C  
+ATOM   1999  CG1 ILE A 922      19.955  22.953  71.031  1.00 37.27           C  
+ATOM   2000  CG2 ILE A 922      21.776  21.973  69.682  1.00 48.26           C  
+ATOM   2001  CD1 ILE A 922      20.891  23.229  72.157  1.00 48.32           C  
+ATOM   2002  N   MET A 923      20.830  24.241  66.841  1.00 41.32           N  
+ATOM   2003  CA  MET A 923      21.229  24.190  65.440  1.00 40.08           C  
+ATOM   2004  C   MET A 923      22.004  25.437  65.054  1.00 40.96           C  
+ATOM   2005  O   MET A 923      23.027  25.358  64.389  1.00 50.36           O  
+ATOM   2006  CB  MET A 923      20.004  24.033  64.537  1.00 34.16           C  
+ATOM   2007  CG  MET A 923      19.175  22.782  64.835  1.00 39.27           C  
+ATOM   2008  SD  MET A 923      17.581  22.722  63.984  1.00 53.56           S  
+ATOM   2009  CE  MET A 923      17.994  23.546  62.618  1.00 37.06           C  
+ATOM   2010  N   VAL A 924      21.534  26.590  65.499  1.00 46.48           N  
+ATOM   2011  CA  VAL A 924      22.204  27.854  65.211  1.00 44.40           C  
+ATOM   2012  C   VAL A 924      23.617  27.921  65.812  1.00 42.15           C  
+ATOM   2013  O   VAL A 924      24.541  28.457  65.189  1.00 37.83           O  
+ATOM   2014  CB  VAL A 924      21.321  29.049  65.685  1.00 44.34           C  
+ATOM   2015  CG1 VAL A 924      22.075  30.385  65.628  1.00 35.94           C  
+ATOM   2016  CG2 VAL A 924      20.087  29.106  64.822  1.00 25.11           C  
+ATOM   2017  N   LYS A 925      23.794  27.352  67.001  1.00 43.48           N  
+ATOM   2018  CA  LYS A 925      25.108  27.365  67.657  1.00 40.80           C  
+ATOM   2019  C   LYS A 925      26.141  26.515  66.918  1.00 44.65           C  
+ATOM   2020  O   LYS A 925      27.328  26.804  66.966  1.00 48.08           O  
+ATOM   2021  CB  LYS A 925      25.006  26.874  69.094  1.00 40.04           C  
+ATOM   2022  CG  LYS A 925      24.345  27.819  70.060  1.00 46.03           C  
+ATOM   2023  CD  LYS A 925      24.275  27.160  71.438  1.00 55.99           C  
+ATOM   2024  CE  LYS A 925      23.660  28.087  72.485  1.00 51.98           C  
+ATOM   2025  NZ  LYS A 925      23.552  27.389  73.781  1.00 76.81           N  
+ATOM   2026  N   CYS A 926      25.692  25.454  66.254  1.00 40.92           N  
+ATOM   2027  CA  CYS A 926      26.593  24.584  65.506  1.00 41.05           C  
+ATOM   2028  C   CYS A 926      27.088  25.314  64.246  1.00 46.96           C  
+ATOM   2029  O   CYS A 926      28.036  24.862  63.592  1.00 45.06           O  
+ATOM   2030  CB  CYS A 926      25.872  23.289  65.083  1.00 33.48           C  
+ATOM   2031  SG  CYS A 926      25.267  22.189  66.390  1.00 43.38           S  
+ATOM   2032  N   TRP A 927      26.435  26.436  63.924  1.00 45.45           N  
+ATOM   2033  CA  TRP A 927      26.735  27.235  62.744  1.00 34.61           C  
+ATOM   2034  C   TRP A 927      27.444  28.573  62.966  1.00 37.33           C  
+ATOM   2035  O   TRP A 927      27.432  29.442  62.087  1.00 38.69           O  
+ATOM   2036  CB  TRP A 927      25.463  27.442  61.932  1.00 29.93           C  
+ATOM   2037  CG  TRP A 927      24.792  26.160  61.532  1.00 44.93           C  
+ATOM   2038  CD1 TRP A 927      25.390  24.946  61.346  1.00 42.64           C  
+ATOM   2039  CD2 TRP A 927      23.389  25.950  61.319  1.00 35.04           C  
+ATOM   2040  NE1 TRP A 927      24.450  23.991  61.042  1.00 45.36           N  
+ATOM   2041  CE2 TRP A 927      23.212  24.576  61.020  1.00 40.08           C  
+ATOM   2042  CE3 TRP A 927      22.262  26.783  61.364  1.00 35.22           C  
+ATOM   2043  CZ2 TRP A 927      21.950  24.010  60.762  1.00 45.51           C  
+ATOM   2044  CZ3 TRP A 927      20.986  26.217  61.108  1.00 32.98           C  
+ATOM   2045  CH2 TRP A 927      20.850  24.845  60.811  1.00 41.20           C  
+ATOM   2046  N   MET A 928      28.059  28.736  64.134  1.00 40.15           N  
+ATOM   2047  CA  MET A 928      28.826  29.942  64.452  1.00 47.61           C  
+ATOM   2048  C   MET A 928      30.069  29.919  63.561  1.00 53.00           C  
+ATOM   2049  O   MET A 928      30.506  28.848  63.160  1.00 61.95           O  
+ATOM   2050  CB  MET A 928      29.311  29.893  65.901  1.00 42.38           C  
+ATOM   2051  CG  MET A 928      28.229  29.672  66.947  1.00 60.23           C  
+ATOM   2052  SD  MET A 928      27.304  31.160  67.360  1.00 64.93           S  
+ATOM   2053  CE  MET A 928      28.256  31.741  68.635  1.00 54.96           C  
+ATOM   2054  N   ILE A 929      30.637  31.086  63.259  1.00 62.12           N  
+ATOM   2055  CA  ILE A 929      31.842  31.180  62.430  1.00 54.18           C  
+ATOM   2056  C   ILE A 929      33.024  30.579  63.193  1.00 57.90           C  
+ATOM   2057  O   ILE A 929      33.742  29.730  62.663  1.00 66.53           O  
+ATOM   2058  CB  ILE A 929      32.156  32.670  62.019  1.00 68.40           C  
+ATOM   2059  CG1 ILE A 929      31.554  33.002  60.647  1.00 65.06           C  
+ATOM   2060  CG2 ILE A 929      33.667  32.920  61.938  1.00 84.32           C  
+ATOM   2061  CD1 ILE A 929      30.052  32.974  60.594  1.00 82.00           C  
+ATOM   2062  N   ASP A 930      33.217  31.013  64.435  1.00 56.88           N  
+ATOM   2063  CA  ASP A 930      34.305  30.507  65.274  1.00 60.72           C  
+ATOM   2064  C   ASP A 930      33.981  29.057  65.674  1.00 65.68           C  
+ATOM   2065  O   ASP A 930      33.073  28.810  66.471  1.00 69.29           O  
+ATOM   2066  CB  ASP A 930      34.464  31.396  66.516  1.00 49.19           C  
+ATOM   2067  CG  ASP A 930      35.653  31.008  67.367  1.00 76.52           C  
+ATOM   2068  OD1 ASP A 930      36.796  31.051  66.858  1.00 91.04           O  
+ATOM   2069  OD2 ASP A 930      35.449  30.672  68.554  1.00 85.32           O  
+ATOM   2070  N   ALA A 931      34.725  28.106  65.111  1.00 64.45           N  
+ATOM   2071  CA  ALA A 931      34.500  26.684  65.363  1.00 54.95           C  
+ATOM   2072  C   ALA A 931      34.458  26.271  66.836  1.00 50.32           C  
+ATOM   2073  O   ALA A 931      33.625  25.440  67.206  1.00 44.54           O  
+ATOM   2074  CB  ALA A 931      35.506  25.829  64.578  1.00 55.27           C  
+ATOM   2075  N   ASP A 932      35.327  26.852  67.668  1.00 45.65           N  
+ATOM   2076  CA  ASP A 932      35.351  26.541  69.109  1.00 49.79           C  
+ATOM   2077  C   ASP A 932      34.110  27.039  69.846  1.00 51.78           C  
+ATOM   2078  O   ASP A 932      33.817  26.598  70.951  1.00 56.79           O  
+ATOM   2079  CB  ASP A 932      36.587  27.131  69.795  1.00 63.01           C  
+ATOM   2080  CG  ASP A 932      37.896  26.559  69.261  1.00 84.76           C  
+ATOM   2081  OD1 ASP A 932      38.005  25.320  69.088  1.00 75.16           O  
+ATOM   2082  OD2 ASP A 932      38.823  27.367  69.024  1.00 81.12           O  
+ATOM   2083  N   SER A 933      33.415  28.002  69.259  1.00 49.93           N  
+ATOM   2084  CA  SER A 933      32.211  28.522  69.872  1.00 53.57           C  
+ATOM   2085  C   SER A 933      31.081  27.511  69.739  1.00 55.00           C  
+ATOM   2086  O   SER A 933      30.162  27.491  70.562  1.00 53.86           O  
+ATOM   2087  CB  SER A 933      31.808  29.847  69.227  1.00 53.41           C  
+ATOM   2088  OG  SER A 933      32.645  30.891  69.698  1.00 74.85           O  
+ATOM   2089  N   ARG A 934      31.151  26.669  68.709  1.00 41.41           N  
+ATOM   2090  CA  ARG A 934      30.115  25.672  68.505  1.00 42.43           C  
+ATOM   2091  C   ARG A 934      30.166  24.667  69.635  1.00 39.42           C  
+ATOM   2092  O   ARG A 934      31.171  24.577  70.336  1.00 41.44           O  
+ATOM   2093  CB  ARG A 934      30.315  24.946  67.189  1.00 36.51           C  
+ATOM   2094  CG  ARG A 934      30.461  25.871  66.050  1.00 46.26           C  
+ATOM   2095  CD  ARG A 934      30.808  25.141  64.794  1.00 40.38           C  
+ATOM   2096  NE  ARG A 934      31.186  26.119  63.780  1.00 60.06           N  
+ATOM   2097  CZ  ARG A 934      32.044  25.902  62.794  1.00 46.49           C  
+ATOM   2098  NH1 ARG A 934      32.651  24.729  62.664  1.00 35.72           N  
+ATOM   2099  NH2 ARG A 934      32.230  26.846  61.896  1.00 32.88           N  
+ATOM   2100  N   PRO A 935      29.040  23.997  69.909  1.00 38.15           N  
+ATOM   2101  CA  PRO A 935      29.044  23.006  70.985  1.00 39.62           C  
+ATOM   2102  C   PRO A 935      29.889  21.789  70.607  1.00 46.52           C  
+ATOM   2103  O   PRO A 935      30.304  21.608  69.449  1.00 42.39           O  
+ATOM   2104  CB  PRO A 935      27.563  22.623  71.127  1.00 29.89           C  
+ATOM   2105  CG  PRO A 935      26.919  23.046  69.850  1.00 42.50           C  
+ATOM   2106  CD  PRO A 935      27.670  24.268  69.425  1.00 37.33           C  
+ATOM   2107  N   LYS A 936      30.145  20.968  71.609  1.00 43.51           N  
+ATOM   2108  CA  LYS A 936      30.903  19.756  71.440  1.00 44.28           C  
+ATOM   2109  C   LYS A 936      29.893  18.631  71.435  1.00 44.64           C  
+ATOM   2110  O   LYS A 936      28.814  18.754  72.034  1.00 41.04           O  
+ATOM   2111  CB  LYS A 936      31.893  19.586  72.600  1.00 39.02           C  
+ATOM   2112  CG  LYS A 936      32.971  20.676  72.637  1.00 47.20           C  
+ATOM   2113  CD  LYS A 936      33.993  20.415  73.748  1.00 75.87           C  
+ATOM   2114  CE  LYS A 936      35.002  21.560  73.915  1.00 77.64           C  
+ATOM   2115  NZ  LYS A 936      34.375  22.796  74.471  1.00 85.90           N  
+ATOM   2116  N   PHE A 937      30.223  17.545  70.737  1.00 46.58           N  
+ATOM   2117  CA  PHE A 937      29.336  16.401  70.681  1.00 36.52           C  
+ATOM   2118  C   PHE A 937      28.941  15.916  72.086  1.00 39.44           C  
+ATOM   2119  O   PHE A 937      27.763  15.612  72.328  1.00 40.59           O  
+ATOM   2120  CB  PHE A 937      29.941  15.279  69.838  1.00 35.72           C  
+ATOM   2121  CG  PHE A 937      29.852  15.530  68.364  1.00 35.87           C  
+ATOM   2122  CD1 PHE A 937      28.613  15.652  67.743  1.00 35.97           C  
+ATOM   2123  CD2 PHE A 937      31.006  15.692  67.601  1.00 40.42           C  
+ATOM   2124  CE1 PHE A 937      28.522  15.938  66.381  1.00 42.10           C  
+ATOM   2125  CE2 PHE A 937      30.927  15.981  66.234  1.00 33.24           C  
+ATOM   2126  CZ  PHE A 937      29.678  16.105  65.629  1.00 55.65           C  
+ATOM   2127  N   ARG A 938      29.884  15.922  73.032  1.00 30.91           N  
+ATOM   2128  CA  ARG A 938      29.534  15.483  74.380  1.00 35.47           C  
+ATOM   2129  C   ARG A 938      28.443  16.392  74.989  1.00 38.99           C  
+ATOM   2130  O   ARG A 938      27.590  15.925  75.754  1.00 40.29           O  
+ATOM   2131  CB  ARG A 938      30.766  15.383  75.297  1.00 33.40           C  
+ATOM   2132  CG  ARG A 938      31.543  16.685  75.490  1.00 56.97           C  
+ATOM   2133  CD  ARG A 938      32.552  16.596  76.620  1.00 63.24           C  
+ATOM   2134  NE  ARG A 938      31.968  16.105  77.880  1.00 88.47           N  
+ATOM   2135  CZ  ARG A 938      31.306  16.844  78.776  1.00 84.19           C  
+ATOM   2136  NH1 ARG A 938      30.836  16.271  79.876  1.00 86.37           N  
+ATOM   2137  NH2 ARG A 938      31.098  18.144  78.586  1.00 81.25           N  
+ATOM   2138  N   GLU A 939      28.430  17.670  74.607  1.00 37.26           N  
+ATOM   2139  CA  GLU A 939      27.409  18.594  75.118  1.00 39.02           C  
+ATOM   2140  C   GLU A 939      26.082  18.416  74.397  1.00 42.19           C  
+ATOM   2141  O   GLU A 939      25.022  18.536  75.014  1.00 41.43           O  
+ATOM   2142  CB  GLU A 939      27.848  20.045  74.999  1.00 27.30           C  
+ATOM   2143  CG  GLU A 939      28.987  20.415  75.928  1.00 33.07           C  
+ATOM   2144  CD  GLU A 939      29.757  21.607  75.406  1.00 46.40           C  
+ATOM   2145  OE1 GLU A 939      29.504  21.991  74.235  1.00 38.96           O  
+ATOM   2146  OE2 GLU A 939      30.598  22.160  76.157  1.00 54.12           O  
+ATOM   2147  N   LEU A 940      26.141  18.144  73.094  1.00 44.41           N  
+ATOM   2148  CA  LEU A 940      24.929  17.926  72.314  1.00 35.45           C  
+ATOM   2149  C   LEU A 940      24.155  16.743  72.898  1.00 36.59           C  
+ATOM   2150  O   LEU A 940      22.929  16.760  72.918  1.00 41.71           O  
+ATOM   2151  CB  LEU A 940      25.269  17.627  70.852  1.00 31.78           C  
+ATOM   2152  CG  LEU A 940      25.457  18.719  69.789  1.00 35.75           C  
+ATOM   2153  CD1 LEU A 940      24.419  19.821  69.948  1.00 30.93           C  
+ATOM   2154  CD2 LEU A 940      26.801  19.285  69.834  1.00 45.73           C  
+ATOM   2155  N   ILE A 941      24.881  15.737  73.393  1.00 33.71           N  
+ATOM   2156  CA  ILE A 941      24.288  14.532  73.980  1.00 32.37           C  
+ATOM   2157  C   ILE A 941      23.479  14.880  75.216  1.00 37.88           C  
+ATOM   2158  O   ILE A 941      22.333  14.455  75.342  1.00 48.34           O  
+ATOM   2159  CB  ILE A 941      25.374  13.524  74.380  1.00 34.04           C  
+ATOM   2160  CG1 ILE A 941      26.124  13.043  73.145  1.00 27.29           C  
+ATOM   2161  CG2 ILE A 941      24.778  12.333  75.163  1.00 18.00           C  
+ATOM   2162  CD1 ILE A 941      27.371  12.199  73.497  1.00 28.95           C  
+ATOM   2163  N   ILE A 942      24.093  15.649  76.123  1.00 45.39           N  
+ATOM   2164  CA  ILE A 942      23.469  16.118  77.375  1.00 38.61           C  
+ATOM   2165  C   ILE A 942      22.218  16.939  77.033  1.00 33.47           C  
+ATOM   2166  O   ILE A 942      21.123  16.627  77.482  1.00 34.41           O  
+ATOM   2167  CB  ILE A 942      24.473  17.007  78.179  1.00 41.34           C  
+ATOM   2168  CG1 ILE A 942      25.632  16.146  78.669  1.00 38.77           C  
+ATOM   2169  CG2 ILE A 942      23.795  17.679  79.392  1.00 36.18           C  
+ATOM   2170  CD1 ILE A 942      26.789  16.937  79.223  1.00 30.80           C  
+ATOM   2171  N   GLU A 943      22.391  17.960  76.198  1.00 28.84           N  
+ATOM   2172  CA  GLU A 943      21.291  18.824  75.784  1.00 30.47           C  
+ATOM   2173  C   GLU A 943      20.089  18.096  75.233  1.00 35.87           C  
+ATOM   2174  O   GLU A 943      18.982  18.214  75.772  1.00 40.99           O  
+ATOM   2175  CB  GLU A 943      21.762  19.871  74.779  1.00 35.02           C  
+ATOM   2176  CG  GLU A 943      22.617  20.986  75.404  1.00 39.86           C  
+ATOM   2177  CD  GLU A 943      22.041  21.483  76.733  1.00 77.41           C  
+ATOM   2178  OE1 GLU A 943      20.966  22.134  76.724  1.00 85.94           O  
+ATOM   2179  OE2 GLU A 943      22.660  21.205  77.789  1.00 72.26           O  
+ATOM   2180  N   PHE A 944      20.300  17.320  74.179  1.00 38.26           N  
+ATOM   2181  CA  PHE A 944      19.202  16.581  73.597  1.00 31.16           C  
+ATOM   2182  C   PHE A 944      18.686  15.504  74.553  1.00 41.19           C  
+ATOM   2183  O   PHE A 944      17.497  15.148  74.523  1.00 41.21           O  
+ATOM   2184  CB  PHE A 944      19.590  16.017  72.237  1.00 24.37           C  
+ATOM   2185  CG  PHE A 944      19.595  17.046  71.138  1.00 27.04           C  
+ATOM   2186  CD1 PHE A 944      18.411  17.457  70.537  1.00 28.88           C  
+ATOM   2187  CD2 PHE A 944      20.767  17.593  70.701  1.00 22.64           C  
+ATOM   2188  CE1 PHE A 944      18.416  18.399  69.516  1.00 26.21           C  
+ATOM   2189  CE2 PHE A 944      20.781  18.539  69.678  1.00 30.12           C  
+ATOM   2190  CZ  PHE A 944      19.597  18.942  69.082  1.00 25.91           C  
+ATOM   2191  N   SER A 945      19.532  15.027  75.459  1.00 32.00           N  
+ATOM   2192  CA  SER A 945      19.027  14.020  76.389  1.00 34.64           C  
+ATOM   2193  C   SER A 945      17.989  14.623  77.342  1.00 35.94           C  
+ATOM   2194  O   SER A 945      16.975  13.992  77.616  1.00 40.02           O  
+ATOM   2195  CB  SER A 945      20.150  13.365  77.177  1.00 23.33           C  
+ATOM   2196  OG  SER A 945      19.937  11.977  77.248  1.00 58.22           O  
+ATOM   2197  N   LYS A 946      18.247  15.833  77.850  1.00 37.03           N  
+ATOM   2198  CA  LYS A 946      17.310  16.518  78.758  1.00 32.11           C  
+ATOM   2199  C   LYS A 946      15.985  16.725  78.029  1.00 35.11           C  
+ATOM   2200  O   LYS A 946      14.945  16.394  78.556  1.00 45.42           O  
+ATOM   2201  CB  LYS A 946      17.836  17.890  79.192  1.00 29.76           C  
+ATOM   2202  CG  LYS A 946      19.123  17.913  80.016  1.00 36.53           C  
+ATOM   2203  CD  LYS A 946      19.429  19.361  80.407  1.00 41.91           C  
+ATOM   2204  CE  LYS A 946      20.719  19.533  81.173  1.00 70.01           C  
+ATOM   2205  NZ  LYS A 946      21.235  20.938  81.036  1.00 67.11           N  
+ATOM   2206  N   MET A 947      16.040  17.250  76.805  1.00 31.98           N  
+ATOM   2207  CA  MET A 947      14.850  17.472  75.994  1.00 33.38           C  
+ATOM   2208  C   MET A 947      14.133  16.168  75.714  1.00 37.66           C  
+ATOM   2209  O   MET A 947      12.928  16.142  75.542  1.00 43.14           O  
+ATOM   2210  CB  MET A 947      15.213  18.100  74.639  1.00 27.03           C  
+ATOM   2211  CG  MET A 947      15.830  19.490  74.725  1.00 26.82           C  
+ATOM   2212  SD  MET A 947      16.241  20.172  73.148  1.00 42.66           S  
+ATOM   2213  CE  MET A 947      16.471  21.663  73.619  1.00 27.60           C  
+ATOM   2214  N   ALA A 948      14.874  15.079  75.615  1.00 40.01           N  
+ATOM   2215  CA  ALA A 948      14.223  13.812  75.319  1.00 42.39           C  
+ATOM   2216  C   ALA A 948      13.339  13.324  76.461  1.00 42.96           C  
+ATOM   2217  O   ALA A 948      12.431  12.534  76.234  1.00 42.41           O  
+ATOM   2218  CB  ALA A 948      15.245  12.759  74.944  1.00 38.29           C  
+ATOM   2219  N   ARG A 949      13.589  13.814  77.673  1.00 42.09           N  
+ATOM   2220  CA  ARG A 949      12.806  13.409  78.839  1.00 47.73           C  
+ATOM   2221  C   ARG A 949      11.431  14.074  78.847  1.00 50.58           C  
+ATOM   2222  O   ARG A 949      10.515  13.617  79.536  1.00 51.13           O  
+ATOM   2223  CB  ARG A 949      13.547  13.738  80.138  1.00 49.42           C  
+ATOM   2224  CG  ARG A 949      14.915  13.105  80.262  1.00 63.41           C  
+ATOM   2225  CD  ARG A 949      15.643  13.621  81.489  1.00 71.71           C  
+ATOM   2226  NE  ARG A 949      15.167  12.973  82.704  1.00 89.72           N  
+ATOM   2227  CZ  ARG A 949      15.696  11.865  83.216  1.00100.01           C  
+ATOM   2228  NH1 ARG A 949      16.727  11.278  82.617  1.00 83.06           N  
+ATOM   2229  NH2 ARG A 949      15.202  11.351  84.336  1.00 95.80           N  
+ATOM   2230  N   ASP A 950      11.286  15.132  78.052  1.00 43.83           N  
+ATOM   2231  CA  ASP A 950      10.025  15.859  77.960  1.00 42.05           C  
+ATOM   2232  C   ASP A 950       9.888  16.435  76.560  1.00 39.84           C  
+ATOM   2233  O   ASP A 950       9.825  17.652  76.389  1.00 39.55           O  
+ATOM   2234  CB  ASP A 950      10.005  16.983  78.998  1.00 51.48           C  
+ATOM   2235  CG  ASP A 950       8.639  17.615  79.156  1.00 58.95           C  
+ATOM   2236  OD1 ASP A 950       7.624  16.976  78.793  1.00 55.22           O  
+ATOM   2237  OD2 ASP A 950       8.589  18.759  79.655  1.00 62.28           O  
+ATOM   2238  N   PRO A 951       9.739  15.551  75.551  1.00 40.81           N  
+ATOM   2239  CA  PRO A 951       9.599  15.784  74.103  1.00 36.20           C  
+ATOM   2240  C   PRO A 951       8.714  16.936  73.658  1.00 37.25           C  
+ATOM   2241  O   PRO A 951       9.136  17.804  72.904  1.00 45.03           O  
+ATOM   2242  CB  PRO A 951       9.006  14.466  73.591  1.00 38.69           C  
+ATOM   2243  CG  PRO A 951       9.428  13.443  74.585  1.00 30.83           C  
+ATOM   2244  CD  PRO A 951       9.386  14.157  75.897  1.00 30.56           C  
+ATOM   2245  N   GLN A 952       7.462  16.904  74.098  1.00 48.37           N  
+ATOM   2246  CA  GLN A 952       6.474  17.902  73.714  1.00 47.07           C  
+ATOM   2247  C   GLN A 952       6.749  19.343  74.138  1.00 44.39           C  
+ATOM   2248  O   GLN A 952       6.193  20.273  73.559  1.00 49.87           O  
+ATOM   2249  CB  GLN A 952       5.099  17.426  74.141  1.00 58.06           C  
+ATOM   2250  CG  GLN A 952       4.902  15.952  73.801  1.00 64.13           C  
+ATOM   2251  CD  GLN A 952       3.465  15.569  73.547  1.00 69.01           C  
+ATOM   2252  OE1 GLN A 952       3.191  14.495  73.009  1.00 72.48           O  
+ATOM   2253  NE2 GLN A 952       2.533  16.442  73.929  1.00 77.08           N  
+ATOM   2254  N   ARG A 953       7.642  19.536  75.103  1.00 38.38           N  
+ATOM   2255  CA  ARG A 953       8.006  20.885  75.526  1.00 41.33           C  
+ATOM   2256  C   ARG A 953       8.999  21.472  74.539  1.00 46.11           C  
+ATOM   2257  O   ARG A 953       9.222  22.690  74.520  1.00 41.69           O  
+ATOM   2258  CB  ARG A 953       8.656  20.859  76.913  1.00 42.06           C  
+ATOM   2259  CG  ARG A 953       9.232  22.194  77.380  1.00 40.58           C  
+ATOM   2260  CD  ARG A 953       9.817  22.082  78.784  1.00 45.08           C  
+ATOM   2261  NE  ARG A 953      10.380  23.346  79.259  1.00 54.96           N  
+ATOM   2262  CZ  ARG A 953      10.877  23.539  80.480  1.00 53.15           C  
+ATOM   2263  NH1 ARG A 953      10.872  22.559  81.373  1.00 54.51           N  
+ATOM   2264  NH2 ARG A 953      11.461  24.687  80.782  1.00 56.52           N  
+ATOM   2265  N   TYR A 954       9.595  20.604  73.717  1.00 45.84           N  
+ATOM   2266  CA  TYR A 954      10.605  21.050  72.768  1.00 45.23           C  
+ATOM   2267  C   TYR A 954      10.288  20.963  71.285  1.00 42.43           C  
+ATOM   2268  O   TYR A 954      10.906  21.671  70.509  1.00 40.53           O  
+ATOM   2269  CB  TYR A 954      11.936  20.393  73.097  1.00 41.53           C  
+ATOM   2270  CG  TYR A 954      12.363  20.693  74.503  1.00 32.06           C  
+ATOM   2271  CD1 TYR A 954      12.926  21.926  74.837  1.00 36.24           C  
+ATOM   2272  CD2 TYR A 954      12.170  19.763  75.507  1.00 33.08           C  
+ATOM   2273  CE1 TYR A 954      13.286  22.217  76.148  1.00 48.55           C  
+ATOM   2274  CE2 TYR A 954      12.515  20.041  76.822  1.00 30.78           C  
+ATOM   2275  CZ  TYR A 954      13.076  21.269  77.141  1.00 48.37           C  
+ATOM   2276  OH  TYR A 954      13.429  21.530  78.454  1.00 43.57           O  
+ATOM   2277  N   LEU A 955       9.380  20.071  70.885  1.00 36.81           N  
+ATOM   2278  CA  LEU A 955       8.962  19.977  69.478  1.00 44.26           C  
+ATOM   2279  C   LEU A 955       7.430  19.979  69.438  1.00 47.79           C  
+ATOM   2280  O   LEU A 955       6.788  19.266  70.208  1.00 53.16           O  
+ATOM   2281  CB  LEU A 955       9.513  18.710  68.808  1.00 44.08           C  
+ATOM   2282  CG  LEU A 955      11.042  18.649  68.728  1.00 45.99           C  
+ATOM   2283  CD1 LEU A 955      11.513  17.281  68.294  1.00 37.54           C  
+ATOM   2284  CD2 LEU A 955      11.549  19.735  67.798  1.00 31.30           C  
+ATOM   2285  N   VAL A 956       6.836  20.779  68.560  1.00 45.47           N  
+ATOM   2286  CA  VAL A 956       5.375  20.832  68.486  1.00 52.78           C  
+ATOM   2287  C   VAL A 956       4.863  20.158  67.203  1.00 53.17           C  
+ATOM   2288  O   VAL A 956       4.915  20.717  66.101  1.00 55.14           O  
+ATOM   2289  CB  VAL A 956       4.854  22.303  68.681  1.00 53.97           C  
+ATOM   2290  CG1 VAL A 956       5.584  22.941  69.856  1.00 45.35           C  
+ATOM   2291  CG2 VAL A 956       5.101  23.162  67.451  1.00 75.38           C  
+ATOM   2292  N   ILE A 957       4.401  18.924  67.343  1.00 56.03           N  
+ATOM   2293  CA  ILE A 957       3.944  18.169  66.179  1.00 57.87           C  
+ATOM   2294  C   ILE A 957       2.466  17.847  66.285  1.00 66.18           C  
+ATOM   2295  O   ILE A 957       2.038  17.212  67.258  1.00 66.05           O  
+ATOM   2296  CB  ILE A 957       4.765  16.874  66.035  1.00 53.85           C  
+ATOM   2297  CG1 ILE A 957       6.244  17.213  65.849  1.00 54.12           C  
+ATOM   2298  CG2 ILE A 957       4.263  16.042  64.873  1.00 54.82           C  
+ATOM   2299  CD1 ILE A 957       7.150  16.007  66.038  1.00 51.62           C  
+ATOM   2300  N   GLN A 958       1.709  18.223  65.249  1.00 71.66           N  
+ATOM   2301  CA  GLN A 958       0.257  18.028  65.226  1.00 73.95           C  
+ATOM   2302  C   GLN A 958      -0.255  16.757  65.881  1.00 73.71           C  
+ATOM   2303  O   GLN A 958      -0.976  16.824  66.878  1.00 85.17           O  
+ATOM   2304  CB  GLN A 958      -0.311  18.205  63.814  1.00 86.01           C  
+ATOM   2305  CG  GLN A 958      -0.287  19.673  63.331  1.00 96.70           C  
+ATOM   2306  CD  GLN A 958      -0.889  19.883  61.938  1.00109.06           C  
+ATOM   2307  OE1 GLN A 958      -1.102  21.024  61.501  1.00 92.87           O  
+ATOM   2308  NE2 GLN A 958      -1.157  18.782  61.234  1.00108.78           N  
+ATOM   2309  N   GLY A 959       0.175  15.606  65.394  1.00 67.82           N  
+ATOM   2310  CA  GLY A 959      -0.286  14.372  65.993  1.00 75.47           C  
+ATOM   2311  C   GLY A 959       0.354  14.001  67.311  1.00 83.33           C  
+ATOM   2312  O   GLY A 959      -0.306  13.944  68.348  1.00 85.18           O  
+ATOM   2313  N   ASP A 960       1.659  13.769  67.258  1.00 91.00           N  
+ATOM   2314  CA  ASP A 960       2.460  13.364  68.408  1.00 97.35           C  
+ATOM   2315  C   ASP A 960       1.929  12.134  69.151  1.00104.78           C  
+ATOM   2316  O   ASP A 960       1.663  12.148  70.363  1.00105.25           O  
+ATOM   2317  CB  ASP A 960       2.754  14.536  69.337  1.00 88.07           C  
+ATOM   2318  CG  ASP A 960       4.243  14.778  69.480  1.00 82.75           C  
+ATOM   2319  OD1 ASP A 960       4.663  15.953  69.615  1.00 94.90           O  
+ATOM   2320  OD2 ASP A 960       4.991  13.776  69.441  1.00 44.80           O  
+ATOM   2321  N   GLU A 961       1.813  11.070  68.357  1.00110.50           N  
+ATOM   2322  CA  GLU A 961       1.346   9.741  68.738  1.00113.27           C  
+ATOM   2323  C   GLU A 961       1.223   9.033  67.376  1.00116.78           C  
+ATOM   2324  O   GLU A 961       2.233   8.581  66.814  1.00115.73           O  
+ATOM   2325  CB  GLU A 961      -0.007   9.818  69.456  0.00107.62           C  
+ATOM   2326  CG  GLU A 961      -0.443   8.523  70.136  0.00103.48           C  
+ATOM   2327  CD  GLU A 961      -1.365   7.680  69.274  0.00107.05           C  
+ATOM   2328  OE1 GLU A 961      -2.389   8.215  68.800  0.00103.70           O  
+ATOM   2329  OE2 GLU A 961      -1.070   6.483  69.077  0.00111.53           O  
+ATOM   2330  N   ARG A 962       0.014   9.028  66.808  1.00116.88           N  
+ATOM   2331  CA  ARG A 962      -0.230   8.407  65.500  1.00116.76           C  
+ATOM   2332  C   ARG A 962      -1.170   9.182  64.565  1.00116.92           C  
+ATOM   2333  O   ARG A 962      -0.910   9.277  63.358  1.00117.27           O  
+ATOM   2334  CB  ARG A 962      -0.771   6.982  65.655  0.00110.04           C  
+ATOM   2335  CG  ARG A 962       0.287   5.908  65.839  0.00112.94           C  
+ATOM   2336  CD  ARG A 962      -0.228   4.561  65.346  0.00104.53           C  
+ATOM   2337  NE  ARG A 962      -0.509   4.587  63.911  0.00110.32           N  
+ATOM   2338  CZ  ARG A 962      -1.144   3.627  63.244  0.00109.74           C  
+ATOM   2339  NH1 ARG A 962      -1.347   3.751  61.939  0.00111.50           N  
+ATOM   2340  NH2 ARG A 962      -1.581   2.546  63.876  0.00106.68           N  
+ATOM   2341  N   MET A 963      -2.247   9.735  65.129  1.00116.91           N  
+ATOM   2342  CA  MET A 963      -3.268  10.474  64.371  1.00115.26           C  
+ATOM   2343  C   MET A 963      -4.108   9.501  63.556  1.00115.17           C  
+ATOM   2344  O   MET A 963      -4.240   9.645  62.335  1.00114.82           O  
+ATOM   2345  CB  MET A 963      -2.650  11.521  63.434  0.00107.81           C  
+ATOM   2346  CG  MET A 963      -2.284  12.822  64.096  0.00109.34           C  
+ATOM   2347  SD  MET A 963      -1.739  14.074  62.916  0.00105.34           S  
+ATOM   2348  CE  MET A 963      -3.220  15.074  62.781  0.00108.60           C  
+ATOM   2349  N   HIS A 964      -4.647   8.496  64.241  1.00112.44           N  
+ATOM   2350  CA  HIS A 964      -5.470   7.475  63.606  1.00115.68           C  
+ATOM   2351  C   HIS A 964      -6.806   8.052  63.112  1.00116.16           C  
+ATOM   2352  O   HIS A 964      -7.013   8.227  61.906  1.00114.87           O  
+ATOM   2353  CB  HIS A 964      -5.725   6.329  64.593  1.00113.98           C  
+ATOM   2354  CG  HIS A 964      -5.734   4.971  63.957  1.00112.53           C  
+ATOM   2355  ND1 HIS A 964      -5.380   3.830  64.649  1.00113.68           N  
+ATOM   2356  CD2 HIS A 964      -6.032   4.572  62.699  1.00105.38           C  
+ATOM   2357  CE1 HIS A 964      -5.457   2.788  63.840  1.00114.57           C  
+ATOM   2358  NE2 HIS A 964      -5.850   3.209  62.651  1.00113.82           N  
+ATOM   2359  N   LEU A 977     -11.036   6.578  61.901  1.00 98.67           N  
+ATOM   2360  CA  LEU A 977     -12.096   6.763  60.910  1.00 97.99           C  
+ATOM   2361  C   LEU A 977     -11.702   7.833  59.892  1.00100.95           C  
+ATOM   2362  O   LEU A 977     -12.067   9.012  60.039  1.00100.25           O  
+ATOM   2363  CB  LEU A 977     -13.399   7.183  61.600  1.00105.55           C  
+ATOM   2364  CG  LEU A 977     -13.984   6.218  62.637  1.00111.80           C  
+ATOM   2365  CD1 LEU A 977     -15.169   6.866  63.378  1.00108.54           C  
+ATOM   2366  CD2 LEU A 977     -14.414   4.929  61.930  1.00109.36           C  
+ATOM   2367  N   MET A 978     -10.962   7.413  58.867  1.00102.70           N  
+ATOM   2368  CA  MET A 978     -10.504   8.315  57.817  1.00103.31           C  
+ATOM   2369  C   MET A 978     -11.650   9.145  57.237  1.00106.84           C  
+ATOM   2370  O   MET A 978     -12.444   8.661  56.414  1.00109.14           O  
+ATOM   2371  CB  MET A 978      -9.778   7.537  56.713  0.00100.10           C  
+ATOM   2372  CG  MET A 978      -8.293   7.385  56.958  0.00 98.27           C  
+ATOM   2373  SD  MET A 978      -7.570   5.997  56.069  0.00 98.15           S  
+ATOM   2374  CE  MET A 978      -7.350   6.699  54.437  0.00 96.91           C  
+ATOM   2375  N   ASP A 979     -11.720  10.400  57.681  1.00106.02           N  
+ATOM   2376  CA  ASP A 979     -12.744  11.335  57.231  1.00104.82           C  
+ATOM   2377  C   ASP A 979     -12.565  11.582  55.749  1.00106.55           C  
+ATOM   2378  O   ASP A 979     -13.533  11.544  54.977  1.00111.17           O  
+ATOM   2379  CB  ASP A 979     -12.606  12.675  57.961  1.00100.55           C  
+ATOM   2380  CG  ASP A 979     -12.518  12.517  59.463  1.00107.51           C  
+ATOM   2381  OD1 ASP A 979     -13.409  13.052  60.162  1.00107.84           O  
+ATOM   2382  OD2 ASP A 979     -11.546  11.879  59.938  1.00103.86           O  
+ATOM   2383  N   GLU A 980     -11.314  11.834  55.363  1.00104.79           N  
+ATOM   2384  CA  GLU A 980     -10.977  12.138  53.975  1.00104.15           C  
+ATOM   2385  C   GLU A 980     -11.654  13.478  53.594  1.00107.13           C  
+ATOM   2386  O   GLU A 980     -11.901  13.769  52.411  1.00105.70           O  
+ATOM   2387  CB  GLU A 980     -11.416  10.988  53.045  1.00 95.70           C  
+ATOM   2388  CG  GLU A 980     -10.265  10.243  52.348  1.00 86.65           C  
+ATOM   2389  CD  GLU A 980      -9.884  10.848  50.990  1.00 99.25           C  
+ATOM   2390  OE1 GLU A 980     -10.798  11.111  50.165  1.00 88.90           O  
+ATOM   2391  OE2 GLU A 980      -8.668  11.043  50.740  1.00100.15           O  
+ATOM   2392  N   GLU A 981     -11.939  14.284  54.623  1.00108.13           N  
+ATOM   2393  CA  GLU A 981     -12.582  15.594  54.474  1.00109.23           C  
+ATOM   2394  C   GLU A 981     -12.015  16.586  55.498  1.00109.07           C  
+ATOM   2395  O   GLU A 981     -11.388  16.190  56.488  1.00110.13           O  
+ATOM   2396  CB  GLU A 981     -14.106  15.483  54.675  1.00111.55           C  
+ATOM   2397  CG  GLU A 981     -14.828  14.476  53.763  1.00108.91           C  
+ATOM   2398  CD  GLU A 981     -14.838  14.889  52.290  1.00111.28           C  
+ATOM   2399  OE1 GLU A 981     -15.248  16.034  51.989  1.00113.42           O  
+ATOM   2400  OE2 GLU A 981     -14.446  14.063  51.434  1.00107.58           O  
+ATOM   2401  N   ASP A 982     -12.282  17.872  55.273  1.00106.21           N  
+ATOM   2402  CA  ASP A 982     -11.790  18.937  56.150  1.00101.89           C  
+ATOM   2403  C   ASP A 982     -12.920  19.459  57.050  1.00101.15           C  
+ATOM   2404  O   ASP A 982     -13.310  20.632  56.965  1.00 97.90           O  
+ATOM   2405  CB  ASP A 982     -11.207  20.084  55.301  1.00100.37           C  
+ATOM   2406  CG  ASP A 982     -10.352  19.582  54.120  1.00104.53           C  
+ATOM   2407  OD1 ASP A 982      -9.101  19.526  54.251  1.00 92.22           O  
+ATOM   2408  OD2 ASP A 982     -10.940  19.251  53.058  1.00 94.95           O  
+ATOM   2409  N   MET A 983     -13.411  18.600  57.944  1.00100.30           N  
+ATOM   2410  CA  MET A 983     -14.513  18.983  58.831  1.00 95.98           C  
+ATOM   2411  C   MET A 983     -14.442  18.547  60.291  1.00 89.83           C  
+ATOM   2412  O   MET A 983     -14.298  17.364  60.589  1.00 85.08           O  
+ATOM   2413  CB  MET A 983     -15.836  18.509  58.233  1.00 93.83           C  
+ATOM   2414  CG  MET A 983     -16.482  19.534  57.333  1.00 98.24           C  
+ATOM   2415  SD  MET A 983     -16.887  21.091  58.209  1.00115.20           S  
+ATOM   2416  CE  MET A 983     -17.448  20.486  59.827  1.00 75.13           C  
+ATOM   2417  N   ASP A 984     -14.630  19.503  61.197  1.00 89.69           N  
+ATOM   2418  CA  ASP A 984     -14.585  19.196  62.624  1.00 92.07           C  
+ATOM   2419  C   ASP A 984     -15.917  19.307  63.369  1.00 88.52           C  
+ATOM   2420  O   ASP A 984     -15.954  19.294  64.605  1.00 93.52           O  
+ATOM   2421  CB  ASP A 984     -13.462  19.980  63.334  1.00101.91           C  
+ATOM   2422  CG  ASP A 984     -13.486  21.471  63.026  1.00100.65           C  
+ATOM   2423  OD1 ASP A 984     -13.756  22.263  63.962  1.00 92.14           O  
+ATOM   2424  OD2 ASP A 984     -13.217  21.845  61.858  1.00 96.89           O  
+ATOM   2425  N   ASP A 985     -17.003  19.442  62.612  1.00 80.70           N  
+ATOM   2426  CA  ASP A 985     -18.350  19.482  63.184  1.00 73.66           C  
+ATOM   2427  C   ASP A 985     -19.064  18.162  62.828  1.00 66.19           C  
+ATOM   2428  O   ASP A 985     -20.287  18.042  62.888  1.00 57.52           O  
+ATOM   2429  CB  ASP A 985     -19.144  20.697  62.689  1.00 80.53           C  
+ATOM   2430  CG  ASP A 985     -18.979  21.918  63.593  1.00 85.08           C  
+ATOM   2431  OD1 ASP A 985     -19.469  21.897  64.742  1.00 84.24           O  
+ATOM   2432  OD2 ASP A 985     -18.365  22.911  63.149  1.00113.46           O  
+ATOM   2433  N   VAL A 986     -18.270  17.171  62.444  1.00 60.54           N  
+ATOM   2434  CA  VAL A 986     -18.783  15.857  62.110  1.00 61.25           C  
+ATOM   2435  C   VAL A 986     -19.165  15.143  63.404  1.00 63.60           C  
+ATOM   2436  O   VAL A 986     -18.457  15.231  64.413  1.00 68.55           O  
+ATOM   2437  CB  VAL A 986     -17.728  15.022  61.328  1.00 56.02           C  
+ATOM   2438  CG1 VAL A 986     -16.358  15.187  61.944  1.00 72.01           C  
+ATOM   2439  CG2 VAL A 986     -18.114  13.549  61.314  1.00 56.88           C  
+ATOM   2440  N   VAL A 987     -20.316  14.485  63.389  1.00 57.43           N  
+ATOM   2441  CA  VAL A 987     -20.781  13.749  64.551  1.00 57.07           C  
+ATOM   2442  C   VAL A 987     -21.338  12.423  64.059  1.00 49.36           C  
+ATOM   2443  O   VAL A 987     -21.979  12.352  63.029  1.00 50.06           O  
+ATOM   2444  CB  VAL A 987     -21.826  14.558  65.384  1.00 62.51           C  
+ATOM   2445  CG1 VAL A 987     -23.176  14.602  64.699  1.00 72.99           C  
+ATOM   2446  CG2 VAL A 987     -21.950  13.973  66.764  1.00 68.30           C  
+ATOM   2447  N   ASP A 988     -21.030  11.357  64.768  1.00 51.01           N  
+ATOM   2448  CA  ASP A 988     -21.487  10.043  64.369  1.00 51.26           C  
+ATOM   2449  C   ASP A 988     -22.997   9.890  64.579  1.00 51.75           C  
+ATOM   2450  O   ASP A 988     -23.565  10.436  65.525  1.00 38.97           O  
+ATOM   2451  CB  ASP A 988     -20.704   8.991  65.148  1.00 64.52           C  
+ATOM   2452  CG  ASP A 988     -20.941   7.601  64.643  1.00 72.88           C  
+ATOM   2453  OD1 ASP A 988     -22.008   7.045  64.958  1.00 73.00           O  
+ATOM   2454  OD2 ASP A 988     -20.065   7.065  63.934  1.00 79.97           O  
+ATOM   2455  N   ALA A 989     -23.641   9.147  63.682  1.00 53.68           N  
+ATOM   2456  CA  ALA A 989     -25.078   8.923  63.748  1.00 54.78           C  
+ATOM   2457  C   ALA A 989     -25.592   8.400  65.086  1.00 53.06           C  
+ATOM   2458  O   ALA A 989     -26.638   8.838  65.550  1.00 40.10           O  
+ATOM   2459  CB  ALA A 989     -25.523   8.009  62.625  1.00 71.08           C  
+ATOM   2460  N   ASP A 990     -24.909   7.451  65.714  1.00 56.09           N  
+ATOM   2461  CA  ASP A 990     -25.451   7.012  66.988  1.00 65.16           C  
+ATOM   2462  C   ASP A 990     -25.320   7.992  68.161  1.00 65.80           C  
+ATOM   2463  O   ASP A 990     -25.670   7.672  69.293  1.00 75.94           O  
+ATOM   2464  CB  ASP A 990     -25.102   5.557  67.342  1.00 65.84           C  
+ATOM   2465  CG  ASP A 990     -23.709   5.159  66.952  1.00 83.21           C  
+ATOM   2466  OD1 ASP A 990     -22.766   5.908  67.269  1.00105.89           O  
+ATOM   2467  OD2 ASP A 990     -23.555   4.061  66.372  1.00 50.58           O  
+ATOM   2468  N   GLU A 991     -24.898   9.218  67.854  1.00 68.05           N  
+ATOM   2469  CA  GLU A 991     -24.777  10.297  68.836  1.00 61.35           C  
+ATOM   2470  C   GLU A 991     -25.731  11.436  68.462  1.00 63.63           C  
+ATOM   2471  O   GLU A 991     -25.868  12.407  69.196  1.00 70.81           O  
+ATOM   2472  CB  GLU A 991     -23.355  10.840  68.920  1.00 69.24           C  
+ATOM   2473  CG  GLU A 991     -22.473  10.174  69.951  1.00 75.90           C  
+ATOM   2474  CD  GLU A 991     -21.844   8.900  69.449  1.00 87.85           C  
+ATOM   2475  OE1 GLU A 991     -22.203   7.816  69.952  1.00 86.52           O  
+ATOM   2476  OE2 GLU A 991     -20.981   8.983  68.553  1.00101.63           O  
+ATOM   2477  N   TYR A 992     -26.373  11.323  67.303  1.00 64.88           N  
+ATOM   2478  CA  TYR A 992     -27.326  12.326  66.853  1.00 66.42           C  
+ATOM   2479  C   TYR A 992     -28.730  11.752  67.046  1.00 71.04           C  
+ATOM   2480  O   TYR A 992     -29.200  10.939  66.238  1.00 72.58           O  
+ATOM   2481  CB  TYR A 992     -27.088  12.685  65.388  1.00 59.44           C  
+ATOM   2482  CG  TYR A 992     -27.873  13.890  64.961  1.00 51.29           C  
+ATOM   2483  CD1 TYR A 992     -29.020  13.766  64.189  1.00 48.15           C  
+ATOM   2484  CD2 TYR A 992     -27.513  15.150  65.402  1.00 67.10           C  
+ATOM   2485  CE1 TYR A 992     -29.792  14.874  63.881  1.00 59.76           C  
+ATOM   2486  CE2 TYR A 992     -28.275  16.264  65.099  1.00 68.08           C  
+ATOM   2487  CZ  TYR A 992     -29.411  16.123  64.345  1.00 57.75           C  
+ATOM   2488  OH  TYR A 992     -30.170  17.240  64.079  1.00 84.13           O  
+ATOM   2489  N   LEU A 993     -29.392  12.186  68.119  1.00 76.45           N  
+ATOM   2490  CA  LEU A 993     -30.731  11.698  68.469  1.00 77.52           C  
+ATOM   2491  C   LEU A 993     -31.900  12.635  68.142  1.00 81.92           C  
+ATOM   2492  O   LEU A 993     -31.709  13.828  67.872  1.00 80.06           O  
+ATOM   2493  CB  LEU A 993     -30.756  11.271  69.945  1.00 70.42           C  
+ATOM   2494  CG  LEU A 993     -29.680  10.238  70.327  1.00 72.50           C  
+ATOM   2495  CD1 LEU A 993     -29.626  10.037  71.805  1.00 68.90           C  
+ATOM   2496  CD2 LEU A 993     -29.940   8.920  69.632  1.00 76.90           C  
+ATOM   2497  N   ILE A 994     -33.105  12.061  68.191  1.00 88.40           N  
+ATOM   2498  CA  ILE A 994     -34.387  12.712  67.878  1.00 89.65           C  
+ATOM   2499  C   ILE A 994     -34.482  14.259  67.897  1.00 97.21           C  
+ATOM   2500  O   ILE A 994     -34.504  14.892  68.960  1.00104.38           O  
+ATOM   2501  CB  ILE A 994     -35.581  12.038  68.674  0.00 85.68           C  
+ATOM   2502  CG1 ILE A 994     -35.951  12.802  69.950  0.00 82.73           C  
+ATOM   2503  CG2 ILE A 994     -35.222  10.605  69.055  0.00 78.46           C  
+ATOM   2504  CD1 ILE A 994     -37.197  13.669  69.803  0.00 89.21           C  
+ATOM   2505  N   PRO A 995     -34.413  14.890  66.708  1.00 96.35           N  
+ATOM   2506  CA  PRO A 995     -34.506  16.354  66.608  1.00 96.33           C  
+ATOM   2507  C   PRO A 995     -35.968  16.813  66.584  1.00 96.89           C  
+ATOM   2508  O   PRO A 995     -36.887  16.005  66.390  1.00 98.69           O  
+ATOM   2509  CB  PRO A 995     -33.814  16.651  65.275  1.00 97.60           C  
+ATOM   2510  CG  PRO A 995     -34.154  15.455  64.454  1.00 95.62           C  
+ATOM   2511  CD  PRO A 995     -33.927  14.315  65.439  1.00 98.63           C  
+TER    2512      PRO A 995                                                      
+HETATM 2513  C1  AQ4 A 999      29.552  -1.989  53.496  1.00 82.82           C  
+HETATM 2514  C2  AQ4 A 999      28.841  -1.022  53.432  1.00 79.21           C  
+HETATM 2515  C3  AQ4 A 999      27.989   0.094  53.366  1.00 77.10           C  
+HETATM 2516  C4  AQ4 A 999      26.606  -0.119  53.323  1.00 78.64           C  
+HETATM 2517  C5  AQ4 A 999      25.725   0.972  53.258  1.00 75.72           C  
+HETATM 2518  N1  AQ4 A 999      24.289   0.712  53.215  1.00 63.33           N  
+HETATM 2519  C6  AQ4 A 999      23.410  -0.217  53.908  1.00 56.92           C  
+HETATM 2520  C7  AQ4 A 999      22.037  -0.309  53.572  1.00 52.23           C  
+HETATM 2521  C8  AQ4 A 999      21.501   0.476  52.546  1.00 48.18           C  
+HETATM 2522  C9  AQ4 A 999      20.143   0.376  52.218  1.00 52.11           C  
+HETATM 2523  O1  AQ4 A 999      19.589   1.220  51.120  1.00 82.48           O  
+HETATM 2524  C10 AQ4 A 999      20.550   1.362  50.041  1.00 83.98           C  
+HETATM 2525  C11 AQ4 A 999      20.235   2.645  49.262  1.00 91.80           C  
+HETATM 2526  O2  AQ4 A 999      18.990   2.485  48.543  1.00 96.57           O  
+HETATM 2527  C12 AQ4 A 999      17.712   2.618  49.399  1.00 88.53           C  
+HETATM 2528  C13 AQ4 A 999      19.301  -0.535  52.923  1.00 52.73           C  
+HETATM 2529  O3  AQ4 A 999      17.828  -0.679  52.597  1.00 83.95           O  
+HETATM 2530  C14 AQ4 A 999      17.227   0.601  52.220  1.00 98.66           C  
+HETATM 2531  C15 AQ4 A 999      15.703   0.494  52.066  1.00102.19           C  
+HETATM 2532  O4  AQ4 A 999      15.108   0.167  53.335  1.00 79.31           O  
+HETATM 2533  C16 AQ4 A 999      13.843  -0.695  53.221  1.00 92.17           C  
+HETATM 2534  C17 AQ4 A 999      19.845  -1.318  53.942  1.00 59.83           C  
+HETATM 2535  C18 AQ4 A 999      21.199  -1.222  54.264  1.00 53.51           C  
+HETATM 2536  N2  AQ4 A 999      21.747  -2.039  55.319  1.00 50.53           N  
+HETATM 2537  C19 AQ4 A 999      23.117  -1.934  55.642  1.00 65.28           C  
+HETATM 2538  N3  AQ4 A 999      23.943  -1.023  54.940  1.00 44.57           N  
+HETATM 2539  C20 AQ4 A 999      26.234   2.292  53.236  1.00 77.38           C  
+HETATM 2540  C21 AQ4 A 999      27.625   2.509  53.279  1.00 70.00           C  
+HETATM 2541  C22 AQ4 A 999      28.508   1.410  53.344  1.00 71.32           C  
+HETATM 2542  O   HOH A   1      32.732  20.638  57.020  1.00 49.98           O  
+HETATM 2543  O   HOH A   2      32.882   9.700  55.317  1.00 47.81           O  
+HETATM 2544  O   HOH A   3      27.504  -1.066  65.946  1.00 58.30           O  
+HETATM 2545  O   HOH A   4      25.698  20.050  48.908  1.00 59.48           O  
+HETATM 2546  O   HOH A   5      23.562  36.184  60.778  1.00 53.83           O  
+HETATM 2547  O   HOH A   6      33.892  18.248  58.731  1.00 38.37           O  
+HETATM 2548  O   HOH A   7      10.334  25.073  74.952  1.00 39.68           O  
+HETATM 2549  O   HOH A   8      27.903  24.827  53.992  1.00 43.63           O  
+HETATM 2550  O   HOH A   9      18.941  -2.491  68.885  1.00 52.41           O  
+HETATM 2551  O   HOH A  10      25.979  -0.494  56.755  1.00 80.23           O  
+HETATM 2552  O   HOH A  11      28.366  -5.361  64.274  1.00 82.86           O  
+HETATM 2553  O   HOH A  12      22.492  -8.282  61.348  1.00 38.44           O  
+HETATM 2554  O   HOH A  13      13.333  18.933  80.447  1.00 54.89           O  
+HETATM 2555  O   HOH A  14      25.457  24.140  55.088  1.00 50.80           O  
+HETATM 2556  O   HOH A  15      18.280  33.231  57.782  1.00 78.01           O  
+HETATM 2557  O   HOH A  16      30.582  -0.221  65.350  1.00 40.66           O  
+HETATM 2558  O   HOH A  17      32.987  24.038  72.100  1.00 63.73           O  
+HETATM 2559  O   HOH A  18       9.251  21.560  60.778  1.00 45.40           O  
+HETATM 2560  O   HOH A  19     -21.187   4.756  70.193  1.00 66.85           O  
+HETATM 2561  O   HOH A  20      18.877  25.444  74.214  1.00 60.04           O  
+CONECT 2513 2514                                                                
+CONECT 2514 2513 2515                                                           
+CONECT 2515 2514 2516 2541                                                      
+CONECT 2516 2515 2517                                                           
+CONECT 2517 2516 2518 2539                                                      
+CONECT 2518 2517 2519                                                           
+CONECT 2519 2518 2520 2538                                                      
+CONECT 2520 2519 2521 2535                                                      
+CONECT 2521 2520 2522                                                           
+CONECT 2522 2521 2523 2528                                                      
+CONECT 2523 2522 2524                                                           
+CONECT 2524 2523 2525                                                           
+CONECT 2525 2524 2526                                                           
+CONECT 2526 2525 2527                                                           
+CONECT 2527 2526                                                                
+CONECT 2528 2522 2529 2534                                                      
+CONECT 2529 2528 2530                                                           
+CONECT 2530 2529 2531                                                           
+CONECT 2531 2530 2532                                                           
+CONECT 2532 2531 2533                                                           
+CONECT 2533 2532                                                                
+CONECT 2534 2528 2535                                                           
+CONECT 2535 2520 2534 2536                                                      
+CONECT 2536 2535 2537                                                           
+CONECT 2537 2536 2538                                                           
+CONECT 2538 2519 2537                                                           
+CONECT 2539 2517 2540                                                           
+CONECT 2540 2539 2541                                                           
+CONECT 2541 2515 2540                                                           
+MASTER      416    0    1   15   11    0    4    6 2546    1   29   26          
+END                                                                             

--- a/nim-skills/evo2-nim/evals/config.yml
+++ b/nim-skills/evo2-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/evo2-nim/evals/evals.json
+++ b/nim-skills/evo2-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to use Evo 2 from the hosted NVIDIA API to extend this DNA promoter-like sequence: ACTGACTGACTGACTG. Generate 64 bases, keep the request reproducible for development, and save the generated sequence so I can inspect it later.",
-      "expected_output": "A Python script that calls the hosted Evo 2 generation endpoint with Bearer auth, uses exact Evo2 request fields, validates/saves the generated DNA sequence as JSON and FASTA, and reports elapsed timing.",
+      "prompt": "I want to use Evo 2 from the hosted NVIDIA API to extend this DNA promoter-like sequence: ACTGACTGACTGACTG. Generate 64 bases, keep the request reproducible for development, and save the generated sequence so I can inspect it later. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted Evo 2 generation request with Bearer auth and exact request fields, plus actual response-derived DNA, sampled probabilities, elapsed timing, and saved JSON and FASTA artifacts.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived DNA, elapsed timing, and saved artifact paths"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted Evo2 generation endpoint",
@@ -38,7 +43,10 @@
           "check": "Script writes a .json file and a .fa or .fasta file"
         }
       ]
-    },
+    }
+  ],
+  "todo": "Waiting on local Docker setup in Harbor before enabling the deferred evals below.",
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "Run Evo 2 locally with Docker and then do a quick DNA generation smoke test against localhost. My NGC_API_KEY and LOCAL_NIM_CACHE are already configured; use the default model unless I set NIM_VARIANT=7b. Please warn me if my GPU is not compatible.",
@@ -112,44 +120,6 @@
           "id": "finite-summary",
           "description": "Checks or reports tensor shape, dtype, and finite numeric values",
           "check": "Script reports 'shape' and 'dtype' and checks 'isfinite' or prints numeric summaries"
-        }
-      ]
-    },
-    {
-      "id": "4",
-      "prompt": "Help me build a small validation script for Evo 2 outputs. It should run a hosted generation request with sampled probabilities, save artifacts, and warn me if the DNA looks low-complexity, has extreme GC, or contains unexpected ambiguous bases.",
-      "expected_output": "A hosted Evo2 validation script that calls the generation endpoint, saves request/response and FASTA artifacts, computes DNA metrics, validates probabilities and timing, and distinguishes warnings from hard failures.",
-      "files": [],
-      "assertions": [
-        {
-          "id": "hosted-endpoint-url",
-          "description": "Uses the correct hosted Evo2 generation endpoint",
-          "check": "Script contains 'https://health.api.nvidia.com/v1/biology/arc/evo2-40b/generate'"
-        },
-        {
-          "id": "sampled-probs-request",
-          "description": "Requests sampled probabilities with exact field name",
-          "check": "Script sets 'enable_sampled_probs' to True or true"
-        },
-        {
-          "id": "artifact-saving",
-          "description": "Saves request, response, FASTA, and metrics artifacts",
-          "check": "Script writes request JSON, response JSON, a .fa or .fasta file, and sequence metrics JSON"
-        },
-        {
-          "id": "probability-validation",
-          "description": "Validates sampled_probs as finite probabilities",
-          "check": "Script checks 'sampled_probs' values are numeric and between 0 and 1"
-        },
-        {
-          "id": "dna-quality-warnings",
-          "description": "Computes GC, low-complexity or homopolymer warnings",
-          "check": "Script calculates GC content and checks low complexity or homopolymer runs"
-        },
-        {
-          "id": "hard-vs-warning",
-          "description": "Distinguishes invalid schema/alphabet failures from scientific quality warnings",
-          "check": "Script separates hard failure conditions from warnings such as extreme GC or low complexity"
         }
       ]
     }

--- a/nim-skills/genmol-nim/evals/config.yml
+++ b/nim-skills/genmol-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/genmol-nim/evals/evals.json
+++ b/nim-skills/genmol-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to generate 20 drug-like molecules from scratch using GenMol. No scaffold — just generate novel molecules and rank them by drug-likeness. Use the hosted NVIDIA API. My NGC_API_KEY is already set in my environment.",
-      "expected_output": "A working Python script that calls the hosted GenMol endpoint with a masked SAFE input for de novo generation, requests 20 molecules with QED scoring, parses the response, and prints the results ranked by score.",
+      "prompt": "I want to generate 20 drug-like molecules from scratch using GenMol. No scaffold — just generate novel molecules and rank them by drug-likeness. Use the hosted NVIDIA API. My NGC_API_KEY is already set in my environment. Create and execute the request now, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted GenMol request with a masked SAFE input for de novo generation and QED scoring, plus at least 20 actual returned molecules saved and reported in score-ranked order.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived molecules, scores, and saved artifact paths"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted endpoint URL",
@@ -38,7 +43,9 @@
           "check": "Script accesses result['molecules'] or result[\"molecules\"] and prints or displays each molecule's score"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I have a pyrrolidinone scaffold (SMILES: C1CC(=O)NC1) that I want to decorate with new fragments to generate drug-like analogs. Generate 10 molecules using GenMol with QED scoring. Use the hosted API.",
@@ -78,6 +85,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me set up GenMol locally with Docker on my H100 machine. My NGC_API_KEY is set. Once it's running, do a quick de novo generation of 5 molecules.",
       "expected_output": "Step-by-step Docker setup commands that use shell env first and optional repo-root .env overrides, require NGC_API_KEY or NVIDIA_API_KEY fallback plus LOCAL_NIM_CACHE, run GenMol with correct flags, health-check it, then send a no-auth generation request to localhost:8000 producing 5 molecules.",

--- a/nim-skills/meta-skills/drug-discovery-pipeline/evals/config.yml
+++ b/nim-skills/meta-skills/drug-discovery-pipeline/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/meta-skills/drug-discovery-pipeline/evals/evals.json
+++ b/nim-skills/meta-skills/drug-discovery-pipeline/evals/evals.json
@@ -3,10 +3,17 @@
   "evals": [
     {
       "id": "eval-1-de-novo-hit-discovery",
-      "prompt": "I want to discover new drug-like molecules that could inhibit the EGFR kinase. I have the EGFR crystal structure as a PDB file. Can you run a pipeline that generates novel molecules, docks them to EGFR, and scores their binding affinity? I want to start from scratch — no known scaffold.",
-      "expected_output": "A script or sequence of steps that calls GenMol with a SAFE notation scaffold in the `smiles` field with string-typed temperature and noise, pipes the output SMILES into DiffDock with ligand_file_type set to 'txt', and then calls Boltz2 on top docking hits to predict binding affinity.",
-      "files": [],
+      "prompt": "I want to discover new drug-like molecules that could inhibit the EGFR kinase using the staged receptor at /workspace/input/egfr.pdb. Run the hosted pipeline now: generate novel molecules, dock them to EGFR, and score the top hits for binding affinity. Start from scratch with no known scaffold. For this smoke test, request 10 molecules from GenMol, dock the top 2 candidates with 1 pose each, and run Boltz2 affinity prediction for the best docked hit. Use NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual responses; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted GenMol to DiffDock to Boltz2 pipeline using the staged EGFR receptor and a bounded 10-to-2-to-1 smoke-test fan-out, correct SAFE/typing and ligand handoffs, plus saved artifacts and actual generated molecules, docking scores, and affinity results from all three services.",
+      "files": [
+        "evals/files/egfr.pdb"
+      ],
       "assertions": [
+        {
+          "id": "hosted-pipeline-executed",
+          "description": "Executes all hosted pipeline stages instead of only writing code",
+          "check": "Trajectory shows successful GenMol, DiffDock, and Boltz2 requests, and the final response reports actual response-derived molecules, docking scores, affinity values, and saved artifact paths"
+        },
         {
           "id": "a1-genmol-safe-notation",
           "description": "GenMol smiles field uses SAFE notation, not raw SMILES",
@@ -38,7 +45,9 @@
           "check": "The pipeline correctly reads the `smiles` field from each GenMol response molecule and passes that value as the `ligand` field in the DiffDock request, establishing the handoff between Step 1 and Step 2."
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "eval-2-lead-optimization-scaffold",
       "prompt": "I have a known lead compound with SMILES 'CC1=CC=C(C=C1)NC(=O)C2=CC=CC=C2' that partially inhibits CDK2. I want to generate analogs around this scaffold, dock them to CDK2, and get binding affinity predictions. My CDK2 PDB is ready. Can you help me set up this pipeline?",

--- a/nim-skills/meta-skills/drug-discovery-pipeline/evals/files/egfr.pdb
+++ b/nim-skills/meta-skills/drug-discovery-pipeline/evals/files/egfr.pdb
@@ -1,0 +1,3120 @@
+HEADER    TRANSFERASE                             17-JUN-02   1M17              
+TITLE     EPIDERMAL GROWTH FACTOR RECEPTOR TYROSINE KINASE DOMAIN WITH 4-       
+TITLE    2 ANILINOQUINAZOLINE INHIBITOR ERLOTINIB                               
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: EPIDERMAL GROWTH FACTOR RECEPTOR;                          
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: TYROSINE KINASE DOMAIN (RESIDUES 671-998);                 
+COMPND   5 SYNONYM: RECEPTOR PROTEIN-TYROSINE KINASE ERBB-1;                    
+COMPND   6 EC: 2.7.1.112;                                                       
+COMPND   7 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: EGFR;                                                          
+SOURCE   6 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE   7 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE   8 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE   9 EXPRESSION_SYSTEM_STRAIN: AUTOGRAPHICA CALIFORNICA/T.NICOPLUSIA;     
+SOURCE  10 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  11 EXPRESSION_SYSTEM_VECTOR_TYPE: PLASMID;                              
+SOURCE  12 EXPRESSION_SYSTEM_PLASMID: PVL1392                                   
+KEYWDS    TRANSFERASE, TYROSINE KINASE DOMAIN                                   
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    J.STAMOS,M.X.SLIWKOWSKI,C.EIGENBROT                                   
+REVDAT   4   14-FEB-24 1M17    1       REMARK SEQADV                            
+REVDAT   3   24-FEB-09 1M17    1       VERSN                                    
+REVDAT   2   25-FEB-03 1M17    1       JRNL                                     
+REVDAT   1   04-SEP-02 1M17    0                                                
+JRNL        AUTH   J.STAMOS,M.X.SLIWKOWSKI,C.EIGENBROT                          
+JRNL        TITL   STRUCTURE OF THE EPIDERMAL GROWTH FACTOR RECEPTOR KINASE     
+JRNL        TITL 2 DOMAIN ALONE AND IN COMPLEX WITH A 4-ANILINOQUINAZOLINE      
+JRNL        TITL 3 INHIBITOR.                                                   
+JRNL        REF    J.BIOL.CHEM.                  V. 277 46265 2002              
+JRNL        REFN                   ISSN 0021-9258                               
+JRNL        PMID   12196540                                                     
+JRNL        DOI    10.1074/JBC.M207135200                                       
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.60 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : X-PLOR 98.1                                          
+REMARK   3   AUTHORS     : BRUNGER                                              
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.60                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 30.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.200                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : 1000000.000                    
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : 0.0010                         
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 99.8                           
+REMARK   3   NUMBER OF REFLECTIONS             : 16628                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE            (WORKING SET) : 0.251                           
+REMARK   3   FREE R VALUE                     : 0.295                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 4.100                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 689                             
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : 0.011                           
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 10                           
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.60                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 2.69                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 97.80                        
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 1560                         
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.5850                       
+REMARK   3   BIN FREE R VALUE                    : 0.5770                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : 3.30                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : 53                           
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : 0.059                        
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 2497                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 29                                      
+REMARK   3   SOLVENT ATOMS            : 20                                      
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 88.50                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 70.40                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : 9.70000                                              
+REMARK   3    B22 (A**2) : 9.70000                                              
+REMARK   3    B33 (A**2) : 9.70000                                              
+REMARK   3    B12 (A**2) : 0.00000                                              
+REMARK   3    B13 (A**2) : 0.00000                                              
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.36                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.33                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : 5.00                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.41                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.41                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.011                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.500                           
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : 23.30                           
+REMARK   3   IMPROPER ANGLES        (DEGREES) : 1.810                           
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : RESTRAINED                                
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : 4.850 ; 2.000                
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : 7.220 ; 3.000                
+REMARK   3   SIDE-CHAIN BOND              (A**2) : 10.250; 4.000                
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : 13.670; 6.000                
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : MSI_XPLOR_PARHCSDX.PRO                         
+REMARK   3  PARAMETER FILE  2  : TAR.PAR                                        
+REMARK   3  PARAMETER FILE  3  : PARWAT.PRO                                     
+REMARK   3  PARAMETER FILE  4  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : MSI_XPLOR_TOPHCSDX.PRO                         
+REMARK   3  TOPOLOGY FILE  2   : TAR.TOP                                        
+REMARK   3  TOPOLOGY FILE  3   : TOPWAT.PRO                                     
+REMARK   3  TOPOLOGY FILE  4   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: BULK SOLVENT MODEL USED                   
+REMARK   4                                                                      
+REMARK   4 1M17 COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 01-JUL-02.                  
+REMARK 100 THE DEPOSITION ID IS D_1000016470.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 18-NOV-01                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 7.0                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : ALS                                
+REMARK 200  BEAMLINE                       : 5.0.1                              
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.00                               
+REMARK 200  MONOCHROMATOR                  : CURVED CRYSTAL MONOCHROMATOR       
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : ADSC QUANTUM 4                     
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO, TRUNCATE                    
+REMARK 200  DATA SCALING SOFTWARE          : CCP4 (TRUNCATE)                    
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 16628                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.600                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 30.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : -3.000                             
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 100.0                              
+REMARK 200  DATA REDUNDANCY                : 11.00                              
+REMARK 200  R MERGE                    (I) : 0.09300                            
+REMARK 200  R SYM                      (I) : 0.09300                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 27.0000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.60                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.69                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 100.0                              
+REMARK 200  DATA REDUNDANCY IN SHELL       : 10.50                              
+REMARK 200  R MERGE FOR SHELL          (I) : 0.99000                            
+REMARK 200  R SYM FOR SHELL            (I) : 0.99000                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 2.800                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: AMORE                                                 
+REMARK 200 STARTING MODEL: PDB ENTRY 1FGK; POLY ALANINE                         
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 65.35                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 3.55                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: TARTRATE, PH 7.0, VAPOR DIFFUSION,       
+REMARK 280  HANGING DROP, TEMPERATURE 292K                                      
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: I 2 3                            
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,-Y,Z                                                 
+REMARK 290       3555   -X,Y,-Z                                                 
+REMARK 290       4555   X,-Y,-Z                                                 
+REMARK 290       5555   Z,X,Y                                                   
+REMARK 290       6555   Z,-X,-Y                                                 
+REMARK 290       7555   -Z,-X,Y                                                 
+REMARK 290       8555   -Z,X,-Y                                                 
+REMARK 290       9555   Y,Z,X                                                   
+REMARK 290      10555   -Y,Z,-X                                                 
+REMARK 290      11555   Y,-Z,-X                                                 
+REMARK 290      12555   -Y,-Z,X                                                 
+REMARK 290      13555   X+1/2,Y+1/2,Z+1/2                                       
+REMARK 290      14555   -X+1/2,-Y+1/2,Z+1/2                                     
+REMARK 290      15555   -X+1/2,Y+1/2,-Z+1/2                                     
+REMARK 290      16555   X+1/2,-Y+1/2,-Z+1/2                                     
+REMARK 290      17555   Z+1/2,X+1/2,Y+1/2                                       
+REMARK 290      18555   Z+1/2,-X+1/2,-Y+1/2                                     
+REMARK 290      19555   -Z+1/2,-X+1/2,Y+1/2                                     
+REMARK 290      20555   -Z+1/2,X+1/2,-Y+1/2                                     
+REMARK 290      21555   Y+1/2,Z+1/2,X+1/2                                       
+REMARK 290      22555   -Y+1/2,Z+1/2,-X+1/2                                     
+REMARK 290      23555   Y+1/2,-Z+1/2,-X+1/2                                     
+REMARK 290      24555   -Y+1/2,-Z+1/2,X+1/2                                     
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   5  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY2   5  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   5  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   6  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY2   6 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   6  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   7  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY2   7 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   7  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   8  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY2   8  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   8  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY1   9  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   9  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY3   9  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  10  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  10  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY3  10 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  11  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  11  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY3  11 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  12  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  12  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY3  12  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY1  13  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  13  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  13  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY1  14 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  14  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  14  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY1  15 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  15  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  15  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY1  16  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  16  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  16  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY1  17  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY2  17  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  17  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  18  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY2  18 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  18  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  19  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY2  19 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  19  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  20  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY2  20  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY3  20  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  21  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  21  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY3  21  1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  22  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  22  0.000000  0.000000  1.000000       73.90000            
+REMARK 290   SMTRY3  22 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  23  0.000000  1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  23  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY3  23 -1.000000  0.000000  0.000000       73.90000            
+REMARK 290   SMTRY1  24  0.000000 -1.000000  0.000000       73.90000            
+REMARK 290   SMTRY2  24  0.000000  0.000000 -1.000000       73.90000            
+REMARK 290   SMTRY3  24  1.000000  0.000000  0.000000       73.90000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     GLY A   666                                                      
+REMARK 465     SER A   667                                                      
+REMARK 465     HIS A   668                                                      
+REMARK 465     MET A   669                                                      
+REMARK 465     ALA A   670                                                      
+REMARK 465     SER A   671                                                      
+REMARK 465     LEU A   965                                                      
+REMARK 465     PRO A   966                                                      
+REMARK 465     SER A   967                                                      
+REMARK 465     PRO A   968                                                      
+REMARK 465     THR A   969                                                      
+REMARK 465     ASP A   970                                                      
+REMARK 465     SER A   971                                                      
+REMARK 465     ASN A   972                                                      
+REMARK 465     PHE A   973                                                      
+REMARK 465     TYR A   974                                                      
+REMARK 465     ARG A   975                                                      
+REMARK 465     ALA A   976                                                      
+REMARK 465     GLN A   996                                                      
+REMARK 465     GLN A   997                                                      
+REMARK 465     GLY A   998                                                      
+REMARK 475                                                                      
+REMARK 475 ZERO OCCUPANCY RESIDUES                                              
+REMARK 475 THE FOLLOWING RESIDUES WERE MODELED WITH ZERO OCCUPANCY.             
+REMARK 475 THE LOCATION AND PROPERTIES OF THESE RESIDUES MAY NOT                
+REMARK 475 BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;                      
+REMARK 475 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE)          
+REMARK 475   M RES C  SSEQI                                                     
+REMARK 475     GLU A   725                                                      
+REMARK 480                                                                      
+REMARK 480 ZERO OCCUPANCY ATOM                                                  
+REMARK 480 THE FOLLOWING RESIDUES HAVE ATOMS MODELED WITH ZERO                  
+REMARK 480 OCCUPANCY. THE LOCATION AND PROPERTIES OF THESE ATOMS                
+REMARK 480 MAY NOT BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;              
+REMARK 480 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):         
+REMARK 480   M RES C SSEQI ATOMS                                                
+REMARK 480     LYS A  730   CG   CD   CE   NZ                                   
+REMARK 480     GLU A  961   CB   CG   CD   OE1  OE2                             
+REMARK 480     ARG A  962   CB   CG   CD   NE   CZ   NH1  NH2                   
+REMARK 480     MET A  963   CB   CG   SD   CE                                   
+REMARK 480     MET A  978   CB   CG   SD   CE                                   
+REMARK 480     ILE A  994   CB   CG1  CG2  CD1                                  
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    PRO A 951   C   -  N   -  CA  ANGL. DEV. =  10.6 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ILE A 691      -25.30   -142.93                                   
+REMARK 500    LYS A 692      142.35   -174.91                                   
+REMARK 500    SER A 696       64.50   -113.56                                   
+REMARK 500    PHE A 699      -18.20   -164.03                                   
+REMARK 500    GLU A 712     -179.24    -59.98                                   
+REMARK 500    THR A 759     -148.11   -104.25                                   
+REMARK 500    ASP A 783        2.15    -69.42                                   
+REMARK 500    HIS A 811      -70.63    -22.63                                   
+REMARK 500    ASP A 813       49.55   -155.75                                   
+REMARK 500    ASP A 831       80.70     54.04                                   
+REMARK 500    ASP A 831       82.14     54.44                                   
+REMARK 500    GLU A 848      -89.90   -131.32                                   
+REMARK 500    LYS A 851       19.04   -142.06                                   
+REMARK 500    ASP A 892      -38.02    -39.93                                   
+REMARK 500    ILE A 894      130.75    -26.87                                   
+REMARK 500    ALA A 896      -33.42    -36.08                                   
+REMARK 500    GLU A 961      -95.66    171.34                                   
+REMARK 500    ARG A 962      -41.08   -139.59                                   
+REMARK 500    MET A 963       53.16     72.86                                   
+REMARK 500    MET A 978      101.51    -50.90                                   
+REMARK 500    ASP A 982       65.59   -103.83                                   
+REMARK 500    ILE A 994       99.42    -19.72                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: MAIN CHAIN PLANARITY                                       
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING RESIDUES HAVE A PSEUDO PLANARITY                       
+REMARK 500 TORSION ANGLE, C(I) - CA(I) - N(I+1) - O(I), GREATER                 
+REMARK 500 10.0 DEGREES. (M=MODEL NUMBER; RES=RESIDUE NAME;                     
+REMARK 500 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;                            
+REMARK 500 I=INSERTION CODE).                                                   
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        ANGLE                                           
+REMARK 500    HIS A 811        -14.02                                           
+REMARK 500    ARG A 812        -10.67                                           
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE AQ4 A 999                 
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 1M14   RELATED DB: PDB                                   
+REMARK 900 APO-FORM EPIDERMAL GROWTH FACTOR RECEPTOR KINASE DOMAIN              
+DBREF  1M17 A  671   998  UNP    P00533   EGFR_HUMAN     695   1022             
+SEQADV 1M17 GLY A  666  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 SER A  667  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 HIS A  668  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 MET A  669  UNP  P00533              CLONING ARTIFACT               
+SEQADV 1M17 ALA A  670  UNP  P00533              CLONING ARTIFACT               
+SEQRES   1 A  333  GLY SER HIS MET ALA SER GLY GLU ALA PRO ASN GLN ALA          
+SEQRES   2 A  333  LEU LEU ARG ILE LEU LYS GLU THR GLU PHE LYS LYS ILE          
+SEQRES   3 A  333  LYS VAL LEU GLY SER GLY ALA PHE GLY THR VAL TYR LYS          
+SEQRES   4 A  333  GLY LEU TRP ILE PRO GLU GLY GLU LYS VAL LYS ILE PRO          
+SEQRES   5 A  333  VAL ALA ILE LYS GLU LEU ARG GLU ALA THR SER PRO LYS          
+SEQRES   6 A  333  ALA ASN LYS GLU ILE LEU ASP GLU ALA TYR VAL MET ALA          
+SEQRES   7 A  333  SER VAL ASP ASN PRO HIS VAL CYS ARG LEU LEU GLY ILE          
+SEQRES   8 A  333  CYS LEU THR SER THR VAL GLN LEU ILE THR GLN LEU MET          
+SEQRES   9 A  333  PRO PHE GLY CYS LEU LEU ASP TYR VAL ARG GLU HIS LYS          
+SEQRES  10 A  333  ASP ASN ILE GLY SER GLN TYR LEU LEU ASN TRP CYS VAL          
+SEQRES  11 A  333  GLN ILE ALA LYS GLY MET ASN TYR LEU GLU ASP ARG ARG          
+SEQRES  12 A  333  LEU VAL HIS ARG ASP LEU ALA ALA ARG ASN VAL LEU VAL          
+SEQRES  13 A  333  LYS THR PRO GLN HIS VAL LYS ILE THR ASP PHE GLY LEU          
+SEQRES  14 A  333  ALA LYS LEU LEU GLY ALA GLU GLU LYS GLU TYR HIS ALA          
+SEQRES  15 A  333  GLU GLY GLY LYS VAL PRO ILE LYS TRP MET ALA LEU GLU          
+SEQRES  16 A  333  SER ILE LEU HIS ARG ILE TYR THR HIS GLN SER ASP VAL          
+SEQRES  17 A  333  TRP SER TYR GLY VAL THR VAL TRP GLU LEU MET THR PHE          
+SEQRES  18 A  333  GLY SER LYS PRO TYR ASP GLY ILE PRO ALA SER GLU ILE          
+SEQRES  19 A  333  SER SER ILE LEU GLU LYS GLY GLU ARG LEU PRO GLN PRO          
+SEQRES  20 A  333  PRO ILE CYS THR ILE ASP VAL TYR MET ILE MET VAL LYS          
+SEQRES  21 A  333  CYS TRP MET ILE ASP ALA ASP SER ARG PRO LYS PHE ARG          
+SEQRES  22 A  333  GLU LEU ILE ILE GLU PHE SER LYS MET ALA ARG ASP PRO          
+SEQRES  23 A  333  GLN ARG TYR LEU VAL ILE GLN GLY ASP GLU ARG MET HIS          
+SEQRES  24 A  333  LEU PRO SER PRO THR ASP SER ASN PHE TYR ARG ALA LEU          
+SEQRES  25 A  333  MET ASP GLU GLU ASP MET ASP ASP VAL VAL ASP ALA ASP          
+SEQRES  26 A  333  GLU TYR LEU ILE PRO GLN GLN GLY                              
+HET    AQ4  A 999      29                                                       
+HETNAM     AQ4 [6,7-BIS(2-METHOXY-ETHOXY)QUINAZOLINE-4-YL]-(3-                  
+HETNAM   2 AQ4  ETHYNYLPHENYL)AMINE                                             
+HETSYN     AQ4 ERLOTINIB                                                        
+FORMUL   2  AQ4    C22 H23 N3 O4                                                
+FORMUL   3  HOH   *20(H2 O)                                                     
+HELIX    1   1 LYS A  684  THR A  686  5                                   3    
+HELIX    2   2 SER A  728  ALA A  743  1                                  16    
+HELIX    3   3 CYS A  773  GLU A  780  1                                   8    
+HELIX    4   4 HIS A  781  ILE A  785  5                                   5    
+HELIX    5   5 GLY A  786  ARG A  807  1                                  22    
+HELIX    6   6 ALA A  815  ARG A  817  5                                   3    
+HELIX    7   7 PRO A  853  MET A  857  5                                   5    
+HELIX    8   8 ALA A  858  ARG A  865  1                                   8    
+HELIX    9   9 THR A  868  THR A  885  1                                  18    
+HELIX   10  10 PRO A  895  LYS A  905  1                                  11    
+HELIX   11  11 THR A  916  CYS A  926  1                                  11    
+HELIX   12  12 ASP A  930  ARG A  934  5                                   5    
+HELIX   13  13 LYS A  936  ARG A  949  1                                  14    
+HELIX   14  14 ASP A  950  TYR A  954  5                                   5    
+HELIX   15  15 ASP A  988  TYR A  992  5                                   5    
+SHEET    1   A 5 PHE A 688  GLY A 695  0                                        
+SHEET    2   A 5 THR A 701  TRP A 707 -1  O  LEU A 706   N  LYS A 689           
+SHEET    3   A 5 ILE A 716  GLU A 722 -1  O  ILE A 720   N  TYR A 703           
+SHEET    4   A 5 VAL A 762  GLN A 767 -1  O  LEU A 764   N  LYS A 721           
+SHEET    5   A 5 LEU A 753  LEU A 758 -1  N  GLY A 755   O  ILE A 765           
+SHEET    1   B 2 LEU A 809  VAL A 810  0                                        
+SHEET    2   B 2 LYS A 836  LEU A 837 -1  O  LYS A 836   N  VAL A 810           
+SHEET    1   C 2 VAL A 819  THR A 823  0                                        
+SHEET    2   C 2 HIS A 826  ILE A 829 -1  O  LYS A 828   N  LEU A 820           
+SHEET    1   D 2 TYR A 845  HIS A 846  0                                        
+SHEET    2   D 2 ILE A 866  TYR A 867 -1  O  TYR A 867   N  TYR A 845           
+SITE     1 AC1 14 HOH A  10  LEU A 694  ALA A 719  LEU A 764                    
+SITE     2 AC1 14 THR A 766  GLN A 767  LEU A 768  MET A 769                    
+SITE     3 AC1 14 PRO A 770  PHE A 771  GLY A 772  LEU A 820                    
+SITE     4 AC1 14 THR A 830  ASP A 831                                          
+CRYST1  147.800  147.800  147.800  90.00  90.00  90.00 I 2 3        24          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.006766  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.006766  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.006766        0.00000                         
+ATOM      1  N   GLY A 672      55.000   8.448  68.519  1.00101.99           N  
+ATOM      2  CA  GLY A 672      54.168   8.340  69.707  1.00104.94           C  
+ATOM      3  C   GLY A 672      52.692   8.194  69.380  1.00105.46           C  
+ATOM      4  O   GLY A 672      51.877   9.045  69.750  1.00108.67           O  
+ATOM      5  N   GLU A 673      52.359   7.101  68.691  1.00102.41           N  
+ATOM      6  CA  GLU A 673      50.994   6.785  68.274  1.00 89.17           C  
+ATOM      7  C   GLU A 673      50.624   5.325  68.585  1.00 81.77           C  
+ATOM      8  O   GLU A 673      51.438   4.411  68.405  1.00 81.88           O  
+ATOM      9  CB  GLU A 673      50.850   7.050  66.777  1.00 96.53           C  
+ATOM     10  CG  GLU A 673      50.252   8.399  66.438  1.00 99.19           C  
+ATOM     11  CD  GLU A 673      48.788   8.486  66.827  1.00115.45           C  
+ATOM     12  OE1 GLU A 673      48.062   7.477  66.681  1.00116.71           O  
+ATOM     13  OE2 GLU A 673      48.356   9.561  67.286  1.00113.58           O  
+ATOM     14  N   ALA A 674      49.387   5.109  69.023  1.00 67.27           N  
+ATOM     15  CA  ALA A 674      48.912   3.768  69.370  1.00 63.11           C  
+ATOM     16  C   ALA A 674      48.702   2.826  68.174  1.00 58.54           C  
+ATOM     17  O   ALA A 674      48.064   3.183  67.186  1.00 62.02           O  
+ATOM     18  CB  ALA A 674      47.616   3.866  70.189  1.00 47.04           C  
+ATOM     19  N   PRO A 675      49.260   1.612  68.240  1.00 55.66           N  
+ATOM     20  CA  PRO A 675      49.087   0.665  67.134  1.00 52.95           C  
+ATOM     21  C   PRO A 675      47.629   0.261  66.997  1.00 48.19           C  
+ATOM     22  O   PRO A 675      46.975  -0.018  67.990  1.00 52.74           O  
+ATOM     23  CB  PRO A 675      49.957  -0.520  67.559  1.00 47.27           C  
+ATOM     24  CG  PRO A 675      49.985  -0.423  69.030  1.00 45.81           C  
+ATOM     25  CD  PRO A 675      50.160   1.054  69.259  1.00 50.66           C  
+ATOM     26  N   ASN A 676      47.124   0.267  65.767  1.00 44.01           N  
+ATOM     27  CA  ASN A 676      45.735  -0.094  65.484  1.00 40.28           C  
+ATOM     28  C   ASN A 676      45.670  -1.611  65.311  1.00 48.80           C  
+ATOM     29  O   ASN A 676      45.949  -2.152  64.242  1.00 55.33           O  
+ATOM     30  CB  ASN A 676      45.253   0.656  64.234  1.00 20.42           C  
+ATOM     31  CG  ASN A 676      43.833   0.305  63.840  1.00 38.31           C  
+ATOM     32  OD1 ASN A 676      43.184  -0.547  64.462  1.00 38.69           O  
+ATOM     33  ND2 ASN A 676      43.352   0.935  62.761  1.00 34.99           N  
+ATOM     34  N   GLN A 677      45.279  -2.295  66.375  1.00 48.40           N  
+ATOM     35  CA  GLN A 677      45.231  -3.744  66.357  1.00 40.03           C  
+ATOM     36  C   GLN A 677      43.926  -4.343  65.921  1.00 45.90           C  
+ATOM     37  O   GLN A 677      43.625  -5.501  66.240  1.00 49.60           O  
+ATOM     38  CB  GLN A 677      45.616  -4.279  67.715  1.00 29.98           C  
+ATOM     39  CG  GLN A 677      47.009  -3.846  68.116  1.00 42.03           C  
+ATOM     40  CD  GLN A 677      47.436  -4.467  69.415  1.00 62.22           C  
+ATOM     41  OE1 GLN A 677      47.647  -5.682  69.495  1.00 70.94           O  
+ATOM     42  NE2 GLN A 677      47.561  -3.643  70.450  1.00 59.09           N  
+ATOM     43  N   ALA A 678      43.161  -3.570  65.163  1.00 34.42           N  
+ATOM     44  CA  ALA A 678      41.893  -4.066  64.686  1.00 35.12           C  
+ATOM     45  C   ALA A 678      42.111  -5.288  63.790  1.00 44.91           C  
+ATOM     46  O   ALA A 678      43.117  -5.391  63.081  1.00 41.52           O  
+ATOM     47  CB  ALA A 678      41.180  -2.978  63.914  1.00 32.34           C  
+ATOM     48  N   LEU A 679      41.136  -6.189  63.819  1.00 48.66           N  
+ATOM     49  CA  LEU A 679      41.137  -7.401  63.023  1.00 45.01           C  
+ATOM     50  C   LEU A 679      40.349  -7.257  61.728  1.00 48.23           C  
+ATOM     51  O   LEU A 679      39.169  -6.941  61.768  1.00 56.09           O  
+ATOM     52  CB  LEU A 679      40.525  -8.546  63.825  1.00 44.12           C  
+ATOM     53  CG  LEU A 679      41.521  -9.444  64.556  1.00 51.90           C  
+ATOM     54  CD1 LEU A 679      42.537  -8.601  65.285  1.00 58.50           C  
+ATOM     55  CD2 LEU A 679      40.775 -10.364  65.507  1.00 42.04           C  
+ATOM     56  N   LEU A 680      40.996  -7.482  60.581  1.00 49.83           N  
+ATOM     57  CA  LEU A 680      40.291  -7.423  59.298  1.00 43.39           C  
+ATOM     58  C   LEU A 680      39.949  -8.882  58.974  1.00 48.99           C  
+ATOM     59  O   LEU A 680      40.826  -9.740  58.934  1.00 53.76           O  
+ATOM     60  CB  LEU A 680      41.175  -6.827  58.207  1.00 37.01           C  
+ATOM     61  CG  LEU A 680      40.573  -6.816  56.796  1.00 35.30           C  
+ATOM     62  CD1 LEU A 680      39.397  -5.821  56.701  1.00 37.97           C  
+ATOM     63  CD2 LEU A 680      41.665  -6.429  55.796  1.00 35.95           C  
+ATOM     64  N   ARG A 681      38.667  -9.166  58.795  1.00 44.02           N  
+ATOM     65  CA  ARG A 681      38.223 -10.519  58.522  1.00 42.32           C  
+ATOM     66  C   ARG A 681      37.949 -10.740  57.035  1.00 45.12           C  
+ATOM     67  O   ARG A 681      37.255  -9.945  56.386  1.00 38.01           O  
+ATOM     68  CB  ARG A 681      36.972 -10.804  59.347  1.00 41.38           C  
+ATOM     69  CG  ARG A 681      36.533 -12.246  59.396  1.00 46.82           C  
+ATOM     70  CD  ARG A 681      36.971 -12.935  60.685  1.00 82.56           C  
+ATOM     71  NE  ARG A 681      36.424 -14.290  60.780  1.00 86.14           N  
+ATOM     72  CZ  ARG A 681      35.187 -14.578  61.182  1.00 84.63           C  
+ATOM     73  NH1 ARG A 681      34.352 -13.610  61.546  1.00 72.91           N  
+ATOM     74  NH2 ARG A 681      34.766 -15.836  61.176  1.00 83.37           N  
+ATOM     75  N   ILE A 682      38.552 -11.795  56.496  1.00 39.80           N  
+ATOM     76  CA  ILE A 682      38.382 -12.164  55.101  1.00 47.32           C  
+ATOM     77  C   ILE A 682      37.343 -13.270  55.114  1.00 51.12           C  
+ATOM     78  O   ILE A 682      37.536 -14.301  55.751  1.00 59.26           O  
+ATOM     79  CB  ILE A 682      39.697 -12.693  54.479  1.00 49.82           C  
+ATOM     80  CG1 ILE A 682      40.840 -11.707  54.727  1.00 56.94           C  
+ATOM     81  CG2 ILE A 682      39.533 -12.862  52.973  1.00 51.45           C  
+ATOM     82  CD1 ILE A 682      40.727 -10.401  53.970  1.00 56.08           C  
+ATOM     83  N   LEU A 683      36.228 -13.026  54.437  1.00 53.87           N  
+ATOM     84  CA  LEU A 683      35.113 -13.966  54.380  1.00 52.97           C  
+ATOM     85  C   LEU A 683      35.007 -14.617  53.017  1.00 56.46           C  
+ATOM     86  O   LEU A 683      35.076 -13.933  51.990  1.00 55.89           O  
+ATOM     87  CB  LEU A 683      33.800 -13.220  54.654  1.00 51.20           C  
+ATOM     88  CG  LEU A 683      33.288 -12.808  56.041  1.00 54.79           C  
+ATOM     89  CD1 LEU A 683      34.366 -12.460  56.994  1.00 51.48           C  
+ATOM     90  CD2 LEU A 683      32.346 -11.632  55.877  1.00 66.29           C  
+ATOM     91  N   LYS A 684      34.781 -15.928  53.010  1.00 58.26           N  
+ATOM     92  CA  LYS A 684      34.639 -16.678  51.758  1.00 59.33           C  
+ATOM     93  C   LYS A 684      33.318 -16.321  51.089  1.00 54.25           C  
+ATOM     94  O   LYS A 684      32.303 -16.216  51.763  1.00 58.73           O  
+ATOM     95  CB  LYS A 684      34.684 -18.185  52.032  1.00 67.19           C  
+ATOM     96  CG  LYS A 684      36.076 -18.725  52.314  1.00 66.13           C  
+ATOM     97  CD  LYS A 684      36.039 -20.146  52.877  1.00 88.84           C  
+ATOM     98  CE  LYS A 684      36.020 -20.161  54.414  1.00 96.10           C  
+ATOM     99  NZ  LYS A 684      37.299 -19.673  55.046  1.00 87.18           N  
+ATOM    100  N   GLU A 685      33.343 -16.113  49.776  1.00 57.85           N  
+ATOM    101  CA  GLU A 685      32.135 -15.771  49.021  1.00 62.13           C  
+ATOM    102  C   GLU A 685      31.104 -16.891  49.081  1.00 62.48           C  
+ATOM    103  O   GLU A 685      29.931 -16.662  48.802  1.00 63.27           O  
+ATOM    104  CB  GLU A 685      32.453 -15.464  47.551  1.00 68.26           C  
+ATOM    105  CG  GLU A 685      31.226 -15.010  46.765  1.00 84.32           C  
+ATOM    106  CD  GLU A 685      31.443 -14.943  45.262  1.00 91.80           C  
+ATOM    107  OE1 GLU A 685      32.017 -15.896  44.688  1.00 84.66           O  
+ATOM    108  OE2 GLU A 685      31.002 -13.944  44.647  1.00 98.29           O  
+ATOM    109  N   THR A 686      31.550 -18.099  49.421  1.00 61.51           N  
+ATOM    110  CA  THR A 686      30.656 -19.251  49.526  1.00 58.28           C  
+ATOM    111  C   THR A 686      29.838 -19.192  50.808  1.00 62.68           C  
+ATOM    112  O   THR A 686      28.806 -19.855  50.926  1.00 66.33           O  
+ATOM    113  CB  THR A 686      31.447 -20.581  49.535  1.00 63.51           C  
+ATOM    114  OG1 THR A 686      32.425 -20.559  50.583  1.00 67.12           O  
+ATOM    115  CG2 THR A 686      32.147 -20.796  48.205  1.00 67.37           C  
+ATOM    116  N   GLU A 687      30.316 -18.412  51.775  1.00 60.23           N  
+ATOM    117  CA  GLU A 687      29.646 -18.278  53.054  1.00 58.34           C  
+ATOM    118  C   GLU A 687      28.446 -17.321  53.054  1.00 64.79           C  
+ATOM    119  O   GLU A 687      27.706 -17.238  54.036  1.00 64.31           O  
+ATOM    120  CB  GLU A 687      30.646 -17.874  54.130  1.00 58.34           C  
+ATOM    121  CG  GLU A 687      31.562 -18.990  54.600  1.00 80.80           C  
+ATOM    122  CD  GLU A 687      32.437 -18.572  55.784  1.00 97.59           C  
+ATOM    123  OE1 GLU A 687      32.747 -17.356  55.913  1.00 75.67           O  
+ATOM    124  OE2 GLU A 687      32.808 -19.466  56.587  1.00 97.68           O  
+ATOM    125  N   PHE A 688      28.251 -16.580  51.975  1.00 64.31           N  
+ATOM    126  CA  PHE A 688      27.116 -15.684  51.945  1.00 67.98           C  
+ATOM    127  C   PHE A 688      26.294 -15.748  50.684  1.00 69.25           C  
+ATOM    128  O   PHE A 688      26.815 -15.813  49.583  1.00 68.74           O  
+ATOM    129  CB  PHE A 688      27.494 -14.240  52.322  1.00 70.10           C  
+ATOM    130  CG  PHE A 688      28.572 -13.633  51.481  1.00 58.86           C  
+ATOM    131  CD1 PHE A 688      28.279 -13.095  50.231  1.00 56.79           C  
+ATOM    132  CD2 PHE A 688      29.870 -13.533  51.970  1.00 55.85           C  
+ATOM    133  CE1 PHE A 688      29.266 -12.454  49.471  1.00 65.53           C  
+ATOM    134  CE2 PHE A 688      30.866 -12.899  51.228  1.00 72.14           C  
+ATOM    135  CZ  PHE A 688      30.562 -12.355  49.969  1.00 65.97           C  
+ATOM    136  N   LYS A 689      24.983 -15.763  50.878  1.00 80.77           N  
+ATOM    137  CA  LYS A 689      24.030 -15.845  49.785  1.00 91.79           C  
+ATOM    138  C   LYS A 689      23.388 -14.498  49.462  1.00 96.14           C  
+ATOM    139  O   LYS A 689      22.547 -14.029  50.231  1.00100.71           O  
+ATOM    140  CB  LYS A 689      22.945 -16.878  50.142  1.00 83.32           C  
+ATOM    141  CG  LYS A 689      23.489 -18.305  50.331  1.00100.98           C  
+ATOM    142  CD  LYS A 689      22.477 -19.245  50.999  1.00115.48           C  
+ATOM    143  CE  LYS A 689      23.006 -20.685  51.088  1.00116.29           C  
+ATOM    144  NZ  LYS A 689      24.379 -20.774  51.687  1.00116.57           N  
+ATOM    145  N   LYS A 690      23.804 -13.861  48.359  1.00 95.36           N  
+ATOM    146  CA  LYS A 690      23.202 -12.584  47.943  1.00 95.83           C  
+ATOM    147  C   LYS A 690      21.732 -12.882  47.677  1.00100.52           C  
+ATOM    148  O   LYS A 690      21.374 -14.028  47.393  1.00105.12           O  
+ATOM    149  CB  LYS A 690      23.821 -12.043  46.655  1.00 82.71           C  
+ATOM    150  CG  LYS A 690      25.275 -11.623  46.754  1.00100.02           C  
+ATOM    151  CD  LYS A 690      25.737 -10.992  45.442  1.00 99.11           C  
+ATOM    152  CE  LYS A 690      27.224 -10.673  45.442  1.00106.97           C  
+ATOM    153  NZ  LYS A 690      27.659 -10.051  44.153  1.00102.61           N  
+ATOM    154  N   ILE A 691      20.882 -11.864  47.738  1.00100.52           N  
+ATOM    155  CA  ILE A 691      19.458 -12.095  47.535  1.00103.05           C  
+ATOM    156  C   ILE A 691      18.717 -10.999  46.775  1.00101.59           C  
+ATOM    157  O   ILE A 691      17.699 -11.269  46.137  1.00102.59           O  
+ATOM    158  CB  ILE A 691      18.750 -12.447  48.894  1.00106.08           C  
+ATOM    159  CG1 ILE A 691      19.039 -13.922  49.260  1.00107.21           C  
+ATOM    160  CG2 ILE A 691      17.249 -12.126  48.836  1.00 99.67           C  
+ATOM    161  CD1 ILE A 691      18.389 -14.450  50.534  1.00 96.73           C  
+ATOM    162  N   LYS A 692      19.232  -9.775  46.820  1.00 98.47           N  
+ATOM    163  CA  LYS A 692      18.600  -8.669  46.111  1.00 99.96           C  
+ATOM    164  C   LYS A 692      19.409  -7.388  46.189  1.00 99.94           C  
+ATOM    165  O   LYS A 692      20.030  -7.092  47.206  1.00105.63           O  
+ATOM    166  CB  LYS A 692      17.181  -8.414  46.637  1.00103.26           C  
+ATOM    167  CG  LYS A 692      16.382  -7.413  45.792  1.00111.51           C  
+ATOM    168  CD  LYS A 692      14.918  -7.296  46.228  1.00111.95           C  
+ATOM    169  CE  LYS A 692      14.780  -6.664  47.611  1.00116.20           C  
+ATOM    170  NZ  LYS A 692      13.355  -6.525  48.042  1.00109.63           N  
+ATOM    171  N   VAL A 693      19.418  -6.644  45.092  1.00 97.62           N  
+ATOM    172  CA  VAL A 693      20.135  -5.382  45.039  1.00 97.34           C  
+ATOM    173  C   VAL A 693      19.298  -4.314  45.738  1.00 92.97           C  
+ATOM    174  O   VAL A 693      18.082  -4.249  45.558  1.00 92.20           O  
+ATOM    175  CB  VAL A 693      20.429  -4.968  43.570  1.00105.18           C  
+ATOM    176  CG1 VAL A 693      19.148  -5.003  42.744  1.00119.10           C  
+ATOM    177  CG2 VAL A 693      21.072  -3.579  43.511  1.00 97.02           C  
+ATOM    178  N   LEU A 694      19.948  -3.530  46.592  1.00 91.31           N  
+ATOM    179  CA  LEU A 694      19.280  -2.458  47.324  1.00 87.66           C  
+ATOM    180  C   LEU A 694      19.436  -1.120  46.591  1.00 87.83           C  
+ATOM    181  O   LEU A 694      18.608  -0.221  46.749  1.00 85.52           O  
+ATOM    182  CB  LEU A 694      19.836  -2.349  48.753  1.00 72.62           C  
+ATOM    183  CG  LEU A 694      19.623  -3.538  49.701  1.00 74.33           C  
+ATOM    184  CD1 LEU A 694      20.383  -3.331  51.001  1.00 66.02           C  
+ATOM    185  CD2 LEU A 694      18.159  -3.739  49.984  1.00 65.19           C  
+ATOM    186  N   GLY A 695      20.488  -0.999  45.783  1.00 87.25           N  
+ATOM    187  CA  GLY A 695      20.722   0.231  45.050  1.00 88.89           C  
+ATOM    188  C   GLY A 695      21.960   0.190  44.182  1.00 92.19           C  
+ATOM    189  O   GLY A 695      23.025  -0.204  44.642  1.00 93.06           O  
+ATOM    190  N   SER A 696      21.821   0.632  42.935  1.00 96.47           N  
+ATOM    191  CA  SER A 696      22.923   0.647  41.974  1.00101.62           C  
+ATOM    192  C   SER A 696      23.323   2.078  41.602  1.00104.11           C  
+ATOM    193  O   SER A 696      23.201   2.478  40.441  1.00108.43           O  
+ATOM    194  CB  SER A 696      22.521  -0.115  40.699  1.00108.42           C  
+ATOM    195  OG  SER A 696      22.151  -1.460  40.966  1.00108.36           O  
+ATOM    196  N   GLY A 697      23.823   2.838  42.573  1.00103.19           N  
+ATOM    197  CA  GLY A 697      24.214   4.215  42.311  1.00104.91           C  
+ATOM    198  C   GLY A 697      25.517   4.427  41.555  1.00108.96           C  
+ATOM    199  O   GLY A 697      26.128   3.482  41.054  1.00104.19           O  
+ATOM    200  N   ALA A 698      25.933   5.689  41.469  1.00114.52           N  
+ATOM    201  CA  ALA A 698      27.167   6.072  40.782  1.00117.16           C  
+ATOM    202  C   ALA A 698      28.370   5.871  41.706  1.00118.16           C  
+ATOM    203  O   ALA A 698      29.097   6.815  42.035  1.00119.72           O  
+ATOM    204  CB  ALA A 698      27.083   7.533  40.316  1.00115.19           C  
+ATOM    205  N   PHE A 699      28.558   4.623  42.122  1.00116.72           N  
+ATOM    206  CA  PHE A 699      29.645   4.231  43.015  1.00113.53           C  
+ATOM    207  C   PHE A 699      29.797   2.714  42.961  1.00109.26           C  
+ATOM    208  O   PHE A 699      30.824   2.165  43.355  1.00111.65           O  
+ATOM    209  CB  PHE A 699      29.338   4.667  44.456  1.00118.75           C  
+ATOM    210  CG  PHE A 699      28.004   4.176  44.973  1.00118.74           C  
+ATOM    211  CD1 PHE A 699      27.866   2.883  45.478  1.00111.76           C  
+ATOM    212  CD2 PHE A 699      26.885   5.006  44.943  1.00107.12           C  
+ATOM    213  CE1 PHE A 699      26.639   2.420  45.936  1.00 97.80           C  
+ATOM    214  CE2 PHE A 699      25.652   4.554  45.399  1.00106.02           C  
+ATOM    215  CZ  PHE A 699      25.529   3.258  45.898  1.00109.04           C  
+ATOM    216  N   GLY A 700      28.753   2.052  42.474  1.00104.85           N  
+ATOM    217  CA  GLY A 700      28.740   0.605  42.369  1.00 97.40           C  
+ATOM    218  C   GLY A 700      27.358   0.121  42.761  1.00 93.71           C  
+ATOM    219  O   GLY A 700      26.354   0.697  42.344  1.00 95.38           O  
+ATOM    220  N   THR A 701      27.296  -0.906  43.599  1.00 87.61           N  
+ATOM    221  CA  THR A 701      26.015  -1.440  44.039  1.00 86.49           C  
+ATOM    222  C   THR A 701      26.071  -1.916  45.491  1.00 82.66           C  
+ATOM    223  O   THR A 701      27.139  -2.237  46.011  1.00 85.92           O  
+ATOM    224  CB  THR A 701      25.567  -2.640  43.161  1.00 91.10           C  
+ATOM    225  OG1 THR A 701      26.550  -3.678  43.240  1.00102.39           O  
+ATOM    226  CG2 THR A 701      25.401  -2.229  41.702  1.00 98.64           C  
+ATOM    227  N   VAL A 702      24.908  -1.947  46.137  1.00 75.13           N  
+ATOM    228  CA  VAL A 702      24.783  -2.409  47.510  1.00 64.88           C  
+ATOM    229  C   VAL A 702      23.764  -3.539  47.482  1.00 61.79           C  
+ATOM    230  O   VAL A 702      22.630  -3.357  47.065  1.00 63.97           O  
+ATOM    231  CB  VAL A 702      24.297  -1.281  48.468  1.00 65.09           C  
+ATOM    232  CG1 VAL A 702      24.107  -1.820  49.880  1.00 43.16           C  
+ATOM    233  CG2 VAL A 702      25.304  -0.149  48.505  1.00 62.08           C  
+ATOM    234  N   TYR A 703      24.185  -4.718  47.903  1.00 60.53           N  
+ATOM    235  CA  TYR A 703      23.306  -5.870  47.920  1.00 63.58           C  
+ATOM    236  C   TYR A 703      22.822  -6.169  49.326  1.00 68.03           C  
+ATOM    237  O   TYR A 703      23.352  -5.659  50.309  1.00 66.69           O  
+ATOM    238  CB  TYR A 703      24.037  -7.108  47.396  1.00 68.72           C  
+ATOM    239  CG  TYR A 703      24.558  -6.999  45.981  1.00 79.26           C  
+ATOM    240  CD1 TYR A 703      25.779  -6.382  45.713  1.00 79.20           C  
+ATOM    241  CD2 TYR A 703      23.875  -7.599  44.920  1.00 88.24           C  
+ATOM    242  CE1 TYR A 703      26.314  -6.377  44.426  1.00 98.08           C  
+ATOM    243  CE2 TYR A 703      24.401  -7.601  43.628  1.00101.26           C  
+ATOM    244  CZ  TYR A 703      25.624  -6.994  43.388  1.00102.01           C  
+ATOM    245  OH  TYR A 703      26.174  -7.036  42.126  1.00103.20           O  
+ATOM    246  N   LYS A 704      21.853  -7.070  49.395  1.00 70.52           N  
+ATOM    247  CA  LYS A 704      21.250  -7.522  50.636  1.00 68.05           C  
+ATOM    248  C   LYS A 704      21.421  -9.039  50.616  1.00 68.08           C  
+ATOM    249  O   LYS A 704      21.176  -9.659  49.590  1.00 71.86           O  
+ATOM    250  CB  LYS A 704      19.771  -7.140  50.612  1.00 61.42           C  
+ATOM    251  CG  LYS A 704      18.866  -7.997  51.428  1.00 53.95           C  
+ATOM    252  CD  LYS A 704      17.435  -7.552  51.228  1.00 73.29           C  
+ATOM    253  CE  LYS A 704      16.456  -8.597  51.733  1.00 82.78           C  
+ATOM    254  NZ  LYS A 704      16.843  -9.136  53.079  1.00 85.34           N  
+ATOM    255  N   GLY A 705      21.871  -9.629  51.722  1.00 65.43           N  
+ATOM    256  CA  GLY A 705      22.056 -11.074  51.766  1.00 60.14           C  
+ATOM    257  C   GLY A 705      22.115 -11.706  53.149  1.00 58.50           C  
+ATOM    258  O   GLY A 705      21.702 -11.117  54.135  1.00 60.85           O  
+ATOM    259  N   LEU A 706      22.560 -12.952  53.207  1.00 58.10           N  
+ATOM    260  CA  LEU A 706      22.689 -13.658  54.471  1.00 57.06           C  
+ATOM    261  C   LEU A 706      24.086 -14.237  54.555  1.00 59.35           C  
+ATOM    262  O   LEU A 706      24.561 -14.837  53.603  1.00 56.80           O  
+ATOM    263  CB  LEU A 706      21.680 -14.794  54.588  1.00 60.00           C  
+ATOM    264  CG  LEU A 706      20.246 -14.533  55.056  1.00 64.85           C  
+ATOM    265  CD1 LEU A 706      19.525 -15.885  55.250  1.00 56.92           C  
+ATOM    266  CD2 LEU A 706      20.246 -13.752  56.365  1.00 57.72           C  
+ATOM    267  N   TRP A 707      24.749 -14.021  55.688  1.00 63.08           N  
+ATOM    268  CA  TRP A 707      26.094 -14.530  55.914  1.00 60.99           C  
+ATOM    269  C   TRP A 707      25.945 -15.759  56.789  1.00 60.81           C  
+ATOM    270  O   TRP A 707      25.425 -15.681  57.900  1.00 62.18           O  
+ATOM    271  CB  TRP A 707      26.990 -13.473  56.583  1.00 50.81           C  
+ATOM    272  CG  TRP A 707      28.365 -13.973  56.903  1.00 50.75           C  
+ATOM    273  CD1 TRP A 707      29.090 -14.906  56.203  1.00 55.14           C  
+ATOM    274  CD2 TRP A 707      29.161 -13.616  58.033  1.00 49.31           C  
+ATOM    275  NE1 TRP A 707      30.282 -15.157  56.841  1.00 53.37           N  
+ATOM    276  CE2 TRP A 707      30.351 -14.382  57.968  1.00 46.91           C  
+ATOM    277  CE3 TRP A 707      28.985 -12.728  59.100  1.00 51.20           C  
+ATOM    278  CZ2 TRP A 707      31.355 -14.291  58.938  1.00 52.60           C  
+ATOM    279  CZ3 TRP A 707      29.987 -12.637  60.065  1.00 55.46           C  
+ATOM    280  CH2 TRP A 707      31.156 -13.417  59.978  1.00 45.68           C  
+ATOM    281  N   ILE A 708      26.406 -16.893  56.275  1.00 64.37           N  
+ATOM    282  CA  ILE A 708      26.296 -18.158  56.984  1.00 63.69           C  
+ATOM    283  C   ILE A 708      27.651 -18.807  57.207  1.00 65.54           C  
+ATOM    284  O   ILE A 708      28.080 -19.639  56.414  1.00 68.53           O  
+ATOM    285  CB  ILE A 708      25.389 -19.127  56.190  1.00 65.24           C  
+ATOM    286  CG1 ILE A 708      24.110 -18.389  55.759  1.00 67.60           C  
+ATOM    287  CG2 ILE A 708      25.074 -20.368  57.028  1.00 60.81           C  
+ATOM    288  CD1 ILE A 708      23.233 -19.119  54.753  1.00 73.96           C  
+ATOM    289  N   PRO A 709      28.347 -18.433  58.294  1.00 72.97           N  
+ATOM    290  CA  PRO A 709      29.667 -18.997  58.615  1.00 78.60           C  
+ATOM    291  C   PRO A 709      29.562 -20.523  58.701  1.00 86.74           C  
+ATOM    292  O   PRO A 709      28.729 -21.041  59.450  1.00 88.69           O  
+ATOM    293  CB  PRO A 709      29.968 -18.396  59.983  1.00 70.40           C  
+ATOM    294  CG  PRO A 709      29.209 -17.122  59.977  1.00 73.76           C  
+ATOM    295  CD  PRO A 709      27.911 -17.494  59.339  1.00 78.48           C  
+ATOM    296  N   GLU A 710      30.407 -21.229  57.944  1.00 94.33           N  
+ATOM    297  CA  GLU A 710      30.396 -22.699  57.894  1.00100.22           C  
+ATOM    298  C   GLU A 710      30.231 -23.433  59.229  1.00 98.25           C  
+ATOM    299  O   GLU A 710      29.285 -24.211  59.404  1.00 95.41           O  
+ATOM    300  CB  GLU A 710      31.632 -23.234  57.151  1.00114.07           C  
+ATOM    301  CG  GLU A 710      31.685 -24.773  57.054  1.00118.28           C  
+ATOM    302  CD  GLU A 710      32.772 -25.295  56.119  1.00120.00           C  
+ATOM    303  OE1 GLU A 710      32.411 -25.917  55.093  1.00118.41           O  
+ATOM    304  OE2 GLU A 710      33.978 -25.102  56.416  1.00116.49           O  
+ATOM    305  N   GLY A 711      31.136 -23.172  60.164  1.00 95.50           N  
+ATOM    306  CA  GLY A 711      31.072 -23.831  61.454  1.00 97.93           C  
+ATOM    307  C   GLY A 711      29.738 -23.748  62.179  1.00102.52           C  
+ATOM    308  O   GLY A 711      29.006 -24.742  62.257  1.00 98.79           O  
+ATOM    309  N   GLU A 712      29.403 -22.545  62.649  1.00103.19           N  
+ATOM    310  CA  GLU A 712      28.181 -22.286  63.417  1.00100.94           C  
+ATOM    311  C   GLU A 712      26.840 -22.579  62.762  1.00 99.87           C  
+ATOM    312  O   GLU A 712      26.761 -23.060  61.625  1.00101.77           O  
+ATOM    313  CB  GLU A 712      28.167 -20.844  63.935  1.00104.15           C  
+ATOM    314  CG  GLU A 712      29.306 -20.503  64.869  1.00106.45           C  
+ATOM    315  CD  GLU A 712      30.641 -20.546  64.169  1.00 98.71           C  
+ATOM    316  OE1 GLU A 712      30.834 -19.763  63.218  1.00 91.79           O  
+ATOM    317  OE2 GLU A 712      31.487 -21.383  64.549  1.00118.28           O  
+ATOM    318  N   LYS A 713      25.785 -22.300  63.524  1.00 93.08           N  
+ATOM    319  CA  LYS A 713      24.415 -22.493  63.081  1.00 87.47           C  
+ATOM    320  C   LYS A 713      23.717 -21.153  63.290  1.00 83.58           C  
+ATOM    321  O   LYS A 713      22.860 -21.006  64.174  1.00 84.39           O  
+ATOM    322  CB  LYS A 713      23.735 -23.601  63.899  1.00 92.63           C  
+ATOM    323  CG  LYS A 713      22.389 -24.062  63.342  1.00 92.34           C  
+ATOM    324  CD  LYS A 713      22.530 -24.637  61.931  1.00101.82           C  
+ATOM    325  CE  LYS A 713      21.173 -24.861  61.270  1.00100.66           C  
+ATOM    326  NZ  LYS A 713      20.439 -23.579  61.055  1.00 99.01           N  
+ATOM    327  N   VAL A 714      24.136 -20.166  62.498  1.00 72.31           N  
+ATOM    328  CA  VAL A 714      23.588 -18.814  62.567  1.00 64.14           C  
+ATOM    329  C   VAL A 714      23.487 -18.202  61.172  1.00 59.62           C  
+ATOM    330  O   VAL A 714      24.342 -18.437  60.317  1.00 62.40           O  
+ATOM    331  CB  VAL A 714      24.491 -17.854  63.415  1.00 60.41           C  
+ATOM    332  CG1 VAL A 714      24.682 -18.366  64.832  1.00 42.26           C  
+ATOM    333  CG2 VAL A 714      25.840 -17.672  62.753  1.00 70.57           C  
+ATOM    334  N   LYS A 715      22.429 -17.436  60.939  1.00 53.20           N  
+ATOM    335  CA  LYS A 715      22.257 -16.754  59.662  1.00 56.88           C  
+ATOM    336  C   LYS A 715      22.248 -15.265  59.979  1.00 52.12           C  
+ATOM    337  O   LYS A 715      21.362 -14.786  60.671  1.00 55.66           O  
+ATOM    338  CB  LYS A 715      20.963 -17.176  58.979  1.00 59.13           C  
+ATOM    339  CG  LYS A 715      20.977 -18.618  58.545  1.00 70.74           C  
+ATOM    340  CD  LYS A 715      19.929 -18.876  57.482  1.00 70.42           C  
+ATOM    341  CE  LYS A 715      19.882 -20.345  57.096  1.00 64.16           C  
+ATOM    342  NZ  LYS A 715      18.868 -20.569  56.035  1.00 73.90           N  
+ATOM    343  N   ILE A 716      23.264 -14.553  59.499  1.00 49.01           N  
+ATOM    344  CA  ILE A 716      23.427 -13.130  59.763  1.00 43.48           C  
+ATOM    345  C   ILE A 716      23.045 -12.231  58.597  1.00 43.65           C  
+ATOM    346  O   ILE A 716      23.736 -12.184  57.578  1.00 44.86           O  
+ATOM    347  CB  ILE A 716      24.892 -12.832  60.184  1.00 46.06           C  
+ATOM    348  CG1 ILE A 716      25.302 -13.800  61.299  1.00 52.43           C  
+ATOM    349  CG2 ILE A 716      25.013 -11.389  60.712  1.00 42.87           C  
+ATOM    350  CD1 ILE A 716      26.775 -13.824  61.601  1.00 55.45           C  
+ATOM    351  N   PRO A 717      21.963 -11.461  58.752  1.00 39.57           N  
+ATOM    352  CA  PRO A 717      21.509 -10.555  57.687  1.00 37.70           C  
+ATOM    353  C   PRO A 717      22.577  -9.489  57.449  1.00 40.97           C  
+ATOM    354  O   PRO A 717      22.945  -8.754  58.365  1.00 49.37           O  
+ATOM    355  CB  PRO A 717      20.231  -9.960  58.271  1.00 24.14           C  
+ATOM    356  CG  PRO A 717      19.759 -11.009  59.229  1.00 42.85           C  
+ATOM    357  CD  PRO A 717      21.038 -11.449  59.891  1.00 42.06           C  
+ATOM    358  N   VAL A 718      23.067  -9.398  56.217  1.00 42.07           N  
+ATOM    359  CA  VAL A 718      24.124  -8.446  55.875  1.00 40.31           C  
+ATOM    360  C   VAL A 718      23.873  -7.627  54.603  1.00 45.06           C  
+ATOM    361  O   VAL A 718      22.966  -7.918  53.821  1.00 47.27           O  
+ATOM    362  CB  VAL A 718      25.467  -9.186  55.679  1.00 44.95           C  
+ATOM    363  CG1 VAL A 718      25.841  -9.940  56.936  1.00 55.08           C  
+ATOM    364  CG2 VAL A 718      25.366 -10.168  54.500  1.00 34.55           C  
+ATOM    365  N   ALA A 719      24.670  -6.577  54.437  1.00 43.24           N  
+ATOM    366  CA  ALA A 719      24.618  -5.715  53.268  1.00 47.68           C  
+ATOM    367  C   ALA A 719      26.002  -5.863  52.645  1.00 53.15           C  
+ATOM    368  O   ALA A 719      27.024  -5.858  53.349  1.00 52.60           O  
+ATOM    369  CB  ALA A 719      24.371  -4.263  53.658  1.00 36.19           C  
+ATOM    370  N   ILE A 720      26.019  -6.026  51.326  1.00 55.00           N  
+ATOM    371  CA  ILE A 720      27.254  -6.215  50.570  1.00 51.36           C  
+ATOM    372  C   ILE A 720      27.472  -5.053  49.592  1.00 50.84           C  
+ATOM    373  O   ILE A 720      26.635  -4.793  48.730  1.00 44.07           O  
+ATOM    374  CB  ILE A 720      27.164  -7.543  49.809  1.00 51.98           C  
+ATOM    375  CG1 ILE A 720      26.635  -8.615  50.754  1.00 45.10           C  
+ATOM    376  CG2 ILE A 720      28.518  -7.958  49.265  1.00 47.66           C  
+ATOM    377  CD1 ILE A 720      26.319  -9.897  50.086  1.00 45.86           C  
+ATOM    378  N   LYS A 721      28.581  -4.340  49.744  1.00 46.92           N  
+ATOM    379  CA  LYS A 721      28.881  -3.213  48.864  1.00 58.74           C  
+ATOM    380  C   LYS A 721      30.122  -3.469  47.984  1.00 68.19           C  
+ATOM    381  O   LYS A 721      31.195  -3.787  48.497  1.00 66.76           O  
+ATOM    382  CB  LYS A 721      29.079  -1.966  49.720  1.00 50.56           C  
+ATOM    383  CG  LYS A 721      29.406  -0.697  48.966  1.00 60.00           C  
+ATOM    384  CD  LYS A 721      29.725   0.401  49.960  1.00 57.60           C  
+ATOM    385  CE  LYS A 721      29.871   1.742  49.291  1.00 56.90           C  
+ATOM    386  NZ  LYS A 721      30.122   2.791  50.314  1.00 79.32           N  
+ATOM    387  N   GLU A 722      29.963  -3.329  46.666  1.00 78.88           N  
+ATOM    388  CA  GLU A 722      31.054  -3.527  45.691  1.00 89.59           C  
+ATOM    389  C   GLU A 722      30.942  -2.541  44.531  1.00 99.17           C  
+ATOM    390  O   GLU A 722      29.935  -1.842  44.390  1.00100.93           O  
+ATOM    391  CB  GLU A 722      31.025  -4.942  45.102  1.00 85.25           C  
+ATOM    392  CG  GLU A 722      29.753  -5.252  44.317  1.00 93.73           C  
+ATOM    393  CD  GLU A 722      29.906  -6.411  43.343  1.00107.08           C  
+ATOM    394  OE1 GLU A 722      30.087  -7.566  43.787  1.00108.14           O  
+ATOM    395  OE2 GLU A 722      29.827  -6.166  42.121  1.00114.47           O  
+ATOM    396  N   LEU A 723      31.961  -2.528  43.673  1.00109.61           N  
+ATOM    397  CA  LEU A 723      31.980  -1.644  42.502  1.00115.18           C  
+ATOM    398  C   LEU A 723      31.444  -2.353  41.252  1.00116.14           C  
+ATOM    399  O   LEU A 723      31.014  -3.508  41.318  1.00115.73           O  
+ATOM    400  CB  LEU A 723      33.402  -1.147  42.236  1.00117.55           C  
+ATOM    401  CG  LEU A 723      34.080  -0.347  43.351  1.00118.63           C  
+ATOM    402  CD1 LEU A 723      35.577  -0.251  43.073  1.00114.88           C  
+ATOM    403  CD2 LEU A 723      33.445   1.035  43.491  1.00 94.81           C  
+ATOM    404  N   ARG A 724      31.470  -1.653  40.118  1.00117.88           N  
+ATOM    405  CA  ARG A 724      30.997  -2.209  38.848  1.00118.87           C  
+ATOM    406  C   ARG A 724      31.902  -3.370  38.402  1.00117.77           C  
+ATOM    407  O   ARG A 724      33.056  -3.469  38.832  1.00116.51           O  
+ATOM    408  CB  ARG A 724      30.944  -1.110  37.771  1.00117.03           C  
+ATOM    409  CG  ARG A 724      30.270  -1.520  36.453  1.00120.00           C  
+ATOM    410  CD  ARG A 724      28.782  -1.820  36.650  1.00120.00           C  
+ATOM    411  NE  ARG A 724      28.180  -2.504  35.500  1.00120.00           N  
+ATOM    412  CZ  ARG A 724      27.313  -1.948  34.656  1.00118.30           C  
+ATOM    413  NH1 ARG A 724      26.940  -0.684  34.813  1.00119.88           N  
+ATOM    414  NH2 ARG A 724      26.785  -2.672  33.675  1.00113.01           N  
+ATOM    415  N   GLU A 725      31.367  -4.238  37.545  0.00118.05           N  
+ATOM    416  CA  GLU A 725      32.083  -5.411  37.038  0.00118.88           C  
+ATOM    417  C   GLU A 725      33.549  -5.195  36.652  0.00119.37           C  
+ATOM    418  O   GLU A 725      34.411  -5.990  37.028  0.00119.89           O  
+ATOM    419  CB  GLU A 725      31.310  -6.045  35.876  0.00118.16           C  
+ATOM    420  CG  GLU A 725      30.993  -5.100  34.726  0.00113.14           C  
+ATOM    421  CD  GLU A 725      30.112  -5.744  33.671  0.00116.04           C  
+ATOM    422  OE1 GLU A 725      28.932  -5.350  33.562  0.00115.61           O  
+ATOM    423  OE2 GLU A 725      30.598  -6.644  32.954  0.00110.87           O  
+ATOM    424  N   ALA A 726      33.829  -4.131  35.903  1.00119.87           N  
+ATOM    425  CA  ALA A 726      35.198  -3.828  35.494  1.00118.48           C  
+ATOM    426  C   ALA A 726      35.989  -3.278  36.683  1.00118.95           C  
+ATOM    427  O   ALA A 726      35.437  -2.589  37.549  1.00116.44           O  
+ATOM    428  CB  ALA A 726      35.204  -2.832  34.341  1.00119.45           C  
+ATOM    429  N   THR A 727      37.280  -3.601  36.724  1.00119.85           N  
+ATOM    430  CA  THR A 727      38.153  -3.156  37.807  1.00119.78           C  
+ATOM    431  C   THR A 727      38.641  -1.718  37.613  1.00120.00           C  
+ATOM    432  O   THR A 727      39.152  -1.357  36.544  1.00119.35           O  
+ATOM    433  CB  THR A 727      39.382  -4.091  37.970  1.00118.76           C  
+ATOM    434  OG1 THR A 727      38.940  -5.446  38.127  1.00111.10           O  
+ATOM    435  CG2 THR A 727      40.203  -3.688  39.202  1.00117.14           C  
+ATOM    436  N   SER A 728      38.446  -0.898  38.645  1.00120.00           N  
+ATOM    437  CA  SER A 728      38.878   0.497  38.624  1.00120.00           C  
+ATOM    438  C   SER A 728      40.155   0.604  39.469  1.00120.00           C  
+ATOM    439  O   SER A 728      40.294  -0.076  40.494  1.00119.72           O  
+ATOM    440  CB  SER A 728      37.775   1.415  39.174  1.00120.00           C  
+ATOM    441  OG  SER A 728      38.083   2.785  38.961  1.00112.66           O  
+ATOM    442  N   PRO A 729      41.123   1.424  39.016  1.00120.00           N  
+ATOM    443  CA  PRO A 729      42.419   1.659  39.676  1.00120.00           C  
+ATOM    444  C   PRO A 729      42.347   2.277  41.074  1.00119.43           C  
+ATOM    445  O   PRO A 729      42.668   1.626  42.071  1.00118.61           O  
+ATOM    446  CB  PRO A 729      43.135   2.598  38.695  1.00120.00           C  
+ATOM    447  CG  PRO A 729      42.535   2.225  37.361  1.00119.92           C  
+ATOM    448  CD  PRO A 729      41.074   2.112  37.712  1.00120.00           C  
+ATOM    449  N   LYS A 730      41.954   3.548  41.121  1.00120.00           N  
+ATOM    450  CA  LYS A 730      41.840   4.313  42.362  1.00119.21           C  
+ATOM    451  C   LYS A 730      40.632   3.936  43.225  1.00119.52           C  
+ATOM    452  O   LYS A 730      40.668   4.098  44.446  1.00119.71           O  
+ATOM    453  CB  LYS A 730      41.790   5.812  42.043  1.00115.30           C  
+ATOM    454  CG  LYS A 730      40.654   6.196  41.102  0.00111.42           C  
+ATOM    455  CD  LYS A 730      40.641   7.684  40.801  0.00112.24           C  
+ATOM    456  CE  LYS A 730      39.494   8.038  39.867  0.00115.68           C  
+ATOM    457  NZ  LYS A 730      39.456   9.492  39.551  0.00114.85           N  
+ATOM    458  N   ALA A 731      39.562   3.457  42.593  1.00118.99           N  
+ATOM    459  CA  ALA A 731      38.347   3.069  43.313  1.00115.58           C  
+ATOM    460  C   ALA A 731      38.589   1.846  44.192  1.00112.61           C  
+ATOM    461  O   ALA A 731      37.948   1.673  45.226  1.00111.65           O  
+ATOM    462  CB  ALA A 731      37.215   2.804  42.333  1.00113.88           C  
+ATOM    463  N   ASN A 732      39.530   1.011  43.771  1.00112.01           N  
+ATOM    464  CA  ASN A 732      39.888  -0.194  44.504  1.00110.60           C  
+ATOM    465  C   ASN A 732      40.576   0.162  45.817  1.00106.48           C  
+ATOM    466  O   ASN A 732      40.358  -0.486  46.836  1.00105.64           O  
+ATOM    467  CB  ASN A 732      40.809  -1.061  43.650  1.00118.92           C  
+ATOM    468  CG  ASN A 732      41.126  -2.384  44.303  1.00120.00           C  
+ATOM    469  OD1 ASN A 732      40.402  -3.374  44.118  1.00118.83           O  
+ATOM    470  ND2 ASN A 732      42.214  -2.416  45.079  1.00116.78           N  
+ATOM    471  N   LYS A 733      41.438   1.173  45.770  1.00103.25           N  
+ATOM    472  CA  LYS A 733      42.141   1.636  46.958  1.00102.13           C  
+ATOM    473  C   LYS A 733      41.124   2.239  47.918  1.00100.63           C  
+ATOM    474  O   LYS A 733      41.157   1.973  49.118  1.00104.56           O  
+ATOM    475  CB  LYS A 733      43.181   2.704  46.594  1.00 96.91           C  
+ATOM    476  CG  LYS A 733      43.850   3.336  47.808  1.00110.43           C  
+ATOM    477  CD  LYS A 733      44.779   4.473  47.439  1.00109.50           C  
+ATOM    478  CE  LYS A 733      45.463   5.014  48.686  1.00119.19           C  
+ATOM    479  NZ  LYS A 733      46.474   6.065  48.386  1.00120.00           N  
+ATOM    480  N   GLU A 734      40.201   3.021  47.363  1.00 95.90           N  
+ATOM    481  CA  GLU A 734      39.167   3.687  48.142  1.00 91.10           C  
+ATOM    482  C   GLU A 734      38.256   2.750  48.944  1.00 84.46           C  
+ATOM    483  O   GLU A 734      37.856   3.082  50.065  1.00 81.68           O  
+ATOM    484  CB  GLU A 734      38.366   4.647  47.253  1.00 95.48           C  
+ATOM    485  CG  GLU A 734      39.219   5.805  46.717  1.00102.59           C  
+ATOM    486  CD  GLU A 734      38.412   6.909  46.039  1.00106.44           C  
+ATOM    487  OE1 GLU A 734      37.289   6.637  45.552  1.00114.11           O  
+ATOM    488  OE2 GLU A 734      38.913   8.058  45.989  1.00101.90           O  
+ATOM    489  N   ILE A 735      37.938   1.580  48.396  1.00 76.67           N  
+ATOM    490  CA  ILE A 735      37.106   0.646  49.143  1.00 70.69           C  
+ATOM    491  C   ILE A 735      37.948   0.131  50.292  1.00 62.75           C  
+ATOM    492  O   ILE A 735      37.466  -0.007  51.413  1.00 60.57           O  
+ATOM    493  CB  ILE A 735      36.646  -0.578  48.329  1.00 71.12           C  
+ATOM    494  CG1 ILE A 735      35.780  -0.159  47.148  1.00 92.52           C  
+ATOM    495  CG2 ILE A 735      35.793  -1.478  49.207  1.00 71.12           C  
+ATOM    496  CD1 ILE A 735      35.185  -1.353  46.396  1.00 95.31           C  
+ATOM    497  N   LEU A 736      39.214  -0.150  50.013  1.00 55.25           N  
+ATOM    498  CA  LEU A 736      40.074  -0.653  51.061  1.00 50.87           C  
+ATOM    499  C   LEU A 736      40.323   0.404  52.134  1.00 50.02           C  
+ATOM    500  O   LEU A 736      40.451   0.062  53.305  1.00 55.00           O  
+ATOM    501  CB  LEU A 736      41.371  -1.240  50.490  1.00 57.16           C  
+ATOM    502  CG  LEU A 736      41.367  -2.704  49.997  1.00 63.08           C  
+ATOM    503  CD1 LEU A 736      40.552  -3.581  50.936  1.00 43.77           C  
+ATOM    504  CD2 LEU A 736      40.814  -2.819  48.598  1.00 67.56           C  
+ATOM    505  N   ASP A 737      40.350   1.682  51.751  1.00 46.92           N  
+ATOM    506  CA  ASP A 737      40.530   2.763  52.719  1.00 45.62           C  
+ATOM    507  C   ASP A 737      39.318   2.787  53.626  1.00 51.02           C  
+ATOM    508  O   ASP A 737      39.451   2.899  54.843  1.00 48.39           O  
+ATOM    509  CB  ASP A 737      40.635   4.121  52.046  1.00 44.18           C  
+ATOM    510  CG  ASP A 737      42.036   4.440  51.575  1.00 65.81           C  
+ATOM    511  OD1 ASP A 737      43.010   3.911  52.161  1.00 63.44           O  
+ATOM    512  OD2 ASP A 737      42.160   5.241  50.622  1.00 84.30           O  
+ATOM    513  N   GLU A 738      38.142   2.655  53.013  1.00 49.34           N  
+ATOM    514  CA  GLU A 738      36.880   2.649  53.726  1.00 47.77           C  
+ATOM    515  C   GLU A 738      36.775   1.436  54.641  1.00 52.97           C  
+ATOM    516  O   GLU A 738      36.191   1.524  55.732  1.00 60.99           O  
+ATOM    517  CB  GLU A 738      35.726   2.679  52.736  1.00 50.26           C  
+ATOM    518  CG  GLU A 738      34.346   2.698  53.361  1.00 59.40           C  
+ATOM    519  CD  GLU A 738      33.235   2.863  52.335  1.00 58.37           C  
+ATOM    520  OE1 GLU A 738      33.541   3.249  51.188  1.00 72.29           O  
+ATOM    521  OE2 GLU A 738      32.053   2.620  52.672  1.00 76.77           O  
+ATOM    522  N   ALA A 739      37.367   0.319  54.216  1.00 48.57           N  
+ATOM    523  CA  ALA A 739      37.364  -0.918  55.013  1.00 42.69           C  
+ATOM    524  C   ALA A 739      38.196  -0.701  56.255  1.00 40.88           C  
+ATOM    525  O   ALA A 739      37.799  -1.071  57.347  1.00 46.18           O  
+ATOM    526  CB  ALA A 739      37.934  -2.062  54.221  1.00 38.75           C  
+ATOM    527  N   TYR A 740      39.340  -0.050  56.069  1.00 43.89           N  
+ATOM    528  CA  TYR A 740      40.257   0.252  57.151  1.00 40.40           C  
+ATOM    529  C   TYR A 740      39.600   1.058  58.274  1.00 43.21           C  
+ATOM    530  O   TYR A 740      39.842   0.786  59.443  1.00 45.45           O  
+ATOM    531  CB  TYR A 740      41.481   1.018  56.617  1.00 30.08           C  
+ATOM    532  CG  TYR A 740      42.484   1.396  57.701  1.00 39.41           C  
+ATOM    533  CD1 TYR A 740      42.269   2.492  58.545  1.00 37.60           C  
+ATOM    534  CD2 TYR A 740      43.611   0.620  57.927  1.00 35.27           C  
+ATOM    535  CE1 TYR A 740      43.157   2.791  59.589  1.00 31.20           C  
+ATOM    536  CE2 TYR A 740      44.499   0.915  58.974  1.00 45.40           C  
+ATOM    537  CZ  TYR A 740      44.262   1.996  59.792  1.00 40.96           C  
+ATOM    538  OH  TYR A 740      45.143   2.279  60.799  1.00 51.29           O  
+ATOM    539  N   VAL A 741      38.805   2.068  57.927  1.00 46.94           N  
+ATOM    540  CA  VAL A 741      38.160   2.885  58.952  1.00 48.54           C  
+ATOM    541  C   VAL A 741      37.012   2.132  59.585  1.00 45.15           C  
+ATOM    542  O   VAL A 741      36.920   2.086  60.809  1.00 46.30           O  
+ATOM    543  CB  VAL A 741      37.656   4.248  58.420  1.00 51.92           C  
+ATOM    544  CG1 VAL A 741      38.800   5.053  57.849  1.00 39.01           C  
+ATOM    545  CG2 VAL A 741      36.639   4.037  57.363  1.00 76.92           C  
+ATOM    546  N   MET A 742      36.183   1.472  58.771  1.00 37.09           N  
+ATOM    547  CA  MET A 742      35.058   0.730  59.338  1.00 42.02           C  
+ATOM    548  C   MET A 742      35.466  -0.411  60.251  1.00 46.34           C  
+ATOM    549  O   MET A 742      34.734  -0.768  61.170  1.00 61.43           O  
+ATOM    550  CB  MET A 742      34.133   0.192  58.266  1.00 46.91           C  
+ATOM    551  CG  MET A 742      33.397   1.229  57.479  1.00 49.54           C  
+ATOM    552  SD  MET A 742      32.244   0.362  56.443  1.00 63.27           S  
+ATOM    553  CE  MET A 742      31.080  -0.114  57.631  1.00 46.43           C  
+ATOM    554  N   ALA A 743      36.621  -1.001  59.980  1.00 47.70           N  
+ATOM    555  CA  ALA A 743      37.125  -2.096  60.787  1.00 43.52           C  
+ATOM    556  C   ALA A 743      37.750  -1.558  62.066  1.00 36.10           C  
+ATOM    557  O   ALA A 743      38.013  -2.300  62.995  1.00 43.42           O  
+ATOM    558  CB  ALA A 743      38.155  -2.897  59.985  1.00 39.05           C  
+ATOM    559  N   SER A 744      37.973  -0.256  62.115  1.00 39.86           N  
+ATOM    560  CA  SER A 744      38.603   0.362  63.278  1.00 47.26           C  
+ATOM    561  C   SER A 744      37.661   1.072  64.251  1.00 50.31           C  
+ATOM    562  O   SER A 744      38.122   1.797  65.140  1.00 58.89           O  
+ATOM    563  CB  SER A 744      39.663   1.352  62.804  1.00 46.68           C  
+ATOM    564  OG  SER A 744      40.569   0.726  61.911  1.00 61.12           O  
+ATOM    565  N   VAL A 745      36.356   0.900  64.068  1.00 46.30           N  
+ATOM    566  CA  VAL A 745      35.376   1.538  64.945  1.00 44.52           C  
+ATOM    567  C   VAL A 745      34.450   0.491  65.530  1.00 47.41           C  
+ATOM    568  O   VAL A 745      33.999  -0.410  64.840  1.00 49.93           O  
+ATOM    569  CB  VAL A 745      34.499   2.560  64.193  1.00 42.20           C  
+ATOM    570  CG1 VAL A 745      35.345   3.713  63.637  1.00 27.99           C  
+ATOM    571  CG2 VAL A 745      33.726   1.853  63.081  1.00 37.55           C  
+ATOM    572  N   ASP A 746      34.159   0.623  66.811  1.00 45.95           N  
+ATOM    573  CA  ASP A 746      33.276  -0.307  67.482  1.00 42.74           C  
+ATOM    574  C   ASP A 746      32.422   0.512  68.475  1.00 43.17           C  
+ATOM    575  O   ASP A 746      32.898   0.954  69.530  1.00 42.31           O  
+ATOM    576  CB  ASP A 746      34.111  -1.401  68.178  1.00 29.82           C  
+ATOM    577  CG  ASP A 746      33.245  -2.457  68.879  1.00 55.09           C  
+ATOM    578  OD1 ASP A 746      32.043  -2.581  68.564  1.00 52.73           O  
+ATOM    579  OD2 ASP A 746      33.768  -3.173  69.758  1.00 74.69           O  
+ATOM    580  N   ASN A 747      31.189   0.794  68.063  1.00 35.56           N  
+ATOM    581  CA  ASN A 747      30.245   1.557  68.871  1.00 36.25           C  
+ATOM    582  C   ASN A 747      28.820   1.270  68.415  1.00 34.56           C  
+ATOM    583  O   ASN A 747      28.582   1.014  67.244  1.00 39.61           O  
+ATOM    584  CB  ASN A 747      30.552   3.054  68.774  1.00 40.50           C  
+ATOM    585  CG  ASN A 747      29.631   3.897  69.632  1.00 47.30           C  
+ATOM    586  OD1 ASN A 747      28.535   4.272  69.206  1.00 39.04           O  
+ATOM    587  ND2 ASN A 747      30.063   4.185  70.858  1.00 36.78           N  
+ATOM    588  N   PRO A 748      27.852   1.296  69.345  1.00 36.26           N  
+ATOM    589  CA  PRO A 748      26.438   1.036  69.033  1.00 26.39           C  
+ATOM    590  C   PRO A 748      25.799   2.004  68.052  1.00 29.08           C  
+ATOM    591  O   PRO A 748      24.785   1.704  67.440  1.00 34.03           O  
+ATOM    592  CB  PRO A 748      25.784   1.108  70.396  1.00 26.22           C  
+ATOM    593  CG  PRO A 748      26.891   0.586  71.335  1.00 20.21           C  
+ATOM    594  CD  PRO A 748      28.071   1.336  70.805  1.00 31.84           C  
+ATOM    595  N   HIS A 749      26.424   3.148  67.858  1.00 36.86           N  
+ATOM    596  CA  HIS A 749      25.886   4.143  66.949  1.00 40.75           C  
+ATOM    597  C   HIS A 749      26.748   4.411  65.732  1.00 43.31           C  
+ATOM    598  O   HIS A 749      26.611   5.439  65.049  1.00 42.41           O  
+ATOM    599  CB  HIS A 749      25.546   5.391  67.740  1.00 39.93           C  
+ATOM    600  CG  HIS A 749      24.555   5.110  68.819  1.00 49.23           C  
+ATOM    601  ND1 HIS A 749      23.249   4.765  68.545  1.00 41.45           N  
+ATOM    602  CD2 HIS A 749      24.713   4.955  70.153  1.00 33.26           C  
+ATOM    603  CE1 HIS A 749      22.650   4.397  69.664  1.00 46.00           C  
+ATOM    604  NE2 HIS A 749      23.517   4.502  70.655  1.00 34.86           N  
+ATOM    605  N   VAL A 750      27.644   3.463  65.467  1.00 45.15           N  
+ATOM    606  CA  VAL A 750      28.491   3.515  64.286  1.00 40.34           C  
+ATOM    607  C   VAL A 750      28.358   2.176  63.567  1.00 35.42           C  
+ATOM    608  O   VAL A 750      28.265   1.117  64.201  1.00 30.82           O  
+ATOM    609  CB  VAL A 750      29.939   3.823  64.645  1.00 34.23           C  
+ATOM    610  CG1 VAL A 750      30.804   3.742  63.421  1.00 44.91           C  
+ATOM    611  CG2 VAL A 750      30.017   5.244  65.201  1.00 34.34           C  
+ATOM    612  N  ACYS A 751      28.271   2.223  62.244  0.50 35.58           N  
+ATOM    613  N  BCYS A 751      28.282   2.243  62.246  0.50 37.41           N  
+ATOM    614  CA ACYS A 751      28.168   0.990  61.469  0.50 42.09           C  
+ATOM    615  CA BCYS A 751      28.150   1.062  61.389  0.50 45.23           C  
+ATOM    616  C  ACYS A 751      29.518   0.324  61.402  0.50 42.98           C  
+ATOM    617  C  BCYS A 751      29.496   0.320  61.313  0.50 44.85           C  
+ATOM    618  O  ACYS A 751      30.528   0.968  61.135  0.50 51.40           O  
+ATOM    619  O  BCYS A 751      30.500   0.925  60.946  0.50 52.45           O  
+ATOM    620  CB ACYS A 751      27.653   1.255  60.060  0.50 32.54           C  
+ATOM    621  CB BCYS A 751      27.681   1.539  60.003  0.50 41.91           C  
+ATOM    622  SG ACYS A 751      25.899   1.515  60.033  0.50 33.14           S  
+ATOM    623  SG BCYS A 751      27.776   0.394  58.620  0.50 52.82           S  
+ATOM    624  N   ARG A 752      29.530  -0.967  61.673  1.00 48.20           N  
+ATOM    625  CA  ARG A 752      30.785  -1.742  61.657  1.00 55.15           C  
+ATOM    626  C   ARG A 752      30.913  -2.768  60.519  1.00 54.92           C  
+ATOM    627  O   ARG A 752      29.924  -3.346  60.023  1.00 52.10           O  
+ATOM    628  CB  ARG A 752      30.976  -2.431  63.014  1.00 73.03           C  
+ATOM    629  CG  ARG A 752      32.335  -3.053  63.269  1.00 62.83           C  
+ATOM    630  CD  ARG A 752      32.250  -3.889  64.539  1.00 74.46           C  
+ATOM    631  NE  ARG A 752      33.423  -4.731  64.764  1.00 85.80           N  
+ATOM    632  CZ  ARG A 752      34.644  -4.269  65.025  1.00100.40           C  
+ATOM    633  NH1 ARG A 752      34.862  -2.962  65.089  1.00 94.64           N  
+ATOM    634  NH2 ARG A 752      35.646  -5.116  65.241  1.00108.37           N  
+ATOM    635  N   LEU A 753      32.156  -2.959  60.105  1.00 53.73           N  
+ATOM    636  CA  LEU A 753      32.503  -3.877  59.045  1.00 45.35           C  
+ATOM    637  C   LEU A 753      32.568  -5.290  59.601  1.00 45.62           C  
+ATOM    638  O   LEU A 753      33.214  -5.520  60.617  1.00 48.14           O  
+ATOM    639  CB  LEU A 753      33.875  -3.502  58.526  1.00 47.11           C  
+ATOM    640  CG  LEU A 753      34.385  -4.207  57.280  1.00 60.05           C  
+ATOM    641  CD1 LEU A 753      33.907  -3.452  56.049  1.00 48.93           C  
+ATOM    642  CD2 LEU A 753      35.903  -4.223  57.324  1.00 59.98           C  
+ATOM    643  N   LEU A 754      31.873  -6.228  58.969  1.00 45.61           N  
+ATOM    644  CA  LEU A 754      31.927  -7.616  59.405  1.00 47.72           C  
+ATOM    645  C   LEU A 754      33.143  -8.249  58.749  1.00 51.77           C  
+ATOM    646  O   LEU A 754      33.798  -9.112  59.334  1.00 51.52           O  
+ATOM    647  CB  LEU A 754      30.670  -8.368  59.006  1.00 41.87           C  
+ATOM    648  CG  LEU A 754      29.466  -7.844  59.777  1.00 50.79           C  
+ATOM    649  CD1 LEU A 754      28.185  -8.363  59.159  1.00 46.72           C  
+ATOM    650  CD2 LEU A 754      29.585  -8.257  61.233  1.00 41.91           C  
+ATOM    651  N   GLY A 755      33.474  -7.757  57.559  1.00 47.03           N  
+ATOM    652  CA  GLY A 755      34.617  -8.276  56.839  1.00 53.28           C  
+ATOM    653  C   GLY A 755      34.628  -7.921  55.365  1.00 48.72           C  
+ATOM    654  O   GLY A 755      33.825  -7.121  54.895  1.00 48.41           O  
+ATOM    655  N   ILE A 756      35.589  -8.478  54.643  1.00 47.20           N  
+ATOM    656  CA  ILE A 756      35.681  -8.242  53.214  1.00 48.14           C  
+ATOM    657  C   ILE A 756      35.803  -9.583  52.507  1.00 53.25           C  
+ATOM    658  O   ILE A 756      36.169 -10.607  53.119  1.00 49.03           O  
+ATOM    659  CB  ILE A 756      36.863  -7.303  52.836  1.00 51.35           C  
+ATOM    660  CG1 ILE A 756      38.199  -7.864  53.317  1.00 47.55           C  
+ATOM    661  CG2 ILE A 756      36.684  -5.931  53.466  1.00 45.34           C  
+ATOM    662  CD1 ILE A 756      39.389  -7.073  52.782  1.00 60.62           C  
+ATOM    663  N   CYS A 757      35.383  -9.589  51.247  1.00 56.20           N  
+ATOM    664  CA  CYS A 757      35.446 -10.779  50.407  1.00 60.93           C  
+ATOM    665  C   CYS A 757      36.230 -10.371  49.152  1.00 60.14           C  
+ATOM    666  O   CYS A 757      35.819  -9.471  48.415  1.00 52.96           O  
+ATOM    667  CB  CYS A 757      34.028 -11.270  50.060  1.00 64.83           C  
+ATOM    668  SG  CYS A 757      33.975 -12.858  49.158  1.00 73.09           S  
+ATOM    669  N   LEU A 758      37.393 -10.986  48.958  1.00 60.02           N  
+ATOM    670  CA  LEU A 758      38.247 -10.664  47.820  1.00 63.37           C  
+ATOM    671  C   LEU A 758      37.824 -11.392  46.550  1.00 66.93           C  
+ATOM    672  O   LEU A 758      38.251 -12.510  46.295  1.00 71.90           O  
+ATOM    673  CB  LEU A 758      39.710 -10.959  48.162  1.00 41.64           C  
+ATOM    674  CG  LEU A 758      40.290 -10.165  49.340  1.00 61.61           C  
+ATOM    675  CD1 LEU A 758      41.696 -10.655  49.616  1.00 67.38           C  
+ATOM    676  CD2 LEU A 758      40.294  -8.646  49.083  1.00 34.49           C  
+ATOM    677  N   THR A 759      36.977 -10.744  45.761  1.00 72.06           N  
+ATOM    678  CA  THR A 759      36.477 -11.320  44.519  1.00 83.08           C  
+ATOM    679  C   THR A 759      37.213 -10.638  43.367  1.00 86.16           C  
+ATOM    680  O   THR A 759      38.379 -10.283  43.507  1.00 94.75           O  
+ATOM    681  CB  THR A 759      34.949 -11.080  44.387  1.00 90.69           C  
+ATOM    682  OG1 THR A 759      34.313 -11.358  45.640  1.00 85.09           O  
+ATOM    683  CG2 THR A 759      34.342 -12.005  43.325  1.00 98.46           C  
+ATOM    684  N   SER A 760      36.553 -10.483  42.224  1.00 86.22           N  
+ATOM    685  CA  SER A 760      37.153  -9.809  41.083  1.00 91.65           C  
+ATOM    686  C   SER A 760      37.433  -8.400  41.602  1.00 95.98           C  
+ATOM    687  O   SER A 760      38.503  -7.829  41.375  1.00 98.69           O  
+ATOM    688  CB  SER A 760      36.148  -9.764  39.937  1.00 98.60           C  
+ATOM    689  OG  SER A 760      35.479 -11.009  39.818  1.00102.77           O  
+ATOM    690  N   THR A 761      36.442  -7.863  42.312  1.00100.97           N  
+ATOM    691  CA  THR A 761      36.518  -6.554  42.960  1.00 96.36           C  
+ATOM    692  C   THR A 761      36.211  -6.823  44.430  1.00 92.44           C  
+ATOM    693  O   THR A 761      35.461  -7.754  44.768  1.00 91.58           O  
+ATOM    694  CB  THR A 761      35.479  -5.533  42.415  1.00 95.81           C  
+ATOM    695  OG1 THR A 761      34.155  -6.078  42.515  1.00 99.68           O  
+ATOM    696  CG2 THR A 761      35.785  -5.165  40.963  1.00102.36           C  
+ATOM    697  N   VAL A 762      36.817  -6.032  45.302  1.00 84.88           N  
+ATOM    698  CA  VAL A 762      36.612  -6.190  46.729  1.00 82.79           C  
+ATOM    699  C   VAL A 762      35.181  -5.820  47.150  1.00 76.73           C  
+ATOM    700  O   VAL A 762      34.583  -4.896  46.603  1.00 81.53           O  
+ATOM    701  CB  VAL A 762      37.641  -5.358  47.511  1.00 84.24           C  
+ATOM    702  CG1 VAL A 762      37.561  -3.908  47.085  1.00 83.27           C  
+ATOM    703  CG2 VAL A 762      37.428  -5.511  49.011  1.00 86.10           C  
+ATOM    704  N   GLN A 763      34.627  -6.599  48.076  1.00 68.77           N  
+ATOM    705  CA  GLN A 763      33.279  -6.385  48.599  1.00 61.32           C  
+ATOM    706  C   GLN A 763      33.321  -6.106  50.101  1.00 52.68           C  
+ATOM    707  O   GLN A 763      33.977  -6.826  50.851  1.00 49.42           O  
+ATOM    708  CB  GLN A 763      32.401  -7.624  48.384  1.00 60.21           C  
+ATOM    709  CG  GLN A 763      32.276  -8.114  46.959  1.00 66.70           C  
+ATOM    710  CD  GLN A 763      31.331  -9.308  46.830  1.00 64.39           C  
+ATOM    711  OE1 GLN A 763      31.427 -10.288  47.577  1.00 69.45           O  
+ATOM    712  NE2 GLN A 763      30.409  -9.223  45.881  1.00 66.28           N  
+ATOM    713  N   LEU A 764      32.649  -5.043  50.531  1.00 51.46           N  
+ATOM    714  CA  LEU A 764      32.572  -4.721  51.952  1.00 48.10           C  
+ATOM    715  C   LEU A 764      31.303  -5.397  52.473  1.00 48.08           C  
+ATOM    716  O   LEU A 764      30.284  -5.395  51.782  1.00 49.33           O  
+ATOM    717  CB  LEU A 764      32.460  -3.224  52.158  1.00 46.76           C  
+ATOM    718  CG  LEU A 764      33.668  -2.358  51.827  1.00 69.78           C  
+ATOM    719  CD1 LEU A 764      33.274  -0.894  51.841  1.00 78.29           C  
+ATOM    720  CD2 LEU A 764      34.745  -2.600  52.834  1.00 72.54           C  
+ATOM    721  N   ILE A 765      31.388  -6.041  53.642  1.00 44.49           N  
+ATOM    722  CA  ILE A 765      30.234  -6.712  54.242  1.00 48.31           C  
+ATOM    723  C   ILE A 765      29.925  -6.093  55.607  1.00 52.32           C  
+ATOM    724  O   ILE A 765      30.805  -5.981  56.462  1.00 52.23           O  
+ATOM    725  CB  ILE A 765      30.460  -8.247  54.415  1.00 52.95           C  
+ATOM    726  CG1 ILE A 765      30.676  -8.917  53.059  1.00 51.87           C  
+ATOM    727  CG2 ILE A 765      29.234  -8.904  55.027  1.00 47.03           C  
+ATOM    728  CD1 ILE A 765      32.075  -8.866  52.606  1.00 56.56           C  
+ATOM    729  N   THR A 766      28.690  -5.637  55.789  1.00 44.63           N  
+ATOM    730  CA  THR A 766      28.297  -5.044  57.053  1.00 44.23           C  
+ATOM    731  C   THR A 766      26.947  -5.541  57.452  1.00 42.35           C  
+ATOM    732  O   THR A 766      26.311  -6.242  56.692  1.00 41.20           O  
+ATOM    733  CB  THR A 766      28.203  -3.507  57.003  1.00 38.85           C  
+ATOM    734  OG1 THR A 766      27.403  -3.109  55.889  1.00 44.72           O  
+ATOM    735  CG2 THR A 766      29.559  -2.884  56.910  1.00 58.58           C  
+ATOM    736  N   GLN A 767      26.525  -5.165  58.659  1.00 41.76           N  
+ATOM    737  CA  GLN A 767      25.224  -5.535  59.181  1.00 40.27           C  
+ATOM    738  C   GLN A 767      24.127  -4.831  58.384  1.00 44.44           C  
+ATOM    739  O   GLN A 767      24.253  -3.657  58.017  1.00 38.81           O  
+ATOM    740  CB  GLN A 767      25.105  -5.121  60.639  1.00 31.22           C  
+ATOM    741  CG  GLN A 767      23.684  -5.080  61.168  1.00 39.37           C  
+ATOM    742  CD  GLN A 767      23.601  -4.560  62.595  1.00 48.51           C  
+ATOM    743  OE1 GLN A 767      24.134  -3.495  62.922  1.00 55.48           O  
+ATOM    744  NE2 GLN A 767      22.920  -5.303  63.446  1.00 42.62           N  
+ATOM    745  N   LEU A 768      23.062  -5.574  58.100  1.00 43.01           N  
+ATOM    746  CA  LEU A 768      21.930  -5.035  57.378  1.00 42.60           C  
+ATOM    747  C   LEU A 768      21.127  -4.065  58.259  1.00 41.70           C  
+ATOM    748  O   LEU A 768      20.777  -4.374  59.401  1.00 41.93           O  
+ATOM    749  CB  LEU A 768      21.019  -6.172  56.932  1.00 38.39           C  
+ATOM    750  CG  LEU A 768      19.813  -5.742  56.110  1.00 42.83           C  
+ATOM    751  CD1 LEU A 768      20.318  -5.188  54.806  1.00 35.06           C  
+ATOM    752  CD2 LEU A 768      18.862  -6.903  55.888  1.00 37.08           C  
+ATOM    753  N   MET A 769      20.898  -2.866  57.744  1.00 45.02           N  
+ATOM    754  CA  MET A 769      20.091  -1.872  58.436  1.00 41.73           C  
+ATOM    755  C   MET A 769      18.783  -1.873  57.605  1.00 41.95           C  
+ATOM    756  O   MET A 769      18.565  -1.027  56.748  1.00 32.59           O  
+ATOM    757  CB  MET A 769      20.818  -0.533  58.411  1.00 40.44           C  
+ATOM    758  CG  MET A 769      22.197  -0.579  59.047  1.00 36.98           C  
+ATOM    759  SD  MET A 769      22.196  -1.163  60.774  1.00 44.95           S  
+ATOM    760  CE  MET A 769      21.937   0.370  61.588  1.00 41.08           C  
+ATOM    761  N   PRO A 770      17.864  -2.795  57.929  1.00 39.46           N  
+ATOM    762  CA  PRO A 770      16.570  -3.027  57.284  1.00 46.88           C  
+ATOM    763  C   PRO A 770      15.737  -1.836  56.847  1.00 50.74           C  
+ATOM    764  O   PRO A 770      15.103  -1.888  55.798  1.00 54.51           O  
+ATOM    765  CB  PRO A 770      15.805  -3.864  58.324  1.00 46.88           C  
+ATOM    766  CG  PRO A 770      16.870  -4.471  59.171  1.00 37.04           C  
+ATOM    767  CD  PRO A 770      17.843  -3.349  59.295  1.00 39.01           C  
+ATOM    768  N   PHE A 771      15.718  -0.780  57.650  1.00 49.47           N  
+ATOM    769  CA  PHE A 771      14.896   0.377  57.343  1.00 45.08           C  
+ATOM    770  C   PHE A 771      15.564   1.455  56.499  1.00 49.13           C  
+ATOM    771  O   PHE A 771      15.018   2.560  56.337  1.00 45.92           O  
+ATOM    772  CB  PHE A 771      14.330   0.938  58.643  1.00 39.19           C  
+ATOM    773  CG  PHE A 771      13.423  -0.022  59.350  1.00 54.15           C  
+ATOM    774  CD1 PHE A 771      13.932  -0.915  60.284  1.00 42.10           C  
+ATOM    775  CD2 PHE A 771      12.059  -0.069  59.047  1.00 49.19           C  
+ATOM    776  CE1 PHE A 771      13.101  -1.852  60.913  1.00 40.02           C  
+ATOM    777  CE2 PHE A 771      11.223  -0.993  59.663  1.00 48.79           C  
+ATOM    778  CZ  PHE A 771      11.747  -1.888  60.601  1.00 45.29           C  
+ATOM    779  N   GLY A 772      16.741   1.120  55.964  1.00 42.45           N  
+ATOM    780  CA  GLY A 772      17.489   2.033  55.119  1.00 42.54           C  
+ATOM    781  C   GLY A 772      17.961   3.315  55.768  1.00 43.91           C  
+ATOM    782  O   GLY A 772      17.986   3.412  56.992  1.00 54.66           O  
+ATOM    783  N   CYS A 773      18.316   4.305  54.947  1.00 45.01           N  
+ATOM    784  CA  CYS A 773      18.810   5.587  55.443  1.00 48.25           C  
+ATOM    785  C   CYS A 773      17.716   6.453  56.069  1.00 48.24           C  
+ATOM    786  O   CYS A 773      16.572   6.447  55.616  1.00 53.93           O  
+ATOM    787  CB  CYS A 773      19.566   6.358  54.350  1.00 49.39           C  
+ATOM    788  SG  CYS A 773      18.542   7.150  53.121  1.00 64.70           S  
+ATOM    789  N   LEU A 774      18.110   7.204  57.099  1.00 45.51           N  
+ATOM    790  CA  LEU A 774      17.238   8.075  57.877  1.00 45.93           C  
+ATOM    791  C   LEU A 774      16.503   9.156  57.090  1.00 42.62           C  
+ATOM    792  O   LEU A 774      15.345   9.434  57.379  1.00 44.08           O  
+ATOM    793  CB  LEU A 774      18.028   8.701  59.035  1.00 37.86           C  
+ATOM    794  CG  LEU A 774      17.224   9.366  60.153  1.00 42.91           C  
+ATOM    795  CD1 LEU A 774      16.227   8.375  60.729  1.00 38.44           C  
+ATOM    796  CD2 LEU A 774      18.153   9.886  61.235  1.00 47.66           C  
+ATOM    797  N   LEU A 775      17.179   9.768  56.121  1.00 44.71           N  
+ATOM    798  CA  LEU A 775      16.583  10.797  55.273  1.00 45.97           C  
+ATOM    799  C   LEU A 775      15.309  10.283  54.631  1.00 52.57           C  
+ATOM    800  O   LEU A 775      14.226  10.821  54.880  1.00 59.37           O  
+ATOM    801  CB  LEU A 775      17.543  11.226  54.166  1.00 41.57           C  
+ATOM    802  CG  LEU A 775      17.033  12.336  53.239  1.00 59.61           C  
+ATOM    803  CD1 LEU A 775      16.790  13.618  54.043  1.00 51.15           C  
+ATOM    804  CD2 LEU A 775      18.051  12.595  52.119  1.00 44.66           C  
+ATOM    805  N   ASP A 776      15.419   9.232  53.825  1.00 47.02           N  
+ATOM    806  CA  ASP A 776      14.224   8.698  53.191  1.00 54.22           C  
+ATOM    807  C   ASP A 776      13.247   8.165  54.195  1.00 51.83           C  
+ATOM    808  O   ASP A 776      12.045   8.153  53.936  1.00 54.00           O  
+ATOM    809  CB  ASP A 776      14.544   7.621  52.157  1.00 63.93           C  
+ATOM    810  CG  ASP A 776      15.193   8.192  50.919  1.00 78.52           C  
+ATOM    811  OD1 ASP A 776      16.228   7.634  50.489  1.00 91.07           O  
+ATOM    812  OD2 ASP A 776      14.676   9.209  50.391  1.00 90.46           O  
+ATOM    813  N   TYR A 777      13.746   7.736  55.349  1.00 47.56           N  
+ATOM    814  CA  TYR A 777      12.849   7.220  56.374  1.00 51.27           C  
+ATOM    815  C   TYR A 777      11.915   8.325  56.909  1.00 53.80           C  
+ATOM    816  O   TYR A 777      10.698   8.130  56.987  1.00 51.44           O  
+ATOM    817  CB  TYR A 777      13.631   6.552  57.508  1.00 52.40           C  
+ATOM    818  CG  TYR A 777      12.740   5.855  58.502  1.00 47.33           C  
+ATOM    819  CD1 TYR A 777      12.351   4.540  58.306  1.00 42.51           C  
+ATOM    820  CD2 TYR A 777      12.245   6.533  59.620  1.00 50.30           C  
+ATOM    821  CE1 TYR A 777      11.483   3.907  59.195  1.00 47.64           C  
+ATOM    822  CE2 TYR A 777      11.380   5.917  60.513  1.00 40.37           C  
+ATOM    823  CZ  TYR A 777      10.998   4.601  60.295  1.00 58.35           C  
+ATOM    824  OH  TYR A 777      10.119   3.984  61.160  1.00 61.78           O  
+ATOM    825  N   VAL A 778      12.463   9.497  57.227  1.00 50.37           N  
+ATOM    826  CA  VAL A 778      11.612  10.569  57.729  1.00 57.80           C  
+ATOM    827  C   VAL A 778      10.652  11.051  56.646  1.00 61.51           C  
+ATOM    828  O   VAL A 778       9.542  11.486  56.945  1.00 63.01           O  
+ATOM    829  CB  VAL A 778      12.399  11.767  58.330  1.00 44.85           C  
+ATOM    830  CG1 VAL A 778      13.212  11.319  59.516  1.00 36.50           C  
+ATOM    831  CG2 VAL A 778      13.268  12.433  57.293  1.00 31.46           C  
+ATOM    832  N   ARG A 779      11.068  10.934  55.387  1.00 60.95           N  
+ATOM    833  CA  ARG A 779      10.221  11.346  54.275  1.00 56.05           C  
+ATOM    834  C   ARG A 779       8.988  10.449  54.107  1.00 56.04           C  
+ATOM    835  O   ARG A 779       7.855  10.934  54.054  1.00 61.52           O  
+ATOM    836  CB  ARG A 779      11.017  11.398  52.979  1.00 45.27           C  
+ATOM    837  CG  ARG A 779      11.913  12.607  52.844  1.00 33.64           C  
+ATOM    838  CD  ARG A 779      12.778  12.486  51.598  1.00 34.97           C  
+ATOM    839  NE  ARG A 779      13.648  13.643  51.403  1.00 36.19           N  
+ATOM    840  CZ  ARG A 779      14.596  13.716  50.468  1.00 55.14           C  
+ATOM    841  NH1 ARG A 779      14.788  12.685  49.647  1.00 56.28           N  
+ATOM    842  NH2 ARG A 779      15.356  14.814  50.349  1.00 34.22           N  
+ATOM    843  N   GLU A 780       9.183   9.145  54.059  1.00 51.97           N  
+ATOM    844  CA  GLU A 780       8.027   8.300  53.897  1.00 60.68           C  
+ATOM    845  C   GLU A 780       7.336   7.921  55.198  1.00 62.37           C  
+ATOM    846  O   GLU A 780       6.592   6.941  55.245  1.00 74.01           O  
+ATOM    847  CB  GLU A 780       8.329   7.075  53.015  1.00 71.86           C  
+ATOM    848  CG  GLU A 780       8.824   5.833  53.726  1.00 76.77           C  
+ATOM    849  CD  GLU A 780       8.651   4.577  52.874  1.00104.17           C  
+ATOM    850  OE1 GLU A 780       9.176   4.549  51.735  1.00112.27           O  
+ATOM    851  OE2 GLU A 780       7.979   3.625  53.339  1.00100.28           O  
+ATOM    852  N   HIS A 781       7.572   8.684  56.259  1.00 61.36           N  
+ATOM    853  CA  HIS A 781       6.900   8.397  57.528  1.00 58.52           C  
+ATOM    854  C   HIS A 781       6.506   9.666  58.306  1.00 57.06           C  
+ATOM    855  O   HIS A 781       6.030   9.559  59.433  1.00 53.86           O  
+ATOM    856  CB  HIS A 781       7.734   7.452  58.423  1.00 55.60           C  
+ATOM    857  CG  HIS A 781       7.904   6.062  57.880  1.00 64.59           C  
+ATOM    858  ND1 HIS A 781       9.013   5.669  57.160  1.00 58.35           N  
+ATOM    859  CD2 HIS A 781       7.109   4.965  57.966  1.00 64.03           C  
+ATOM    860  CE1 HIS A 781       8.894   4.395  56.824  1.00 61.92           C  
+ATOM    861  NE2 HIS A 781       7.747   3.946  57.301  1.00 56.37           N  
+ATOM    862  N   LYS A 782       6.663  10.848  57.690  1.00 55.91           N  
+ATOM    863  CA  LYS A 782       6.326  12.144  58.320  1.00 63.44           C  
+ATOM    864  C   LYS A 782       5.097  12.098  59.232  1.00 71.56           C  
+ATOM    865  O   LYS A 782       5.121  12.598  60.358  1.00 82.57           O  
+ATOM    866  CB  LYS A 782       6.010  13.241  57.285  1.00 64.38           C  
+ATOM    867  CG  LYS A 782       6.653  13.152  55.915  1.00 84.37           C  
+ATOM    868  CD  LYS A 782       5.941  14.098  54.933  1.00 86.64           C  
+ATOM    869  CE  LYS A 782       6.654  14.195  53.573  1.00 92.68           C  
+ATOM    870  NZ  LYS A 782       7.919  15.015  53.619  1.00 93.68           N  
+ATOM    871  N   ASP A 783       4.011  11.529  58.717  1.00 70.30           N  
+ATOM    872  CA  ASP A 783       2.746  11.453  59.441  1.00 73.87           C  
+ATOM    873  C   ASP A 783       2.715  10.520  60.648  1.00 67.87           C  
+ATOM    874  O   ASP A 783       1.674  10.372  61.287  1.00 74.14           O  
+ATOM    875  CB  ASP A 783       1.604  11.092  58.472  1.00 82.36           C  
+ATOM    876  CG  ASP A 783       1.507  12.049  57.278  1.00 81.42           C  
+ATOM    877  OD1 ASP A 783       1.768  13.263  57.440  1.00 86.89           O  
+ATOM    878  OD2 ASP A 783       1.167  11.582  56.168  1.00 86.70           O  
+ATOM    879  N   ASN A 784       3.843   9.896  60.961  1.00 62.82           N  
+ATOM    880  CA  ASN A 784       3.915   8.974  62.091  1.00 69.72           C  
+ATOM    881  C   ASN A 784       5.193   9.144  62.910  1.00 71.25           C  
+ATOM    882  O   ASN A 784       5.564   8.250  63.681  1.00 76.82           O  
+ATOM    883  CB  ASN A 784       3.832   7.512  61.616  1.00 90.63           C  
+ATOM    884  CG  ASN A 784       2.446   7.119  61.138  1.00107.35           C  
+ATOM    885  OD1 ASN A 784       1.608   6.669  61.926  1.00105.06           O  
+ATOM    886  ND2 ASN A 784       2.205   7.261  59.837  1.00103.68           N  
+ATOM    887  N   ILE A 785       5.882  10.267  62.734  1.00 61.17           N  
+ATOM    888  CA  ILE A 785       7.112  10.496  63.475  1.00 55.69           C  
+ATOM    889  C   ILE A 785       6.895  11.507  64.590  1.00 53.27           C  
+ATOM    890  O   ILE A 785       6.709  12.700  64.349  1.00 51.26           O  
+ATOM    891  CB  ILE A 785       8.250  10.919  62.533  1.00 59.66           C  
+ATOM    892  CG1 ILE A 785       8.606   9.748  61.607  1.00 53.69           C  
+ATOM    893  CG2 ILE A 785       9.466  11.321  63.330  1.00 42.75           C  
+ATOM    894  CD1 ILE A 785       9.490  10.135  60.435  1.00 38.87           C  
+ATOM    895  N   GLY A 786       6.879  11.000  65.816  1.00 52.36           N  
+ATOM    896  CA  GLY A 786       6.673  11.848  66.973  1.00 48.87           C  
+ATOM    897  C   GLY A 786       7.954  12.390  67.568  1.00 52.55           C  
+ATOM    898  O   GLY A 786       9.018  11.785  67.435  1.00 57.72           O  
+ATOM    899  N   SER A 787       7.820  13.493  68.300  1.00 49.41           N  
+ATOM    900  CA  SER A 787       8.932  14.186  68.935  1.00 46.89           C  
+ATOM    901  C   SER A 787       9.927  13.323  69.710  1.00 44.61           C  
+ATOM    902  O   SER A 787      11.097  13.669  69.793  1.00 45.04           O  
+ATOM    903  CB  SER A 787       8.397  15.290  69.840  1.00 42.00           C  
+ATOM    904  OG  SER A 787       7.544  14.743  70.825  1.00 47.09           O  
+ATOM    905  N   GLN A 788       9.465  12.223  70.295  1.00 38.92           N  
+ATOM    906  CA  GLN A 788      10.360  11.363  71.045  1.00 47.50           C  
+ATOM    907  C   GLN A 788      11.384  10.692  70.127  1.00 49.03           C  
+ATOM    908  O   GLN A 788      12.556  10.538  70.488  1.00 50.47           O  
+ATOM    909  CB  GLN A 788       9.579  10.305  71.798  1.00 35.97           C  
+ATOM    910  CG  GLN A 788      10.434   9.463  72.716  1.00 41.45           C  
+ATOM    911  CD  GLN A 788      11.013  10.269  73.861  1.00 66.83           C  
+ATOM    912  OE1 GLN A 788      10.393  10.386  74.922  1.00 81.93           O  
+ATOM    913  NE2 GLN A 788      12.207  10.833  73.656  1.00 64.85           N  
+ATOM    914  N   TYR A 789      10.931  10.294  68.946  1.00 45.79           N  
+ATOM    915  CA  TYR A 789      11.806   9.658  67.986  1.00 41.58           C  
+ATOM    916  C   TYR A 789      12.807  10.654  67.428  1.00 41.47           C  
+ATOM    917  O   TYR A 789      14.010  10.362  67.353  1.00 41.43           O  
+ATOM    918  CB  TYR A 789      11.001   8.993  66.880  1.00 44.50           C  
+ATOM    919  CG  TYR A 789      10.392   7.671  67.290  1.00 41.58           C  
+ATOM    920  CD1 TYR A 789       9.295   7.610  68.142  1.00 60.46           C  
+ATOM    921  CD2 TYR A 789      10.902   6.482  66.804  1.00 62.73           C  
+ATOM    922  CE1 TYR A 789       8.723   6.389  68.493  1.00 59.32           C  
+ATOM    923  CE2 TYR A 789      10.344   5.261  67.148  1.00 64.34           C  
+ATOM    924  CZ  TYR A 789       9.259   5.218  67.989  1.00 68.15           C  
+ATOM    925  OH  TYR A 789       8.732   3.989  68.321  1.00 79.92           O  
+ATOM    926  N   LEU A 790      12.339  11.851  67.093  1.00 40.35           N  
+ATOM    927  CA  LEU A 790      13.255  12.869  66.579  1.00 37.27           C  
+ATOM    928  C   LEU A 790      14.393  13.182  67.555  1.00 36.86           C  
+ATOM    929  O   LEU A 790      15.572  13.142  67.178  1.00 41.71           O  
+ATOM    930  CB  LEU A 790      12.508  14.141  66.222  1.00 34.87           C  
+ATOM    931  CG  LEU A 790      11.669  14.039  64.944  1.00 50.24           C  
+ATOM    932  CD1 LEU A 790      10.695  15.208  64.816  1.00 49.40           C  
+ATOM    933  CD2 LEU A 790      12.611  14.011  63.755  1.00 45.56           C  
+ATOM    934  N   LEU A 791      14.047  13.426  68.818  1.00 35.56           N  
+ATOM    935  CA  LEU A 791      15.044  13.755  69.839  1.00 37.69           C  
+ATOM    936  C   LEU A 791      15.975  12.598  70.185  1.00 34.67           C  
+ATOM    937  O   LEU A 791      17.150  12.831  70.435  1.00 40.14           O  
+ATOM    938  CB  LEU A 791      14.382  14.340  71.091  1.00 39.36           C  
+ATOM    939  CG  LEU A 791      13.677  15.661  70.770  1.00 36.13           C  
+ATOM    940  CD1 LEU A 791      12.700  16.007  71.870  1.00 41.31           C  
+ATOM    941  CD2 LEU A 791      14.679  16.797  70.527  1.00 37.25           C  
+ATOM    942  N   ASN A 792      15.458  11.370  70.235  1.00 30.38           N  
+ATOM    943  CA  ASN A 792      16.315  10.202  70.489  1.00 38.22           C  
+ATOM    944  C   ASN A 792      17.323  10.028  69.332  1.00 38.88           C  
+ATOM    945  O   ASN A 792      18.470   9.664  69.571  1.00 41.61           O  
+ATOM    946  CB  ASN A 792      15.507   8.905  70.660  1.00 34.49           C  
+ATOM    947  CG  ASN A 792      14.829   8.794  72.036  1.00 63.91           C  
+ATOM    948  OD1 ASN A 792      15.047   9.615  72.931  1.00 55.49           O  
+ATOM    949  ND2 ASN A 792      14.019   7.752  72.208  1.00 50.57           N  
+ATOM    950  N   TRP A 793      16.917  10.300  68.087  1.00 33.17           N  
+ATOM    951  CA  TRP A 793      17.867  10.174  66.978  1.00 33.22           C  
+ATOM    952  C   TRP A 793      18.986  11.198  67.131  1.00 29.40           C  
+ATOM    953  O   TRP A 793      20.143  10.866  66.921  1.00 40.35           O  
+ATOM    954  CB  TRP A 793      17.196  10.306  65.604  1.00 28.42           C  
+ATOM    955  CG  TRP A 793      16.246   9.195  65.314  1.00 28.39           C  
+ATOM    956  CD1 TRP A 793      16.295   7.929  65.818  1.00 24.44           C  
+ATOM    957  CD2 TRP A 793      15.072   9.253  64.485  1.00 21.75           C  
+ATOM    958  NE1 TRP A 793      15.217   7.187  65.357  1.00 27.89           N  
+ATOM    959  CE2 TRP A 793      14.459   7.976  64.533  1.00 22.72           C  
+ATOM    960  CE3 TRP A 793      14.482  10.252  63.709  1.00 26.78           C  
+ATOM    961  CZ2 TRP A 793      13.289   7.677  63.829  1.00 31.94           C  
+ATOM    962  CZ3 TRP A 793      13.309   9.954  63.005  1.00 26.47           C  
+ATOM    963  CH2 TRP A 793      12.732   8.678  63.070  1.00 24.30           C  
+ATOM    964  N   CYS A 794      18.656  12.420  67.557  1.00 34.46           N  
+ATOM    965  CA  CYS A 794      19.671  13.454  67.761  1.00 29.94           C  
+ATOM    966  C   CYS A 794      20.667  13.036  68.849  1.00 36.44           C  
+ATOM    967  O   CYS A 794      21.868  13.279  68.724  1.00 43.89           O  
+ATOM    968  CB  CYS A 794      19.030  14.778  68.127  1.00 35.59           C  
+ATOM    969  SG  CYS A 794      18.079  15.523  66.796  1.00 34.86           S  
+ATOM    970  N   VAL A 795      20.174  12.370  69.888  1.00 33.82           N  
+ATOM    971  CA  VAL A 795      21.039  11.899  70.968  1.00 36.82           C  
+ATOM    972  C   VAL A 795      21.974  10.804  70.433  1.00 39.85           C  
+ATOM    973  O   VAL A 795      23.185  10.868  70.626  1.00 36.93           O  
+ATOM    974  CB  VAL A 795      20.207  11.329  72.173  1.00 32.68           C  
+ATOM    975  CG1 VAL A 795      21.099  10.583  73.129  1.00 22.10           C  
+ATOM    976  CG2 VAL A 795      19.544  12.458  72.936  1.00 31.09           C  
+ATOM    977  N   GLN A 796      21.391   9.806  69.769  1.00 41.72           N  
+ATOM    978  CA  GLN A 796      22.124   8.679  69.197  1.00 33.94           C  
+ATOM    979  C   GLN A 796      23.180   9.109  68.195  1.00 41.14           C  
+ATOM    980  O   GLN A 796      24.333   8.636  68.242  1.00 31.84           O  
+ATOM    981  CB  GLN A 796      21.145   7.704  68.562  1.00 34.71           C  
+ATOM    982  CG  GLN A 796      20.380   6.910  69.622  1.00 35.30           C  
+ATOM    983  CD  GLN A 796      19.397   5.936  69.035  1.00 39.76           C  
+ATOM    984  OE1 GLN A 796      19.566   5.463  67.910  1.00 56.49           O  
+ATOM    985  NE2 GLN A 796      18.360   5.622  69.790  1.00 47.78           N  
+ATOM    986  N   ILE A 797      22.804  10.025  67.302  1.00 33.81           N  
+ATOM    987  CA  ILE A 797      23.754  10.501  66.317  1.00 34.05           C  
+ATOM    988  C   ILE A 797      24.864  11.244  67.060  1.00 39.39           C  
+ATOM    989  O   ILE A 797      26.021  11.106  66.709  1.00 41.02           O  
+ATOM    990  CB  ILE A 797      23.096  11.422  65.272  1.00 37.63           C  
+ATOM    991  CG1 ILE A 797      22.082  10.634  64.450  1.00 22.87           C  
+ATOM    992  CG2 ILE A 797      24.174  12.076  64.368  1.00 19.73           C  
+ATOM    993  CD1 ILE A 797      21.257  11.506  63.506  1.00 33.35           C  
+ATOM    994  N   ALA A 798      24.520  12.004  68.102  1.00 41.25           N  
+ATOM    995  CA  ALA A 798      25.530  12.733  68.873  1.00 38.55           C  
+ATOM    996  C   ALA A 798      26.474  11.784  69.623  1.00 41.17           C  
+ATOM    997  O   ALA A 798      27.667  12.066  69.761  1.00 41.95           O  
+ATOM    998  CB  ALA A 798      24.882  13.696  69.831  1.00 24.12           C  
+ATOM    999  N   LYS A 799      25.945  10.662  70.099  1.00 36.30           N  
+ATOM   1000  CA  LYS A 799      26.766   9.678  70.787  1.00 30.80           C  
+ATOM   1001  C   LYS A 799      27.768   9.052  69.823  1.00 37.84           C  
+ATOM   1002  O   LYS A 799      28.948   8.934  70.149  1.00 43.91           O  
+ATOM   1003  CB  LYS A 799      25.908   8.577  71.371  1.00 23.13           C  
+ATOM   1004  CG  LYS A 799      25.154   8.978  72.581  1.00 35.42           C  
+ATOM   1005  CD  LYS A 799      24.384   7.804  73.169  1.00 25.21           C  
+ATOM   1006  CE  LYS A 799      23.772   8.278  74.495  1.00 38.54           C  
+ATOM   1007  NZ  LYS A 799      23.067   7.230  75.242  1.00 39.23           N  
+ATOM   1008  N   GLY A 800      27.280   8.631  68.650  1.00 39.67           N  
+ATOM   1009  CA  GLY A 800      28.136   8.037  67.637  1.00 24.71           C  
+ATOM   1010  C   GLY A 800      29.265   8.986  67.264  1.00 43.88           C  
+ATOM   1011  O   GLY A 800      30.439   8.592  67.210  1.00 48.37           O  
+ATOM   1012  N   MET A 801      28.920  10.253  67.061  1.00 37.65           N  
+ATOM   1013  CA  MET A 801      29.900  11.252  66.684  1.00 40.81           C  
+ATOM   1014  C   MET A 801      30.933  11.512  67.781  1.00 40.95           C  
+ATOM   1015  O   MET A 801      32.118  11.707  67.483  1.00 35.77           O  
+ATOM   1016  CB  MET A 801      29.216  12.558  66.277  1.00 28.88           C  
+ATOM   1017  CG  MET A 801      28.439  12.450  65.002  1.00 43.04           C  
+ATOM   1018  SD  MET A 801      29.361  11.787  63.564  1.00 39.80           S  
+ATOM   1019  CE  MET A 801      30.593  13.030  63.460  1.00 26.65           C  
+ATOM   1020  N   ASN A 802      30.488  11.546  69.039  1.00 41.67           N  
+ATOM   1021  CA  ASN A 802      31.397  11.781  70.168  1.00 38.89           C  
+ATOM   1022  C   ASN A 802      32.385  10.623  70.197  1.00 38.51           C  
+ATOM   1023  O   ASN A 802      33.570  10.831  70.432  1.00 36.70           O  
+ATOM   1024  CB  ASN A 802      30.634  11.867  71.498  1.00 31.21           C  
+ATOM   1025  CG  ASN A 802      31.562  11.946  72.722  1.00 38.28           C  
+ATOM   1026  OD1 ASN A 802      32.309  12.913  72.899  1.00 48.15           O  
+ATOM   1027  ND2 ASN A 802      31.501  10.932  73.575  1.00 30.97           N  
+ATOM   1028  N   TYR A 803      31.896   9.421  69.888  1.00 39.61           N  
+ATOM   1029  CA  TYR A 803      32.737   8.235  69.849  1.00 40.41           C  
+ATOM   1030  C   TYR A 803      33.800   8.433  68.778  1.00 43.10           C  
+ATOM   1031  O   TYR A 803      34.993   8.283  69.055  1.00 40.86           O  
+ATOM   1032  CB  TYR A 803      31.924   6.976  69.556  1.00 38.80           C  
+ATOM   1033  CG  TYR A 803      32.803   5.768  69.290  1.00 51.05           C  
+ATOM   1034  CD1 TYR A 803      33.389   5.058  70.341  1.00 40.82           C  
+ATOM   1035  CD2 TYR A 803      33.097   5.372  67.984  1.00 41.58           C  
+ATOM   1036  CE1 TYR A 803      34.247   3.989  70.098  1.00 33.20           C  
+ATOM   1037  CE2 TYR A 803      33.955   4.304  67.727  1.00 43.12           C  
+ATOM   1038  CZ  TYR A 803      34.524   3.618  68.781  1.00 51.70           C  
+ATOM   1039  OH  TYR A 803      35.357   2.563  68.503  1.00 52.98           O  
+ATOM   1040  N   LEU A 804      33.367   8.790  67.569  1.00 36.41           N  
+ATOM   1041  CA  LEU A 804      34.305   9.033  66.481  1.00 37.21           C  
+ATOM   1042  C   LEU A 804      35.352  10.039  66.903  1.00 42.76           C  
+ATOM   1043  O   LEU A 804      36.517   9.849  66.610  1.00 48.28           O  
+ATOM   1044  CB  LEU A 804      33.600   9.520  65.210  1.00 26.16           C  
+ATOM   1045  CG  LEU A 804      32.777   8.438  64.508  1.00 32.34           C  
+ATOM   1046  CD1 LEU A 804      32.304   8.975  63.201  1.00 33.22           C  
+ATOM   1047  CD2 LEU A 804      33.613   7.173  64.286  1.00 22.83           C  
+ATOM   1048  N   GLU A 805      34.949  11.078  67.637  1.00 48.63           N  
+ATOM   1049  CA  GLU A 805      35.894  12.103  68.091  1.00 45.78           C  
+ATOM   1050  C   GLU A 805      36.916  11.506  69.060  1.00 46.23           C  
+ATOM   1051  O   GLU A 805      38.102  11.821  69.002  1.00 49.92           O  
+ATOM   1052  CB  GLU A 805      35.173  13.282  68.739  1.00 38.63           C  
+ATOM   1053  CG  GLU A 805      36.136  14.387  69.171  1.00 48.99           C  
+ATOM   1054  CD  GLU A 805      35.468  15.702  69.557  1.00 53.77           C  
+ATOM   1055  OE1 GLU A 805      34.248  15.865  69.349  1.00 61.76           O  
+ATOM   1056  OE2 GLU A 805      36.182  16.592  70.064  1.00 69.17           O  
+ATOM   1057  N   ASP A 806      36.450  10.633  69.940  1.00 43.87           N  
+ATOM   1058  CA  ASP A 806      37.326   9.969  70.882  1.00 42.71           C  
+ATOM   1059  C   ASP A 806      38.347   9.122  70.109  1.00 47.19           C  
+ATOM   1060  O   ASP A 806      39.509   9.032  70.486  1.00 48.32           O  
+ATOM   1061  CB  ASP A 806      36.504   9.064  71.805  1.00 45.74           C  
+ATOM   1062  CG  ASP A 806      35.943   9.801  73.009  1.00 55.06           C  
+ATOM   1063  OD1 ASP A 806      36.425  10.915  73.305  1.00 65.72           O  
+ATOM   1064  OD2 ASP A 806      35.035   9.255  73.675  1.00 59.34           O  
+ATOM   1065  N   ARG A 807      37.915   8.556  68.990  1.00 45.21           N  
+ATOM   1066  CA  ARG A 807      38.774   7.703  68.186  1.00 47.26           C  
+ATOM   1067  C   ARG A 807      39.634   8.571  67.281  1.00 50.53           C  
+ATOM   1068  O   ARG A 807      40.458   8.074  66.523  1.00 56.70           O  
+ATOM   1069  CB  ARG A 807      37.890   6.740  67.376  1.00 36.57           C  
+ATOM   1070  CG  ARG A 807      38.601   5.639  66.634  1.00 74.03           C  
+ATOM   1071  CD  ARG A 807      39.130   4.547  67.552  1.00 85.23           C  
+ATOM   1072  NE  ARG A 807      39.844   3.522  66.792  1.00 80.58           N  
+ATOM   1073  CZ  ARG A 807      40.957   3.740  66.088  1.00 88.96           C  
+ATOM   1074  NH1 ARG A 807      41.502   4.948  66.033  1.00 71.64           N  
+ATOM   1075  NH2 ARG A 807      41.550   2.737  65.459  1.00 89.67           N  
+ATOM   1076  N   ARG A 808      39.467   9.882  67.414  1.00 48.61           N  
+ATOM   1077  CA  ARG A 808      40.186  10.860  66.604  1.00 47.56           C  
+ATOM   1078  C   ARG A 808      39.818  10.788  65.131  1.00 45.27           C  
+ATOM   1079  O   ARG A 808      40.637  11.061  64.266  1.00 50.55           O  
+ATOM   1080  CB  ARG A 808      41.702  10.729  66.782  1.00 52.89           C  
+ATOM   1081  CG  ARG A 808      42.196  11.179  68.144  1.00 69.77           C  
+ATOM   1082  CD  ARG A 808      43.713  11.261  68.220  1.00 69.15           C  
+ATOM   1083  NE  ARG A 808      44.099  11.842  69.500  1.00 94.06           N  
+ATOM   1084  CZ  ARG A 808      44.409  13.122  69.683  1.00100.61           C  
+ATOM   1085  NH1 ARG A 808      44.399  13.965  68.655  1.00 92.39           N  
+ATOM   1086  NH2 ARG A 808      44.662  13.571  70.908  1.00105.11           N  
+ATOM   1087  N   LEU A 809      38.565  10.467  64.849  1.00 43.95           N  
+ATOM   1088  CA  LEU A 809      38.110  10.376  63.473  1.00 45.44           C  
+ATOM   1089  C   LEU A 809      37.174  11.523  63.054  1.00 37.65           C  
+ATOM   1090  O   LEU A 809      36.206  11.803  63.733  1.00 50.68           O  
+ATOM   1091  CB  LEU A 809      37.406   9.049  63.268  1.00 43.62           C  
+ATOM   1092  CG  LEU A 809      37.172   8.774  61.796  1.00 61.18           C  
+ATOM   1093  CD1 LEU A 809      38.510   8.410  61.181  1.00 79.13           C  
+ATOM   1094  CD2 LEU A 809      36.186   7.647  61.617  1.00 79.36           C  
+ATOM   1095  N   VAL A 810      37.473  12.166  61.933  1.00 33.61           N  
+ATOM   1096  CA  VAL A 810      36.674  13.254  61.405  1.00 33.29           C  
+ATOM   1097  C   VAL A 810      35.856  12.732  60.204  1.00 43.06           C  
+ATOM   1098  O   VAL A 810      36.368  12.615  59.105  1.00 60.59           O  
+ATOM   1099  CB  VAL A 810      37.598  14.456  61.002  1.00 44.36           C  
+ATOM   1100  CG1 VAL A 810      36.851  15.494  60.205  1.00 33.29           C  
+ATOM   1101  CG2 VAL A 810      38.180  15.114  62.237  1.00 32.62           C  
+ATOM   1102  N   HIS A 811      34.667  12.326  60.533  1.00 44.15           N  
+ATOM   1103  CA  HIS A 811      33.711  11.967  59.538  1.00 42.88           C  
+ATOM   1104  C   HIS A 811      33.869  12.518  58.168  1.00 50.87           C  
+ATOM   1105  O   HIS A 811      34.642  11.883  57.384  1.00 79.26           O  
+ATOM   1106  CB  HIS A 811      32.399  11.429  59.969  1.00 29.72           C  
+ATOM   1107  CG  HIS A 811      31.482  10.742  59.051  1.00 26.61           C  
+ATOM   1108  ND1 HIS A 811      30.777  11.308  58.034  1.00 26.25           N  
+ATOM   1109  CD2 HIS A 811      31.041   9.439  59.073  1.00 26.55           C  
+ATOM   1110  CE1 HIS A 811      30.038  10.434  57.399  1.00 25.30           C  
+ATOM   1111  NE2 HIS A 811      30.158   9.279  58.040  1.00 29.81           N  
+ATOM   1112  N   ARG A 812      33.654  13.795  57.914  1.00 43.22           N  
+ATOM   1113  CA  ARG A 812      33.687  14.489  56.673  1.00 40.79           C  
+ATOM   1114  C   ARG A 812      32.524  14.338  55.738  1.00 38.63           C  
+ATOM   1115  O   ARG A 812      32.283  15.152  54.804  1.00 39.36           O  
+ATOM   1116  CB  ARG A 812      34.999  14.790  56.040  1.00 48.30           C  
+ATOM   1117  CG  ARG A 812      36.186  15.234  56.822  1.00 46.56           C  
+ATOM   1118  CD  ARG A 812      37.458  15.150  56.006  1.00 59.48           C  
+ATOM   1119  NE  ARG A 812      37.521  15.981  54.832  1.00 53.74           N  
+ATOM   1120  CZ  ARG A 812      37.711  15.608  53.579  1.00 68.23           C  
+ATOM   1121  NH1 ARG A 812      37.825  14.340  53.240  1.00 50.67           N  
+ATOM   1122  NH2 ARG A 812      37.776  16.537  52.627  1.00 64.39           N  
+ATOM   1123  N   ASP A 813      31.466  13.574  56.067  1.00 33.31           N  
+ATOM   1124  CA  ASP A 813      30.284  13.508  55.232  1.00 36.43           C  
+ATOM   1125  C   ASP A 813      29.051  13.099  56.051  1.00 44.24           C  
+ATOM   1126  O   ASP A 813      28.286  12.201  55.672  1.00 38.40           O  
+ATOM   1127  CB  ASP A 813      30.529  12.559  54.046  1.00 33.59           C  
+ATOM   1128  CG  ASP A 813      29.416  12.603  53.004  1.00 46.44           C  
+ATOM   1129  OD1 ASP A 813      28.721  13.633  52.893  1.00 58.19           O  
+ATOM   1130  OD2 ASP A 813      29.230  11.599  52.290  1.00 53.78           O  
+ATOM   1131  N   LEU A 814      28.860  13.785  57.173  1.00 44.31           N  
+ATOM   1132  CA  LEU A 814      27.734  13.515  58.055  1.00 38.77           C  
+ATOM   1133  C   LEU A 814      26.515  14.207  57.486  1.00 36.03           C  
+ATOM   1134  O   LEU A 814      26.532  15.412  57.294  1.00 27.43           O  
+ATOM   1135  CB  LEU A 814      28.015  14.060  59.462  1.00 47.33           C  
+ATOM   1136  CG  LEU A 814      26.903  13.902  60.512  1.00 47.51           C  
+ATOM   1137  CD1 LEU A 814      26.356  12.463  60.541  1.00 36.48           C  
+ATOM   1138  CD2 LEU A 814      27.450  14.300  61.868  1.00 36.58           C  
+ATOM   1139  N   ALA A 815      25.433  13.454  57.320  1.00 31.91           N  
+ATOM   1140  CA  ALA A 815      24.198  13.990  56.774  1.00 30.48           C  
+ATOM   1141  C   ALA A 815      23.151  12.900  56.943  1.00 38.98           C  
+ATOM   1142  O   ALA A 815      23.513  11.738  57.146  1.00 39.49           O  
+ATOM   1143  CB  ALA A 815      24.393  14.318  55.326  1.00 26.08           C  
+ATOM   1144  N   ALA A 816      21.864  13.254  56.880  1.00 36.62           N  
+ATOM   1145  CA  ALA A 816      20.812  12.244  57.062  1.00 36.89           C  
+ATOM   1146  C   ALA A 816      20.942  11.013  56.161  1.00 34.00           C  
+ATOM   1147  O   ALA A 816      20.623   9.898  56.579  1.00 45.11           O  
+ATOM   1148  CB  ALA A 816      19.402  12.875  56.927  1.00 29.81           C  
+ATOM   1149  N   ARG A 817      21.429  11.206  54.935  1.00 45.25           N  
+ATOM   1150  CA  ARG A 817      21.578  10.086  53.999  1.00 48.10           C  
+ATOM   1151  C   ARG A 817      22.586   9.048  54.494  1.00 44.86           C  
+ATOM   1152  O   ARG A 817      22.506   7.886  54.116  1.00 47.75           O  
+ATOM   1153  CB  ARG A 817      21.986  10.579  52.598  1.00 34.72           C  
+ATOM   1154  CG  ARG A 817      23.366  11.192  52.520  1.00 44.13           C  
+ATOM   1155  CD  ARG A 817      23.628  11.823  51.138  1.00 41.71           C  
+ATOM   1156  NE  ARG A 817      24.198  13.163  51.290  1.00 44.49           N  
+ATOM   1157  CZ  ARG A 817      25.471  13.403  51.581  1.00 57.10           C  
+ATOM   1158  NH1 ARG A 817      26.327  12.396  51.723  1.00 70.85           N  
+ATOM   1159  NH2 ARG A 817      25.861  14.638  51.848  1.00 48.19           N  
+ATOM   1160  N   ASN A 818      23.484   9.475  55.379  1.00 38.66           N  
+ATOM   1161  CA  ASN A 818      24.535   8.632  55.917  1.00 40.52           C  
+ATOM   1162  C   ASN A 818      24.264   8.145  57.349  1.00 43.40           C  
+ATOM   1163  O   ASN A 818      25.191   7.939  58.145  1.00 41.83           O  
+ATOM   1164  CB  ASN A 818      25.885   9.370  55.840  1.00 29.76           C  
+ATOM   1165  CG  ASN A 818      26.331   9.642  54.406  1.00 40.76           C  
+ATOM   1166  OD1 ASN A 818      25.942   8.931  53.475  1.00 41.82           O  
+ATOM   1167  ND2 ASN A 818      27.163  10.679  54.223  1.00 29.10           N  
+ATOM   1168  N   VAL A 819      22.992   8.022  57.696  1.00 33.68           N  
+ATOM   1169  CA  VAL A 819      22.628   7.511  59.007  1.00 36.69           C  
+ATOM   1170  C   VAL A 819      21.658   6.416  58.630  1.00 42.20           C  
+ATOM   1171  O   VAL A 819      20.719   6.665  57.867  1.00 39.63           O  
+ATOM   1172  CB  VAL A 819      21.939   8.582  59.912  1.00 39.03           C  
+ATOM   1173  CG1 VAL A 819      21.390   7.942  61.180  1.00 32.60           C  
+ATOM   1174  CG2 VAL A 819      22.929   9.666  60.302  1.00 31.20           C  
+ATOM   1175  N   LEU A 820      21.942   5.194  59.079  1.00 38.89           N  
+ATOM   1176  CA  LEU A 820      21.098   4.056  58.748  1.00 40.83           C  
+ATOM   1177  C   LEU A 820      20.188   3.713  59.905  1.00 42.46           C  
+ATOM   1178  O   LEU A 820      20.485   4.047  61.049  1.00 41.65           O  
+ATOM   1179  CB  LEU A 820      21.959   2.858  58.309  1.00 47.49           C  
+ATOM   1180  CG  LEU A 820      22.793   3.129  57.035  1.00 42.68           C  
+ATOM   1181  CD1 LEU A 820      23.654   1.948  56.676  1.00 44.67           C  
+ATOM   1182  CD2 LEU A 820      21.887   3.463  55.869  1.00 30.23           C  
+ATOM   1183  N   VAL A 821      19.067   3.070  59.598  1.00 36.86           N  
+ATOM   1184  CA  VAL A 821      18.083   2.707  60.604  1.00 32.03           C  
+ATOM   1185  C   VAL A 821      18.030   1.187  60.862  1.00 36.99           C  
+ATOM   1186  O   VAL A 821      17.669   0.411  59.974  1.00 41.63           O  
+ATOM   1187  CB  VAL A 821      16.683   3.201  60.156  1.00 42.85           C  
+ATOM   1188  CG1 VAL A 821      15.654   2.955  61.246  1.00 29.15           C  
+ATOM   1189  CG2 VAL A 821      16.729   4.678  59.763  1.00 25.63           C  
+ATOM   1190  N   LYS A 822      18.441   0.753  62.051  1.00 34.10           N  
+ATOM   1191  CA  LYS A 822      18.403  -0.678  62.395  1.00 43.02           C  
+ATOM   1192  C   LYS A 822      16.955  -1.007  62.747  1.00 41.79           C  
+ATOM   1193  O   LYS A 822      16.413  -2.027  62.320  1.00 40.06           O  
+ATOM   1194  CB  LYS A 822      19.320  -1.002  63.590  1.00 43.66           C  
+ATOM   1195  CG  LYS A 822      18.994  -2.347  64.244  1.00 36.78           C  
+ATOM   1196  CD  LYS A 822      20.245  -3.112  64.610  1.00 43.51           C  
+ATOM   1197  CE  LYS A 822      20.591  -2.972  66.057  1.00 47.74           C  
+ATOM   1198  NZ  LYS A 822      20.226  -4.214  66.760  1.00 52.69           N  
+ATOM   1199  N   THR A 823      16.376  -0.104  63.539  1.00 45.11           N  
+ATOM   1200  CA  THR A 823      14.993  -0.112  64.008  1.00 49.31           C  
+ATOM   1201  C   THR A 823      14.647   1.369  64.185  1.00 50.51           C  
+ATOM   1202  O   THR A 823      15.542   2.210  64.313  1.00 48.71           O  
+ATOM   1203  CB  THR A 823      14.831  -0.764  65.402  1.00 47.80           C  
+ATOM   1204  OG1 THR A 823      15.463   0.050  66.393  1.00 60.85           O  
+ATOM   1205  CG2 THR A 823      15.433  -2.153  65.432  1.00 43.68           C  
+ATOM   1206  N   PRO A 824      13.350   1.711  64.200  1.00 51.63           N  
+ATOM   1207  CA  PRO A 824      12.948   3.112  64.373  1.00 48.88           C  
+ATOM   1208  C   PRO A 824      13.548   3.725  65.654  1.00 47.85           C  
+ATOM   1209  O   PRO A 824      13.749   4.939  65.732  1.00 51.00           O  
+ATOM   1210  CB  PRO A 824      11.430   3.010  64.443  1.00 52.73           C  
+ATOM   1211  CG  PRO A 824      11.149   1.840  63.524  1.00 57.21           C  
+ATOM   1212  CD  PRO A 824      12.176   0.847  63.993  1.00 48.93           C  
+ATOM   1213  N   GLN A 825      13.867   2.877  66.631  1.00 38.49           N  
+ATOM   1214  CA  GLN A 825      14.466   3.330  67.877  1.00 45.07           C  
+ATOM   1215  C   GLN A 825      16.005   3.176  67.972  1.00 48.24           C  
+ATOM   1216  O   GLN A 825      16.610   3.470  69.008  1.00 48.28           O  
+ATOM   1217  CB  GLN A 825      13.778   2.678  69.096  1.00 42.30           C  
+ATOM   1218  CG  GLN A 825      13.343   1.226  68.957  1.00 66.86           C  
+ATOM   1219  CD  GLN A 825      11.994   1.054  68.244  1.00 70.98           C  
+ATOM   1220  OE1 GLN A 825      11.879   0.264  67.315  1.00 69.95           O  
+ATOM   1221  NE2 GLN A 825      10.972   1.778  68.699  1.00 76.17           N  
+ATOM   1222  N   HIS A 826      16.651   2.801  66.876  1.00 38.77           N  
+ATOM   1223  CA  HIS A 826      18.096   2.613  66.912  1.00 42.02           C  
+ATOM   1224  C   HIS A 826      18.764   2.910  65.560  1.00 39.66           C  
+ATOM   1225  O   HIS A 826      18.636   2.128  64.615  1.00 42.04           O  
+ATOM   1226  CB  HIS A 826      18.406   1.172  67.368  1.00 23.62           C  
+ATOM   1227  CG  HIS A 826      19.854   0.918  67.659  1.00 37.86           C  
+ATOM   1228  ND1 HIS A 826      20.308  -0.253  68.226  1.00 39.94           N  
+ATOM   1229  CD2 HIS A 826      20.956   1.690  67.474  1.00 39.90           C  
+ATOM   1230  CE1 HIS A 826      21.619  -0.195  68.380  1.00 36.12           C  
+ATOM   1231  NE2 HIS A 826      22.035   0.976  67.932  1.00 38.38           N  
+ATOM   1232  N   VAL A 827      19.464   4.037  65.472  1.00 32.91           N  
+ATOM   1233  CA  VAL A 827      20.161   4.417  64.239  1.00 35.49           C  
+ATOM   1234  C   VAL A 827      21.686   4.429  64.440  1.00 40.79           C  
+ATOM   1235  O   VAL A 827      22.166   4.458  65.582  1.00 38.18           O  
+ATOM   1236  CB  VAL A 827      19.711   5.805  63.711  1.00 34.84           C  
+ATOM   1237  CG1 VAL A 827      18.201   5.828  63.522  1.00 44.64           C  
+ATOM   1238  CG2 VAL A 827      20.159   6.925  64.657  1.00 24.65           C  
+ATOM   1239  N   LYS A 828      22.431   4.401  63.327  1.00 43.74           N  
+ATOM   1240  CA  LYS A 828      23.905   4.400  63.329  1.00 36.35           C  
+ATOM   1241  C   LYS A 828      24.485   5.185  62.164  1.00 35.34           C  
+ATOM   1242  O   LYS A 828      23.919   5.220  61.070  1.00 43.44           O  
+ATOM   1243  CB  LYS A 828      24.458   2.980  63.219  1.00 42.12           C  
+ATOM   1244  CG  LYS A 828      23.916   1.974  64.210  1.00 47.39           C  
+ATOM   1245  CD  LYS A 828      24.681   0.680  64.073  1.00 48.36           C  
+ATOM   1246  CE  LYS A 828      23.978  -0.468  64.761  1.00 34.76           C  
+ATOM   1247  NZ  LYS A 828      24.835  -1.702  64.709  1.00 40.58           N  
+ATOM   1248  N   ILE A 829      25.655   5.762  62.387  1.00 30.08           N  
+ATOM   1249  CA  ILE A 829      26.341   6.538  61.360  1.00 38.70           C  
+ATOM   1250  C   ILE A 829      27.096   5.598  60.396  1.00 41.13           C  
+ATOM   1251  O   ILE A 829      27.615   4.564  60.805  1.00 46.09           O  
+ATOM   1252  CB  ILE A 829      27.335   7.502  62.007  1.00 38.85           C  
+ATOM   1253  CG1 ILE A 829      26.610   8.449  62.960  1.00 38.83           C  
+ATOM   1254  CG2 ILE A 829      28.042   8.301  60.959  1.00 34.04           C  
+ATOM   1255  CD1 ILE A 829      27.569   9.284  63.764  1.00 34.00           C  
+ATOM   1256  N   THR A 830      27.187   5.976  59.128  1.00 35.80           N  
+ATOM   1257  CA  THR A 830      27.862   5.143  58.157  1.00 40.58           C  
+ATOM   1258  C   THR A 830      28.557   5.994  57.099  1.00 46.89           C  
+ATOM   1259  O   THR A 830      28.742   7.210  57.293  1.00 46.28           O  
+ATOM   1260  CB  THR A 830      26.857   4.149  57.520  1.00 45.84           C  
+ATOM   1261  OG1 THR A 830      27.557   3.072  56.887  1.00 55.49           O  
+ATOM   1262  CG2 THR A 830      25.974   4.851  56.529  1.00 54.15           C  
+ATOM   1263  N  AASP A 831      28.952   5.339  56.003  0.50 46.16           N  
+ATOM   1264  N  BASP A 831      28.946   5.352  55.998  0.50 48.15           N  
+ATOM   1265  CA AASP A 831      29.643   5.954  54.868  0.50 41.99           C  
+ATOM   1266  CA BASP A 831      29.642   5.987  54.876  0.50 45.50           C  
+ATOM   1267  C  AASP A 831      30.901   6.726  55.228  0.50 39.76           C  
+ATOM   1268  C  BASP A 831      30.902   6.732  55.268  0.50 41.60           C  
+ATOM   1269  O  AASP A 831      30.893   7.946  55.282  0.50 40.46           O  
+ATOM   1270  O  BASP A 831      30.895   7.948  55.395  0.50 45.22           O  
+ATOM   1271  CB AASP A 831      28.683   6.812  54.040  0.50 36.83           C  
+ATOM   1272  CB BASP A 831      28.733   6.925  54.078  0.50 49.73           C  
+ATOM   1273  CG AASP A 831      27.943   6.002  52.979  0.50 38.86           C  
+ATOM   1274  CG BASP A 831      29.347   7.321  52.742  0.50 58.97           C  
+ATOM   1275  OD1AASP A 831      28.489   5.849  51.866  0.50 64.02           O  
+ATOM   1276  OD1BASP A 831      29.092   6.606  51.755  0.50 72.85           O  
+ATOM   1277  OD2AASP A 831      26.827   5.510  53.247  0.50 35.84           O  
+ATOM   1278  OD2BASP A 831      30.096   8.321  52.675  0.50 62.80           O  
+ATOM   1279  N   PHE A 832      31.996   5.996  55.411  1.00 44.92           N  
+ATOM   1280  CA  PHE A 832      33.281   6.583  55.779  1.00 43.17           C  
+ATOM   1281  C   PHE A 832      34.200   6.881  54.604  1.00 46.94           C  
+ATOM   1282  O   PHE A 832      35.402   7.100  54.784  1.00 45.58           O  
+ATOM   1283  CB  PHE A 832      33.974   5.683  56.794  1.00 39.91           C  
+ATOM   1284  CG  PHE A 832      33.245   5.605  58.109  1.00 50.66           C  
+ATOM   1285  CD1 PHE A 832      32.296   4.619  58.336  1.00 49.56           C  
+ATOM   1286  CD2 PHE A 832      33.443   6.573  59.084  1.00 48.51           C  
+ATOM   1287  CE1 PHE A 832      31.548   4.610  59.510  1.00 49.07           C  
+ATOM   1288  CE2 PHE A 832      32.701   6.568  60.258  1.00 28.64           C  
+ATOM   1289  CZ  PHE A 832      31.754   5.591  60.472  1.00 38.59           C  
+ATOM   1290  N   GLY A 833      33.602   6.987  53.417  1.00 48.67           N  
+ATOM   1291  CA  GLY A 833      34.361   7.265  52.207  1.00 44.97           C  
+ATOM   1292  C   GLY A 833      35.294   8.457  52.253  1.00 45.44           C  
+ATOM   1293  O   GLY A 833      36.305   8.478  51.570  1.00 58.13           O  
+ATOM   1294  N   LEU A 834      34.991   9.440  53.087  1.00 45.82           N  
+ATOM   1295  CA  LEU A 834      35.820  10.628  53.168  1.00 36.57           C  
+ATOM   1296  C   LEU A 834      36.482  10.795  54.529  1.00 41.93           C  
+ATOM   1297  O   LEU A 834      37.194  11.791  54.762  1.00 39.29           O  
+ATOM   1298  CB  LEU A 834      34.963  11.856  52.845  1.00 47.53           C  
+ATOM   1299  CG  LEU A 834      34.528  12.161  51.399  1.00 55.51           C  
+ATOM   1300  CD1 LEU A 834      34.028  10.951  50.650  1.00 80.50           C  
+ATOM   1301  CD2 LEU A 834      33.437  13.218  51.422  1.00 66.67           C  
+ATOM   1302  N   ALA A 835      36.274   9.822  55.420  1.00 38.33           N  
+ATOM   1303  CA  ALA A 835      36.821   9.896  56.783  1.00 44.47           C  
+ATOM   1304  C   ALA A 835      38.338   9.874  56.859  1.00 50.84           C  
+ATOM   1305  O   ALA A 835      38.983   9.091  56.169  1.00 64.89           O  
+ATOM   1306  CB  ALA A 835      36.243   8.774  57.643  1.00 42.10           C  
+ATOM   1307  N   LYS A 836      38.904  10.723  57.712  1.00 50.08           N  
+ATOM   1308  CA  LYS A 836      40.355  10.801  57.893  1.00 49.52           C  
+ATOM   1309  C   LYS A 836      40.717  10.723  59.374  1.00 54.11           C  
+ATOM   1310  O   LYS A 836      40.073  11.369  60.193  1.00 62.01           O  
+ATOM   1311  CB  LYS A 836      40.897  12.125  57.334  1.00 45.56           C  
+ATOM   1312  CG  LYS A 836      40.660  12.360  55.828  1.00 58.47           C  
+ATOM   1313  CD  LYS A 836      41.473  11.395  54.978  1.00 61.89           C  
+ATOM   1314  CE  LYS A 836      41.264  11.604  53.479  1.00 71.39           C  
+ATOM   1315  NZ  LYS A 836      39.915  11.144  53.014  1.00 79.33           N  
+ATOM   1316  N   LEU A 837      41.716   9.909  59.726  1.00 59.41           N  
+ATOM   1317  CA  LEU A 837      42.172   9.804  61.119  1.00 63.16           C  
+ATOM   1318  C   LEU A 837      43.249  10.865  61.352  1.00 64.99           C  
+ATOM   1319  O   LEU A 837      44.182  10.982  60.560  1.00 75.83           O  
+ATOM   1320  CB  LEU A 837      42.749   8.418  61.423  1.00 65.59           C  
+ATOM   1321  CG  LEU A 837      41.804   7.239  61.190  1.00 81.66           C  
+ATOM   1322  CD1 LEU A 837      41.731   6.954  59.696  1.00 92.32           C  
+ATOM   1323  CD2 LEU A 837      42.271   5.998  61.937  1.00 80.11           C  
+ATOM   1324  N   LEU A 838      43.111  11.656  62.411  1.00 61.87           N  
+ATOM   1325  CA  LEU A 838      44.081  12.701  62.701  1.00 62.05           C  
+ATOM   1326  C   LEU A 838      45.183  12.173  63.595  1.00 72.70           C  
+ATOM   1327  O   LEU A 838      44.956  11.266  64.396  1.00 76.57           O  
+ATOM   1328  CB  LEU A 838      43.421  13.882  63.401  1.00 57.41           C  
+ATOM   1329  CG  LEU A 838      42.195  14.552  62.785  1.00 64.73           C  
+ATOM   1330  CD1 LEU A 838      41.809  15.776  63.636  1.00 43.22           C  
+ATOM   1331  CD2 LEU A 838      42.460  14.953  61.351  1.00 53.73           C  
+ATOM   1332  N   GLY A 839      46.368  12.768  63.476  1.00 75.85           N  
+ATOM   1333  CA  GLY A 839      47.498  12.363  64.293  1.00 76.63           C  
+ATOM   1334  C   GLY A 839      47.292  12.628  65.775  1.00 80.92           C  
+ATOM   1335  O   GLY A 839      46.178  12.903  66.229  1.00 82.23           O  
+ATOM   1336  N   ALA A 840      48.365  12.506  66.545  1.00 86.34           N  
+ATOM   1337  CA  ALA A 840      48.281  12.736  67.978  1.00 95.21           C  
+ATOM   1338  C   ALA A 840      48.291  14.228  68.251  1.00 98.27           C  
+ATOM   1339  O   ALA A 840      47.475  14.733  69.018  1.00102.27           O  
+ATOM   1340  CB  ALA A 840      49.444  12.061  68.694  1.00108.61           C  
+ATOM   1341  N   GLU A 841      49.226  14.928  67.622  1.00 98.92           N  
+ATOM   1342  CA  GLU A 841      49.341  16.366  67.806  1.00105.76           C  
+ATOM   1343  C   GLU A 841      48.789  17.096  66.586  1.00106.30           C  
+ATOM   1344  O   GLU A 841      49.109  18.263  66.345  1.00107.09           O  
+ATOM   1345  CB  GLU A 841      50.808  16.756  68.051  1.00113.03           C  
+ATOM   1346  CG  GLU A 841      51.495  16.014  69.208  1.00113.21           C  
+ATOM   1347  CD  GLU A 841      50.746  16.141  70.533  1.00119.82           C  
+ATOM   1348  OE1 GLU A 841      50.266  15.101  71.042  1.00118.11           O  
+ATOM   1349  OE2 GLU A 841      50.642  17.272  71.066  1.00101.46           O  
+ATOM   1350  N   GLU A 842      47.973  16.388  65.809  1.00105.18           N  
+ATOM   1351  CA  GLU A 842      47.358  16.946  64.609  1.00104.00           C  
+ATOM   1352  C   GLU A 842      45.977  17.497  64.994  1.00102.97           C  
+ATOM   1353  O   GLU A 842      45.166  16.795  65.603  1.00105.99           O  
+ATOM   1354  CB  GLU A 842      47.240  15.859  63.541  1.00100.30           C  
+ATOM   1355  CG  GLU A 842      47.102  16.360  62.118  1.00101.00           C  
+ATOM   1356  CD  GLU A 842      46.873  15.227  61.128  1.00103.69           C  
+ATOM   1357  OE1 GLU A 842      47.821  14.467  60.841  1.00104.94           O  
+ATOM   1358  OE2 GLU A 842      45.736  15.091  60.639  1.00110.90           O  
+ATOM   1359  N   LYS A 843      45.722  18.756  64.646  1.00100.06           N  
+ATOM   1360  CA  LYS A 843      44.462  19.415  64.990  1.00 93.63           C  
+ATOM   1361  C   LYS A 843      43.456  19.483  63.855  1.00 85.63           C  
+ATOM   1362  O   LYS A 843      42.260  19.590  64.095  1.00 80.69           O  
+ATOM   1363  CB  LYS A 843      44.741  20.840  65.476  1.00103.45           C  
+ATOM   1364  CG  LYS A 843      45.401  21.720  64.409  1.00103.41           C  
+ATOM   1365  CD  LYS A 843      45.764  23.105  64.929  1.00109.38           C  
+ATOM   1366  CE  LYS A 843      46.384  23.972  63.824  1.00109.40           C  
+ATOM   1367  NZ  LYS A 843      47.620  23.386  63.209  1.00 97.57           N  
+ATOM   1368  N   GLU A 844      43.939  19.454  62.619  1.00 82.73           N  
+ATOM   1369  CA  GLU A 844      43.045  19.547  61.475  1.00 78.81           C  
+ATOM   1370  C   GLU A 844      43.560  18.863  60.229  1.00 74.67           C  
+ATOM   1371  O   GLU A 844      44.760  18.658  60.066  1.00 83.49           O  
+ATOM   1372  CB  GLU A 844      42.742  21.018  61.159  1.00 81.67           C  
+ATOM   1373  CG  GLU A 844      43.967  21.890  60.919  1.00 78.85           C  
+ATOM   1374  CD  GLU A 844      43.650  23.386  60.944  1.00 92.66           C  
+ATOM   1375  OE1 GLU A 844      42.942  23.834  61.878  1.00107.61           O  
+ATOM   1376  OE2 GLU A 844      44.121  24.115  60.039  1.00 85.28           O  
+ATOM   1377  N   TYR A 845      42.630  18.516  59.351  1.00 62.83           N  
+ATOM   1378  CA  TYR A 845      42.957  17.871  58.102  1.00 62.12           C  
+ATOM   1379  C   TYR A 845      42.804  18.855  56.955  1.00 68.06           C  
+ATOM   1380  O   TYR A 845      41.799  19.552  56.852  1.00 65.92           O  
+ATOM   1381  CB  TYR A 845      42.060  16.656  57.872  1.00 60.32           C  
+ATOM   1382  CG  TYR A 845      42.157  16.108  56.467  1.00 59.62           C  
+ATOM   1383  CD1 TYR A 845      43.211  15.270  56.088  1.00 65.72           C  
+ATOM   1384  CD2 TYR A 845      41.208  16.456  55.503  1.00 62.42           C  
+ATOM   1385  CE1 TYR A 845      43.315  14.793  54.773  1.00 68.26           C  
+ATOM   1386  CE2 TYR A 845      41.298  15.989  54.198  1.00 60.79           C  
+ATOM   1387  CZ  TYR A 845      42.352  15.160  53.838  1.00 77.11           C  
+ATOM   1388  OH  TYR A 845      42.430  14.705  52.546  1.00 71.74           O  
+ATOM   1389  N   HIS A 846      43.799  18.865  56.071  1.00 79.11           N  
+ATOM   1390  CA  HIS A 846      43.816  19.744  54.911  1.00 82.38           C  
+ATOM   1391  C   HIS A 846      43.508  18.900  53.689  1.00 84.19           C  
+ATOM   1392  O   HIS A 846      44.308  18.058  53.296  1.00 91.80           O  
+ATOM   1393  CB  HIS A 846      45.193  20.398  54.788  1.00 94.00           C  
+ATOM   1394  CG  HIS A 846      45.676  21.018  56.066  1.00 99.87           C  
+ATOM   1395  ND1 HIS A 846      45.670  22.380  56.282  1.00110.18           N  
+ATOM   1396  CD2 HIS A 846      46.136  20.457  57.211  1.00104.37           C  
+ATOM   1397  CE1 HIS A 846      46.101  22.632  57.506  1.00113.99           C  
+ATOM   1398  NE2 HIS A 846      46.390  21.482  58.091  1.00109.21           N  
+ATOM   1399  N   ALA A 847      42.335  19.120  53.105  1.00 86.91           N  
+ATOM   1400  CA  ALA A 847      41.881  18.363  51.942  1.00 87.82           C  
+ATOM   1401  C   ALA A 847      42.546  18.739  50.628  1.00 92.21           C  
+ATOM   1402  O   ALA A 847      43.412  19.612  50.583  1.00 90.71           O  
+ATOM   1403  CB  ALA A 847      40.378  18.465  51.813  1.00 79.99           C  
+ATOM   1404  N   GLU A 848      42.105  18.083  49.557  1.00 95.57           N  
+ATOM   1405  CA  GLU A 848      42.645  18.304  48.224  1.00100.88           C  
+ATOM   1406  C   GLU A 848      41.553  18.516  47.170  1.00105.24           C  
+ATOM   1407  O   GLU A 848      41.116  19.643  46.944  1.00107.38           O  
+ATOM   1408  CB  GLU A 848      43.583  17.142  47.833  1.00107.92           C  
+ATOM   1409  CG  GLU A 848      42.957  15.722  47.817  1.00115.49           C  
+ATOM   1410  CD  GLU A 848      42.469  15.231  49.189  1.00120.00           C  
+ATOM   1411  OE1 GLU A 848      41.279  14.853  49.320  1.00120.00           O  
+ATOM   1412  OE2 GLU A 848      43.284  15.215  50.136  1.00120.00           O  
+ATOM   1413  N   GLY A 849      41.097  17.429  46.555  1.00110.25           N  
+ATOM   1414  CA  GLY A 849      40.077  17.507  45.523  1.00115.58           C  
+ATOM   1415  C   GLY A 849      38.689  17.950  45.948  1.00119.73           C  
+ATOM   1416  O   GLY A 849      38.325  17.901  47.130  1.00120.00           O  
+ATOM   1417  N   GLY A 850      37.909  18.378  44.958  1.00120.00           N  
+ATOM   1418  CA  GLY A 850      36.552  18.838  45.201  1.00120.00           C  
+ATOM   1419  C   GLY A 850      35.496  17.778  44.941  1.00118.42           C  
+ATOM   1420  O   GLY A 850      34.973  17.650  43.830  1.00117.29           O  
+ATOM   1421  N   LYS A 851      35.169  17.024  45.981  1.00114.16           N  
+ATOM   1422  CA  LYS A 851      34.171  15.977  45.870  1.00112.90           C  
+ATOM   1423  C   LYS A 851      33.323  15.911  47.136  1.00107.97           C  
+ATOM   1424  O   LYS A 851      32.656  14.907  47.398  1.00109.24           O  
+ATOM   1425  CB  LYS A 851      34.854  14.629  45.610  1.00120.00           C  
+ATOM   1426  CG  LYS A 851      35.925  14.245  46.636  1.00120.00           C  
+ATOM   1427  CD  LYS A 851      36.394  12.806  46.430  1.00113.74           C  
+ATOM   1428  CE  LYS A 851      37.438  12.397  47.466  1.00115.06           C  
+ATOM   1429  NZ  LYS A 851      37.725  10.929  47.416  1.00112.80           N  
+ATOM   1430  N   VAL A 852      33.343  16.993  47.908  1.00101.57           N  
+ATOM   1431  CA  VAL A 852      32.586  17.062  49.154  1.00 98.14           C  
+ATOM   1432  C   VAL A 852      31.280  17.848  48.979  1.00 93.01           C  
+ATOM   1433  O   VAL A 852      31.240  18.832  48.242  1.00 91.35           O  
+ATOM   1434  CB  VAL A 852      33.439  17.710  50.280  1.00 94.32           C  
+ATOM   1435  CG1 VAL A 852      32.775  17.525  51.639  1.00 98.15           C  
+ATOM   1436  CG2 VAL A 852      34.826  17.104  50.300  1.00 93.53           C  
+ATOM   1437  N   PRO A 853      30.176  17.365  49.584  1.00 90.04           N  
+ATOM   1438  CA  PRO A 853      28.871  18.032  49.499  1.00 85.54           C  
+ATOM   1439  C   PRO A 853      28.928  19.353  50.271  1.00 80.38           C  
+ATOM   1440  O   PRO A 853      29.103  19.388  51.494  1.00 78.49           O  
+ATOM   1441  CB  PRO A 853      27.926  17.012  50.129  1.00 86.88           C  
+ATOM   1442  CG  PRO A 853      28.798  16.288  51.081  1.00 83.40           C  
+ATOM   1443  CD  PRO A 853      30.046  16.079  50.285  1.00 91.17           C  
+ATOM   1444  N   ILE A 854      28.788  20.432  49.514  1.00 72.97           N  
+ATOM   1445  CA  ILE A 854      28.884  21.795  50.008  1.00 67.30           C  
+ATOM   1446  C   ILE A 854      27.862  22.255  51.036  1.00 62.17           C  
+ATOM   1447  O   ILE A 854      28.216  22.946  51.999  1.00 47.84           O  
+ATOM   1448  CB  ILE A 854      28.918  22.777  48.808  1.00 69.55           C  
+ATOM   1449  CG1 ILE A 854      30.055  22.362  47.858  1.00 85.91           C  
+ATOM   1450  CG2 ILE A 854      29.173  24.211  49.294  1.00 56.17           C  
+ATOM   1451  CD1 ILE A 854      29.760  22.535  46.374  1.00 94.34           C  
+ATOM   1452  N   LYS A 855      26.611  21.845  50.854  1.00 55.72           N  
+ATOM   1453  CA  LYS A 855      25.547  22.256  51.748  1.00 56.79           C  
+ATOM   1454  C   LYS A 855      25.541  21.690  53.171  1.00 62.88           C  
+ATOM   1455  O   LYS A 855      24.616  21.959  53.944  1.00 65.29           O  
+ATOM   1456  CB  LYS A 855      24.203  22.075  51.064  1.00 45.78           C  
+ATOM   1457  CG  LYS A 855      24.028  23.035  49.880  1.00 49.88           C  
+ATOM   1458  CD  LYS A 855      22.685  22.822  49.216  1.00 55.16           C  
+ATOM   1459  CE  LYS A 855      22.546  23.641  47.953  1.00 56.75           C  
+ATOM   1460  NZ  LYS A 855      21.251  23.329  47.259  1.00 64.81           N  
+ATOM   1461  N   TRP A 856      26.568  20.912  53.514  1.00 56.13           N  
+ATOM   1462  CA  TRP A 856      26.697  20.351  54.848  1.00 37.60           C  
+ATOM   1463  C   TRP A 856      28.013  20.733  55.478  1.00 41.96           C  
+ATOM   1464  O   TRP A 856      28.292  20.331  56.608  1.00 40.21           O  
+ATOM   1465  CB  TRP A 856      26.628  18.840  54.819  1.00 36.34           C  
+ATOM   1466  CG  TRP A 856      25.284  18.299  54.737  1.00 34.65           C  
+ATOM   1467  CD1 TRP A 856      24.567  17.791  55.764  1.00 32.37           C  
+ATOM   1468  CD2 TRP A 856      24.467  18.167  53.557  1.00 29.13           C  
+ATOM   1469  NE1 TRP A 856      23.338  17.345  55.309  1.00 44.21           N  
+ATOM   1470  CE2 TRP A 856      23.250  17.568  53.959  1.00 33.03           C  
+ATOM   1471  CE3 TRP A 856      24.652  18.477  52.203  1.00 46.84           C  
+ATOM   1472  CZ2 TRP A 856      22.211  17.278  53.056  1.00 39.80           C  
+ATOM   1473  CZ3 TRP A 856      23.613  18.178  51.290  1.00 37.32           C  
+ATOM   1474  CH2 TRP A 856      22.411  17.589  51.730  1.00 45.88           C  
+ATOM   1475  N   MET A 857      28.828  21.511  54.775  1.00 42.56           N  
+ATOM   1476  CA  MET A 857      30.119  21.864  55.327  1.00 50.23           C  
+ATOM   1477  C   MET A 857      30.305  23.203  55.994  1.00 52.17           C  
+ATOM   1478  O   MET A 857      29.684  24.194  55.629  1.00 56.89           O  
+ATOM   1479  CB  MET A 857      31.246  21.586  54.318  1.00 59.84           C  
+ATOM   1480  CG  MET A 857      30.973  21.963  52.865  1.00 76.16           C  
+ATOM   1481  SD  MET A 857      31.919  20.907  51.685  1.00 66.94           S  
+ATOM   1482  CE  MET A 857      33.580  21.533  51.907  1.00 36.00           C  
+ATOM   1483  N   ALA A 858      31.156  23.204  57.013  1.00 51.20           N  
+ATOM   1484  CA  ALA A 858      31.478  24.410  57.752  1.00 54.29           C  
+ATOM   1485  C   ALA A 858      31.986  25.425  56.748  1.00 58.76           C  
+ATOM   1486  O   ALA A 858      32.401  25.049  55.664  1.00 51.68           O  
+ATOM   1487  CB  ALA A 858      32.556  24.122  58.780  1.00 40.54           C  
+ATOM   1488  N   LEU A 859      31.929  26.707  57.106  1.00 69.17           N  
+ATOM   1489  CA  LEU A 859      32.389  27.780  56.228  1.00 65.10           C  
+ATOM   1490  C   LEU A 859      33.886  27.641  55.982  1.00 64.58           C  
+ATOM   1491  O   LEU A 859      34.337  27.707  54.844  1.00 61.58           O  
+ATOM   1492  CB  LEU A 859      32.107  29.142  56.855  1.00 62.30           C  
+ATOM   1493  CG  LEU A 859      32.456  30.359  55.991  1.00 68.90           C  
+ATOM   1494  CD1 LEU A 859      31.554  30.404  54.751  1.00 53.78           C  
+ATOM   1495  CD2 LEU A 859      32.309  31.635  56.823  1.00 59.88           C  
+ATOM   1496  N   GLU A 860      34.646  27.419  57.055  1.00 63.16           N  
+ATOM   1497  CA  GLU A 860      36.095  27.270  56.960  1.00 61.85           C  
+ATOM   1498  C   GLU A 860      36.492  26.083  56.073  1.00 66.86           C  
+ATOM   1499  O   GLU A 860      37.603  26.037  55.550  1.00 69.54           O  
+ATOM   1500  CB  GLU A 860      36.739  27.151  58.350  1.00 52.67           C  
+ATOM   1501  CG  GLU A 860      36.441  25.865  59.123  1.00 69.29           C  
+ATOM   1502  CD  GLU A 860      35.135  25.897  59.928  1.00 68.29           C  
+ATOM   1503  OE1 GLU A 860      34.298  26.807  59.730  1.00 57.68           O  
+ATOM   1504  OE2 GLU A 860      34.943  24.981  60.758  1.00 57.06           O  
+ATOM   1505  N   SER A 861      35.587  25.129  55.899  1.00 59.99           N  
+ATOM   1506  CA  SER A 861      35.883  24.000  55.053  1.00 60.83           C  
+ATOM   1507  C   SER A 861      35.855  24.457  53.605  1.00 65.66           C  
+ATOM   1508  O   SER A 861      36.765  24.153  52.836  1.00 70.82           O  
+ATOM   1509  CB  SER A 861      34.865  22.871  55.269  1.00 63.62           C  
+ATOM   1510  OG  SER A 861      34.996  22.298  56.568  1.00 51.51           O  
+ATOM   1511  N   ILE A 862      34.824  25.220  53.250  1.00 70.95           N  
+ATOM   1512  CA  ILE A 862      34.630  25.715  51.883  1.00 72.41           C  
+ATOM   1513  C   ILE A 862      35.659  26.759  51.485  1.00 73.84           C  
+ATOM   1514  O   ILE A 862      36.031  26.876  50.319  1.00 75.38           O  
+ATOM   1515  CB  ILE A 862      33.230  26.355  51.713  1.00 75.86           C  
+ATOM   1516  CG1 ILE A 862      32.133  25.347  52.056  1.00 82.33           C  
+ATOM   1517  CG2 ILE A 862      33.040  26.865  50.291  1.00 61.00           C  
+ATOM   1518  CD1 ILE A 862      30.735  25.939  51.995  1.00 78.19           C  
+ATOM   1519  N   LEU A 863      36.102  27.525  52.467  1.00 74.09           N  
+ATOM   1520  CA  LEU A 863      37.060  28.578  52.224  1.00 80.31           C  
+ATOM   1521  C   LEU A 863      38.516  28.147  52.330  1.00 81.76           C  
+ATOM   1522  O   LEU A 863      39.358  28.638  51.574  1.00 87.29           O  
+ATOM   1523  CB  LEU A 863      36.780  29.768  53.156  1.00 87.79           C  
+ATOM   1524  CG  LEU A 863      35.675  30.769  52.770  1.00 90.84           C  
+ATOM   1525  CD1 LEU A 863      36.089  31.539  51.532  1.00106.44           C  
+ATOM   1526  CD2 LEU A 863      34.350  30.083  52.526  1.00 97.61           C  
+ATOM   1527  N   HIS A 864      38.822  27.239  53.252  1.00 75.77           N  
+ATOM   1528  CA  HIS A 864      40.204  26.802  53.439  1.00 77.04           C  
+ATOM   1529  C   HIS A 864      40.456  25.294  53.349  1.00 74.54           C  
+ATOM   1530  O   HIS A 864      41.584  24.841  53.556  1.00 71.29           O  
+ATOM   1531  CB  HIS A 864      40.731  27.306  54.790  1.00 89.06           C  
+ATOM   1532  CG  HIS A 864      40.632  28.790  54.976  1.00101.33           C  
+ATOM   1533  ND1 HIS A 864      40.171  29.641  53.996  1.00 96.56           N  
+ATOM   1534  CD2 HIS A 864      40.944  29.575  56.038  1.00104.71           C  
+ATOM   1535  CE1 HIS A 864      40.203  30.884  54.441  1.00 97.95           C  
+ATOM   1536  NE2 HIS A 864      40.669  30.871  55.678  1.00 94.10           N  
+ATOM   1537  N   ARG A 865      39.425  24.520  53.029  1.00 76.08           N  
+ATOM   1538  CA  ARG A 865      39.548  23.063  52.953  1.00 79.92           C  
+ATOM   1539  C   ARG A 865      40.019  22.465  54.290  1.00 80.59           C  
+ATOM   1540  O   ARG A 865      40.646  21.400  54.311  1.00 79.96           O  
+ATOM   1541  CB  ARG A 865      40.503  22.632  51.830  1.00 85.88           C  
+ATOM   1542  CG  ARG A 865      40.006  22.875  50.408  1.00 95.58           C  
+ATOM   1543  CD  ARG A 865      41.088  22.482  49.404  1.00100.32           C  
+ATOM   1544  NE  ARG A 865      40.771  22.860  48.026  1.00105.35           N  
+ATOM   1545  CZ  ARG A 865      41.672  22.983  47.052  1.00 88.91           C  
+ATOM   1546  NH1 ARG A 865      42.958  22.762  47.288  1.00 84.44           N  
+ATOM   1547  NH2 ARG A 865      41.284  23.331  45.834  1.00 91.45           N  
+ATOM   1548  N   ILE A 866      39.763  23.176  55.391  1.00 72.57           N  
+ATOM   1549  CA  ILE A 866      40.127  22.702  56.728  1.00 68.39           C  
+ATOM   1550  C   ILE A 866      38.942  21.905  57.324  1.00 67.59           C  
+ATOM   1551  O   ILE A 866      37.771  22.271  57.145  1.00 68.97           O  
+ATOM   1552  CB  ILE A 866      40.456  23.875  57.684  1.00 73.75           C  
+ATOM   1553  CG1 ILE A 866      41.594  24.729  57.132  1.00 79.37           C  
+ATOM   1554  CG2 ILE A 866      40.829  23.346  59.058  1.00 69.39           C  
+ATOM   1555  CD1 ILE A 866      42.917  24.046  57.154  1.00 85.39           C  
+ATOM   1556  N   TYR A 867      39.249  20.795  57.993  1.00 57.78           N  
+ATOM   1557  CA  TYR A 867      38.228  19.957  58.613  1.00 46.91           C  
+ATOM   1558  C   TYR A 867      38.616  19.575  60.025  1.00 47.40           C  
+ATOM   1559  O   TYR A 867      39.766  19.275  60.311  1.00 50.13           O  
+ATOM   1560  CB  TYR A 867      37.986  18.711  57.792  1.00 36.27           C  
+ATOM   1561  CG  TYR A 867      37.416  19.008  56.441  1.00 48.68           C  
+ATOM   1562  CD1 TYR A 867      38.216  19.562  55.438  1.00 48.05           C  
+ATOM   1563  CD2 TYR A 867      36.095  18.697  56.139  1.00 30.60           C  
+ATOM   1564  CE1 TYR A 867      37.723  19.796  54.172  1.00 42.98           C  
+ATOM   1565  CE2 TYR A 867      35.585  18.922  54.853  1.00 46.74           C  
+ATOM   1566  CZ  TYR A 867      36.416  19.475  53.877  1.00 45.09           C  
+ATOM   1567  OH  TYR A 867      35.955  19.699  52.606  1.00 48.35           O  
+ATOM   1568  N   THR A 868      37.648  19.590  60.923  1.00 44.34           N  
+ATOM   1569  CA  THR A 868      37.935  19.277  62.309  1.00 45.71           C  
+ATOM   1570  C   THR A 868      36.722  18.587  62.884  1.00 47.69           C  
+ATOM   1571  O   THR A 868      35.730  18.376  62.181  1.00 54.68           O  
+ATOM   1572  CB  THR A 868      38.154  20.581  63.084  1.00 57.55           C  
+ATOM   1573  OG1 THR A 868      37.068  21.473  62.787  1.00 67.06           O  
+ATOM   1574  CG2 THR A 868      39.475  21.266  62.675  1.00 49.57           C  
+ATOM   1575  N   HIS A 869      36.818  18.174  64.141  1.00 46.30           N  
+ATOM   1576  CA  HIS A 869      35.671  17.568  64.807  1.00 46.04           C  
+ATOM   1577  C   HIS A 869      34.575  18.653  64.836  1.00 44.36           C  
+ATOM   1578  O   HIS A 869      33.411  18.364  64.540  1.00 39.31           O  
+ATOM   1579  CB  HIS A 869      36.030  17.131  66.237  1.00 38.94           C  
+ATOM   1580  CG  HIS A 869      37.044  16.031  66.291  1.00 55.49           C  
+ATOM   1581  ND1 HIS A 869      36.982  14.919  65.481  1.00 60.18           N  
+ATOM   1582  CD2 HIS A 869      38.150  15.872  67.058  1.00 55.80           C  
+ATOM   1583  CE1 HIS A 869      38.003  14.123  65.744  1.00 42.39           C  
+ATOM   1584  NE2 HIS A 869      38.725  14.680  66.699  1.00 53.12           N  
+ATOM   1585  N   GLN A 870      34.989  19.903  65.097  1.00 38.13           N  
+ATOM   1586  CA  GLN A 870      34.080  21.047  65.145  1.00 47.26           C  
+ATOM   1587  C   GLN A 870      33.450  21.328  63.784  1.00 46.64           C  
+ATOM   1588  O   GLN A 870      32.377  21.920  63.680  1.00 48.50           O  
+ATOM   1589  CB  GLN A 870      34.787  22.295  65.687  1.00 43.21           C  
+ATOM   1590  CG  GLN A 870      35.165  22.207  67.173  1.00 44.89           C  
+ATOM   1591  CD  GLN A 870      34.014  21.704  68.049  1.00 55.93           C  
+ATOM   1592  OE1 GLN A 870      34.075  20.605  68.609  1.00 52.78           O  
+ATOM   1593  NE2 GLN A 870      32.949  22.498  68.147  1.00 51.09           N  
+ATOM   1594  N   SER A 871      34.114  20.866  62.738  1.00 45.92           N  
+ATOM   1595  CA  SER A 871      33.612  21.035  61.382  1.00 41.71           C  
+ATOM   1596  C   SER A 871      32.472  20.044  61.236  1.00 39.62           C  
+ATOM   1597  O   SER A 871      31.515  20.274  60.496  1.00 40.23           O  
+ATOM   1598  CB  SER A 871      34.718  20.707  60.368  1.00 49.46           C  
+ATOM   1599  OG  SER A 871      34.226  20.813  59.047  1.00 65.84           O  
+ATOM   1600  N   ASP A 872      32.602  18.919  61.935  1.00 36.76           N  
+ATOM   1601  CA  ASP A 872      31.585  17.884  61.894  1.00 42.07           C  
+ATOM   1602  C   ASP A 872      30.323  18.351  62.617  1.00 44.13           C  
+ATOM   1603  O   ASP A 872      29.205  17.969  62.239  1.00 42.71           O  
+ATOM   1604  CB  ASP A 872      32.124  16.566  62.485  1.00 43.22           C  
+ATOM   1605  CG  ASP A 872      32.855  15.701  61.441  1.00 52.71           C  
+ATOM   1606  OD1 ASP A 872      32.890  16.079  60.244  1.00 44.74           O  
+ATOM   1607  OD2 ASP A 872      33.376  14.621  61.811  1.00 43.46           O  
+ATOM   1608  N   VAL A 873      30.505  19.186  63.644  1.00 38.62           N  
+ATOM   1609  CA  VAL A 873      29.377  19.715  64.385  1.00 43.88           C  
+ATOM   1610  C   VAL A 873      28.464  20.528  63.461  1.00 44.53           C  
+ATOM   1611  O   VAL A 873      27.242  20.346  63.492  1.00 47.58           O  
+ATOM   1612  CB  VAL A 873      29.824  20.530  65.583  1.00 52.01           C  
+ATOM   1613  CG1 VAL A 873      28.595  21.135  66.279  1.00 43.88           C  
+ATOM   1614  CG2 VAL A 873      30.607  19.632  66.546  1.00 24.92           C  
+ATOM   1615  N   TRP A 874      29.052  21.366  62.602  1.00 34.94           N  
+ATOM   1616  CA  TRP A 874      28.261  22.137  61.636  1.00 39.19           C  
+ATOM   1617  C   TRP A 874      27.383  21.169  60.862  1.00 42.81           C  
+ATOM   1618  O   TRP A 874      26.182  21.369  60.725  1.00 51.78           O  
+ATOM   1619  CB  TRP A 874      29.156  22.865  60.634  1.00 37.85           C  
+ATOM   1620  CG  TRP A 874      28.400  23.745  59.647  1.00 37.55           C  
+ATOM   1621  CD1 TRP A 874      27.470  23.349  58.716  1.00 31.62           C  
+ATOM   1622  CD2 TRP A 874      28.516  25.168  59.511  1.00 26.63           C  
+ATOM   1623  NE1 TRP A 874      27.005  24.440  58.016  1.00 36.13           N  
+ATOM   1624  CE2 TRP A 874      27.629  25.567  58.495  1.00 37.51           C  
+ATOM   1625  CE3 TRP A 874      29.283  26.143  60.161  1.00 42.94           C  
+ATOM   1626  CZ2 TRP A 874      27.483  26.903  58.120  1.00 32.52           C  
+ATOM   1627  CZ3 TRP A 874      29.141  27.463  59.786  1.00 32.60           C  
+ATOM   1628  CH2 TRP A 874      28.249  27.832  58.780  1.00 36.94           C  
+ATOM   1629  N   SER A 875      27.996  20.110  60.352  1.00 47.84           N  
+ATOM   1630  CA  SER A 875      27.266  19.113  59.593  1.00 40.55           C  
+ATOM   1631  C   SER A 875      26.225  18.457  60.465  1.00 40.22           C  
+ATOM   1632  O   SER A 875      25.149  18.096  59.968  1.00 37.79           O  
+ATOM   1633  CB  SER A 875      28.217  18.070  59.010  1.00 45.99           C  
+ATOM   1634  OG  SER A 875      29.320  18.711  58.377  1.00 54.72           O  
+ATOM   1635  N   TYR A 876      26.540  18.267  61.753  1.00 32.94           N  
+ATOM   1636  CA  TYR A 876      25.555  17.676  62.659  1.00 35.18           C  
+ATOM   1637  C   TYR A 876      24.318  18.606  62.727  1.00 39.79           C  
+ATOM   1638  O   TYR A 876      23.183  18.131  62.698  1.00 34.33           O  
+ATOM   1639  CB  TYR A 876      26.139  17.444  64.053  1.00 36.03           C  
+ATOM   1640  CG  TYR A 876      25.119  16.961  65.086  1.00 41.88           C  
+ATOM   1641  CD1 TYR A 876      24.888  15.602  65.288  1.00 35.74           C  
+ATOM   1642  CD2 TYR A 876      24.418  17.874  65.892  1.00 42.01           C  
+ATOM   1643  CE1 TYR A 876      23.995  15.153  66.267  1.00 38.92           C  
+ATOM   1644  CE2 TYR A 876      23.515  17.435  66.872  1.00 31.92           C  
+ATOM   1645  CZ  TYR A 876      23.312  16.074  67.049  1.00 39.35           C  
+ATOM   1646  OH  TYR A 876      22.417  15.629  67.988  1.00 34.93           O  
+ATOM   1647  N   GLY A 877      24.552  19.921  62.773  1.00 35.22           N  
+ATOM   1648  CA  GLY A 877      23.458  20.882  62.807  1.00 41.84           C  
+ATOM   1649  C   GLY A 877      22.541  20.743  61.604  1.00 44.84           C  
+ATOM   1650  O   GLY A 877      21.300  20.674  61.741  1.00 48.16           O  
+ATOM   1651  N   VAL A 878      23.148  20.697  60.420  1.00 38.89           N  
+ATOM   1652  CA  VAL A 878      22.393  20.545  59.183  1.00 34.99           C  
+ATOM   1653  C   VAL A 878      21.618  19.228  59.181  1.00 32.91           C  
+ATOM   1654  O   VAL A 878      20.448  19.178  58.779  1.00 36.20           O  
+ATOM   1655  CB  VAL A 878      23.312  20.589  57.965  1.00 43.75           C  
+ATOM   1656  CG1 VAL A 878      22.499  20.390  56.706  1.00 32.58           C  
+ATOM   1657  CG2 VAL A 878      24.045  21.908  57.927  1.00 20.51           C  
+ATOM   1658  N   THR A 879      22.271  18.164  59.644  1.00 30.85           N  
+ATOM   1659  CA  THR A 879      21.638  16.849  59.729  1.00 35.42           C  
+ATOM   1660  C   THR A 879      20.404  16.938  60.620  1.00 37.48           C  
+ATOM   1661  O   THR A 879      19.390  16.317  60.336  1.00 44.60           O  
+ATOM   1662  CB  THR A 879      22.595  15.789  60.311  1.00 40.57           C  
+ATOM   1663  OG1 THR A 879      23.794  15.756  59.532  1.00 41.23           O  
+ATOM   1664  CG2 THR A 879      21.949  14.413  60.279  1.00 22.48           C  
+ATOM   1665  N   VAL A 880      20.517  17.690  61.716  1.00 37.92           N  
+ATOM   1666  CA  VAL A 880      19.417  17.902  62.648  1.00 37.92           C  
+ATOM   1667  C   VAL A 880      18.284  18.636  61.907  1.00 42.69           C  
+ATOM   1668  O   VAL A 880      17.119  18.246  61.993  1.00 41.81           O  
+ATOM   1669  CB  VAL A 880      19.903  18.709  63.870  1.00 39.09           C  
+ATOM   1670  CG1 VAL A 880      18.728  19.275  64.641  1.00 32.28           C  
+ATOM   1671  CG2 VAL A 880      20.731  17.798  64.794  1.00 27.65           C  
+ATOM   1672  N   TRP A 881      18.643  19.651  61.124  1.00 38.52           N  
+ATOM   1673  CA  TRP A 881      17.663  20.406  60.338  1.00 34.16           C  
+ATOM   1674  C   TRP A 881      16.880  19.487  59.382  1.00 42.10           C  
+ATOM   1675  O   TRP A 881      15.653  19.571  59.280  1.00 42.01           O  
+ATOM   1676  CB  TRP A 881      18.396  21.474  59.547  1.00 41.93           C  
+ATOM   1677  CG  TRP A 881      17.528  22.465  58.907  1.00 54.28           C  
+ATOM   1678  CD1 TRP A 881      17.127  23.658  59.431  1.00 45.14           C  
+ATOM   1679  CD2 TRP A 881      16.929  22.369  57.612  1.00 58.96           C  
+ATOM   1680  NE1 TRP A 881      16.304  24.305  58.549  1.00 45.48           N  
+ATOM   1681  CE2 TRP A 881      16.162  23.540  57.422  1.00 55.71           C  
+ATOM   1682  CE3 TRP A 881      16.965  21.411  56.592  1.00 55.70           C  
+ATOM   1683  CZ2 TRP A 881      15.433  23.782  56.249  1.00 56.85           C  
+ATOM   1684  CZ3 TRP A 881      16.237  21.655  55.421  1.00 67.37           C  
+ATOM   1685  CH2 TRP A 881      15.483  22.833  55.264  1.00 46.32           C  
+ATOM   1686  N   GLU A 882      17.583  18.593  58.690  1.00 44.93           N  
+ATOM   1687  CA  GLU A 882      16.914  17.675  57.776  1.00 38.96           C  
+ATOM   1688  C   GLU A 882      15.853  16.864  58.507  1.00 47.67           C  
+ATOM   1689  O   GLU A 882      14.744  16.671  58.000  1.00 52.57           O  
+ATOM   1690  CB  GLU A 882      17.910  16.718  57.147  1.00 41.57           C  
+ATOM   1691  CG  GLU A 882      18.897  17.351  56.190  1.00 42.00           C  
+ATOM   1692  CD  GLU A 882      19.960  16.364  55.770  1.00 54.77           C  
+ATOM   1693  OE1 GLU A 882      19.658  15.471  54.944  1.00 64.48           O  
+ATOM   1694  OE2 GLU A 882      21.098  16.473  56.283  1.00 50.07           O  
+ATOM   1695  N   LEU A 883      16.194  16.387  59.699  1.00 42.41           N  
+ATOM   1696  CA  LEU A 883      15.262  15.603  60.486  1.00 43.89           C  
+ATOM   1697  C   LEU A 883      14.038  16.413  60.944  1.00 46.61           C  
+ATOM   1698  O   LEU A 883      12.905  15.985  60.725  1.00 41.35           O  
+ATOM   1699  CB  LEU A 883      15.979  15.006  61.686  1.00 47.94           C  
+ATOM   1700  CG  LEU A 883      17.207  14.147  61.384  1.00 40.44           C  
+ATOM   1701  CD1 LEU A 883      17.792  13.664  62.702  1.00 22.45           C  
+ATOM   1702  CD2 LEU A 883      16.808  12.974  60.504  1.00 27.80           C  
+ATOM   1703  N   MET A 884      14.260  17.585  61.549  1.00 51.07           N  
+ATOM   1704  CA  MET A 884      13.153  18.429  62.042  1.00 54.93           C  
+ATOM   1705  C   MET A 884      12.197  18.891  60.946  1.00 53.65           C  
+ATOM   1706  O   MET A 884      11.016  19.117  61.213  1.00 47.38           O  
+ATOM   1707  CB  MET A 884      13.666  19.640  62.826  1.00 47.94           C  
+ATOM   1708  CG  MET A 884      14.515  19.295  64.047  1.00 40.93           C  
+ATOM   1709  SD  MET A 884      13.765  18.040  65.105  1.00 43.08           S  
+ATOM   1710  CE  MET A 884      15.132  17.661  66.291  1.00 40.50           C  
+ATOM   1711  N   THR A 885      12.717  19.032  59.724  1.00 56.12           N  
+ATOM   1712  CA  THR A 885      11.915  19.437  58.560  1.00 50.40           C  
+ATOM   1713  C   THR A 885      11.350  18.219  57.820  1.00 51.58           C  
+ATOM   1714  O   THR A 885      10.750  18.367  56.767  1.00 52.15           O  
+ATOM   1715  CB  THR A 885      12.740  20.210  57.542  1.00 42.22           C  
+ATOM   1716  OG1 THR A 885      13.864  19.414  57.145  1.00 44.04           O  
+ATOM   1717  CG2 THR A 885      13.231  21.507  58.124  1.00 37.23           C  
+ATOM   1718  N   PHE A 886      11.574  17.024  58.371  1.00 52.60           N  
+ATOM   1719  CA  PHE A 886      11.117  15.758  57.795  1.00 48.48           C  
+ATOM   1720  C   PHE A 886      11.711  15.385  56.428  1.00 47.47           C  
+ATOM   1721  O   PHE A 886      11.082  14.680  55.643  1.00 54.64           O  
+ATOM   1722  CB  PHE A 886       9.588  15.683  57.763  1.00 49.37           C  
+ATOM   1723  CG  PHE A 886       8.959  15.801  59.111  1.00 51.23           C  
+ATOM   1724  CD1 PHE A 886       8.910  14.712  59.960  1.00 43.11           C  
+ATOM   1725  CD2 PHE A 886       8.476  17.027  59.562  1.00 43.45           C  
+ATOM   1726  CE1 PHE A 886       8.391  14.836  61.269  1.00 45.93           C  
+ATOM   1727  CE2 PHE A 886       7.962  17.166  60.852  1.00 43.47           C  
+ATOM   1728  CZ  PHE A 886       7.919  16.066  61.712  1.00 44.23           C  
+ATOM   1729  N   GLY A 887      12.930  15.839  56.157  1.00 43.49           N  
+ATOM   1730  CA  GLY A 887      13.576  15.486  54.908  1.00 49.02           C  
+ATOM   1731  C   GLY A 887      13.732  16.535  53.831  1.00 55.35           C  
+ATOM   1732  O   GLY A 887      13.879  16.190  52.665  1.00 60.81           O  
+ATOM   1733  N   SER A 888      13.742  17.806  54.202  1.00 54.70           N  
+ATOM   1734  CA  SER A 888      13.876  18.863  53.209  1.00 57.45           C  
+ATOM   1735  C   SER A 888      15.311  19.029  52.734  1.00 63.69           C  
+ATOM   1736  O   SER A 888      16.261  18.685  53.440  1.00 68.90           O  
+ATOM   1737  CB  SER A 888      13.342  20.189  53.757  1.00 55.72           C  
+ATOM   1738  OG  SER A 888      11.958  20.080  54.045  1.00 59.11           O  
+ATOM   1739  N   LYS A 889      15.460  19.537  51.516  1.00 63.91           N  
+ATOM   1740  CA  LYS A 889      16.776  19.754  50.937  1.00 59.47           C  
+ATOM   1741  C   LYS A 889      17.256  21.113  51.418  1.00 57.20           C  
+ATOM   1742  O   LYS A 889      16.566  22.114  51.257  1.00 63.58           O  
+ATOM   1743  CB  LYS A 889      16.689  19.703  49.399  1.00 60.28           C  
+ATOM   1744  CG  LYS A 889      16.109  18.379  48.843  1.00 76.31           C  
+ATOM   1745  CD  LYS A 889      15.484  18.517  47.440  1.00 79.63           C  
+ATOM   1746  CE  LYS A 889      16.498  19.012  46.399  1.00100.56           C  
+ATOM   1747  NZ  LYS A 889      15.908  19.336  45.056  1.00 96.73           N  
+ATOM   1748  N   PRO A 890      18.404  21.150  52.099  1.00 53.44           N  
+ATOM   1749  CA  PRO A 890      18.929  22.424  52.595  1.00 56.97           C  
+ATOM   1750  C   PRO A 890      19.215  23.404  51.470  1.00 63.42           C  
+ATOM   1751  O   PRO A 890      19.933  23.087  50.525  1.00 69.89           O  
+ATOM   1752  CB  PRO A 890      20.193  22.013  53.364  1.00 50.25           C  
+ATOM   1753  CG  PRO A 890      20.553  20.663  52.767  1.00 54.14           C  
+ATOM   1754  CD  PRO A 890      19.220  20.017  52.556  1.00 46.07           C  
+ATOM   1755  N   TYR A 891      18.649  24.605  51.600  1.00 70.10           N  
+ATOM   1756  CA  TYR A 891      18.781  25.682  50.616  1.00 64.39           C  
+ATOM   1757  C   TYR A 891      18.258  25.157  49.280  1.00 65.48           C  
+ATOM   1758  O   TYR A 891      18.945  25.258  48.268  1.00 63.83           O  
+ATOM   1759  CB  TYR A 891      20.241  26.125  50.459  1.00 53.66           C  
+ATOM   1760  CG  TYR A 891      21.053  26.175  51.735  1.00 54.86           C  
+ATOM   1761  CD1 TYR A 891      21.034  27.295  52.560  1.00 35.95           C  
+ATOM   1762  CD2 TYR A 891      21.889  25.116  52.086  1.00 53.10           C  
+ATOM   1763  CE1 TYR A 891      21.842  27.363  53.708  1.00 46.08           C  
+ATOM   1764  CE2 TYR A 891      22.697  25.171  53.227  1.00 45.68           C  
+ATOM   1765  CZ  TYR A 891      22.677  26.289  54.030  1.00 46.76           C  
+ATOM   1766  OH  TYR A 891      23.519  26.334  55.127  1.00 42.39           O  
+ATOM   1767  N   ASP A 892      17.036  24.616  49.293  1.00 68.49           N  
+ATOM   1768  CA  ASP A 892      16.402  24.020  48.110  1.00 76.56           C  
+ATOM   1769  C   ASP A 892      16.600  24.734  46.784  1.00 81.31           C  
+ATOM   1770  O   ASP A 892      16.719  24.081  45.744  1.00 81.13           O  
+ATOM   1771  CB  ASP A 892      14.908  23.787  48.342  1.00 88.49           C  
+ATOM   1772  CG  ASP A 892      14.225  23.143  47.142  1.00 91.77           C  
+ATOM   1773  OD1 ASP A 892      14.429  21.929  46.905  1.00 78.82           O  
+ATOM   1774  OD2 ASP A 892      13.495  23.864  46.425  1.00102.90           O  
+ATOM   1775  N   GLY A 893      16.593  26.063  46.806  1.00 80.64           N  
+ATOM   1776  CA  GLY A 893      16.799  26.799  45.575  1.00 84.75           C  
+ATOM   1777  C   GLY A 893      18.280  26.886  45.254  1.00 86.86           C  
+ATOM   1778  O   GLY A 893      18.814  26.120  44.448  1.00 86.53           O  
+ATOM   1779  N   ILE A 894      18.938  27.807  45.944  1.00 89.25           N  
+ATOM   1780  CA  ILE A 894      20.361  28.090  45.815  1.00 90.31           C  
+ATOM   1781  C   ILE A 894      21.240  26.930  45.342  1.00 93.65           C  
+ATOM   1782  O   ILE A 894      21.094  25.806  45.809  1.00 96.52           O  
+ATOM   1783  CB  ILE A 894      20.895  28.616  47.161  1.00 85.72           C  
+ATOM   1784  CG1 ILE A 894      20.037  29.796  47.628  1.00 92.35           C  
+ATOM   1785  CG2 ILE A 894      22.336  29.050  47.030  1.00 88.26           C  
+ATOM   1786  CD1 ILE A 894      20.482  30.422  48.937  1.00100.49           C  
+ATOM   1787  N   PRO A 895      22.095  27.176  44.333  1.00100.33           N  
+ATOM   1788  CA  PRO A 895      23.005  26.165  43.785  1.00100.58           C  
+ATOM   1789  C   PRO A 895      24.327  26.218  44.547  1.00 96.08           C  
+ATOM   1790  O   PRO A 895      24.775  27.288  44.968  1.00 92.76           O  
+ATOM   1791  CB  PRO A 895      23.176  26.618  42.340  1.00102.05           C  
+ATOM   1792  CG  PRO A 895      23.223  28.103  42.489  1.00105.36           C  
+ATOM   1793  CD  PRO A 895      22.078  28.373  43.469  1.00112.44           C  
+ATOM   1794  N   ALA A 896      24.954  25.059  44.687  1.00 94.51           N  
+ATOM   1795  CA  ALA A 896      26.210  24.905  45.415  1.00 90.41           C  
+ATOM   1796  C   ALA A 896      27.224  26.042  45.316  1.00 87.90           C  
+ATOM   1797  O   ALA A 896      27.946  26.324  46.275  1.00 81.76           O  
+ATOM   1798  CB  ALA A 896      26.862  23.594  45.023  1.00 95.34           C  
+ATOM   1799  N   SER A 897      27.266  26.698  44.163  1.00 92.28           N  
+ATOM   1800  CA  SER A 897      28.211  27.789  43.926  1.00 97.61           C  
+ATOM   1801  C   SER A 897      27.975  29.018  44.792  1.00 98.57           C  
+ATOM   1802  O   SER A 897      28.926  29.717  45.159  1.00101.07           O  
+ATOM   1803  CB  SER A 897      28.176  28.211  42.455  1.00100.16           C  
+ATOM   1804  OG  SER A 897      28.393  27.103  41.603  1.00108.85           O  
+ATOM   1805  N   GLU A 898      26.710  29.276  45.115  1.00 97.19           N  
+ATOM   1806  CA  GLU A 898      26.340  30.445  45.907  1.00 91.79           C  
+ATOM   1807  C   GLU A 898      26.438  30.277  47.415  1.00 83.70           C  
+ATOM   1808  O   GLU A 898      26.700  31.256  48.123  1.00 81.80           O  
+ATOM   1809  CB  GLU A 898      24.931  30.911  45.538  1.00 93.24           C  
+ATOM   1810  CG  GLU A 898      24.753  31.241  44.069  1.00 94.50           C  
+ATOM   1811  CD  GLU A 898      23.444  31.948  43.783  1.00111.25           C  
+ATOM   1812  OE1 GLU A 898      22.410  31.589  44.391  1.00111.91           O  
+ATOM   1813  OE2 GLU A 898      23.450  32.872  42.943  1.00120.00           O  
+ATOM   1814  N   ILE A 899      26.271  29.037  47.883  1.00 75.33           N  
+ATOM   1815  CA  ILE A 899      26.304  28.691  49.313  1.00 65.80           C  
+ATOM   1816  C   ILE A 899      27.361  29.406  50.139  1.00 64.64           C  
+ATOM   1817  O   ILE A 899      27.068  29.912  51.219  1.00 70.05           O  
+ATOM   1818  CB  ILE A 899      26.450  27.173  49.529  1.00 43.47           C  
+ATOM   1819  CG1 ILE A 899      25.308  26.427  48.835  1.00 62.40           C  
+ATOM   1820  CG2 ILE A 899      26.475  26.843  51.002  1.00 56.71           C  
+ATOM   1821  CD1 ILE A 899      23.909  26.883  49.223  1.00 60.09           C  
+ATOM   1822  N   SER A 900      28.581  29.470  49.629  1.00 66.88           N  
+ATOM   1823  CA  SER A 900      29.654  30.137  50.352  1.00 67.29           C  
+ATOM   1824  C   SER A 900      29.289  31.585  50.662  1.00 67.66           C  
+ATOM   1825  O   SER A 900      29.486  32.048  51.779  1.00 66.68           O  
+ATOM   1826  CB  SER A 900      30.954  30.093  49.538  1.00 66.04           C  
+ATOM   1827  OG  SER A 900      32.009  30.772  50.207  1.00 66.03           O  
+ATOM   1828  N   SER A 901      28.727  32.277  49.675  1.00 69.06           N  
+ATOM   1829  CA  SER A 901      28.360  33.682  49.819  1.00 73.94           C  
+ATOM   1830  C   SER A 901      27.170  33.959  50.732  1.00 70.98           C  
+ATOM   1831  O   SER A 901      27.201  34.900  51.537  1.00 66.69           O  
+ATOM   1832  CB  SER A 901      28.138  34.320  48.444  1.00 79.40           C  
+ATOM   1833  OG  SER A 901      29.358  34.390  47.724  1.00 96.62           O  
+ATOM   1834  N   ILE A 902      26.113  33.168  50.599  1.00 63.68           N  
+ATOM   1835  CA  ILE A 902      24.968  33.378  51.452  1.00 65.54           C  
+ATOM   1836  C   ILE A 902      25.427  33.166  52.896  1.00 69.07           C  
+ATOM   1837  O   ILE A 902      25.009  33.891  53.796  1.00 77.10           O  
+ATOM   1838  CB  ILE A 902      23.798  32.434  51.110  1.00 74.17           C  
+ATOM   1839  CG1 ILE A 902      24.059  31.035  51.646  1.00 66.26           C  
+ATOM   1840  CG2 ILE A 902      23.546  32.417  49.607  1.00 58.72           C  
+ATOM   1841  CD1 ILE A 902      22.809  30.210  51.746  1.00 92.86           C  
+ATOM   1842  N   LEU A 903      26.352  32.227  53.098  1.00 65.02           N  
+ATOM   1843  CA  LEU A 903      26.870  31.953  54.430  1.00 59.17           C  
+ATOM   1844  C   LEU A 903      27.761  33.073  54.928  1.00 59.34           C  
+ATOM   1845  O   LEU A 903      27.798  33.353  56.115  1.00 64.13           O  
+ATOM   1846  CB  LEU A 903      27.614  30.619  54.471  1.00 64.94           C  
+ATOM   1847  CG  LEU A 903      26.769  29.341  54.317  1.00 62.45           C  
+ATOM   1848  CD1 LEU A 903      27.669  28.119  54.316  1.00 47.66           C  
+ATOM   1849  CD2 LEU A 903      25.754  29.235  55.428  1.00 56.42           C  
+ATOM   1850  N   GLU A 904      28.465  33.732  54.016  1.00 73.27           N  
+ATOM   1851  CA  GLU A 904      29.349  34.837  54.384  1.00 74.37           C  
+ATOM   1852  C   GLU A 904      28.517  36.044  54.824  1.00 72.34           C  
+ATOM   1853  O   GLU A 904      28.928  36.798  55.710  1.00 69.86           O  
+ATOM   1854  CB  GLU A 904      30.283  35.196  53.217  1.00 80.24           C  
+ATOM   1855  CG  GLU A 904      31.300  34.101  52.873  1.00 87.87           C  
+ATOM   1856  CD  GLU A 904      32.208  34.455  51.692  1.00 97.84           C  
+ATOM   1857  OE1 GLU A 904      33.278  35.068  51.919  1.00 83.56           O  
+ATOM   1858  OE2 GLU A 904      31.861  34.098  50.540  1.00100.45           O  
+ATOM   1859  N   LYS A 905      27.330  36.190  54.231  1.00 72.48           N  
+ATOM   1860  CA  LYS A 905      26.406  37.283  54.562  1.00 75.62           C  
+ATOM   1861  C   LYS A 905      25.697  37.042  55.901  1.00 73.77           C  
+ATOM   1862  O   LYS A 905      24.869  37.846  56.315  1.00 70.63           O  
+ATOM   1863  CB  LYS A 905      25.334  37.453  53.477  1.00 84.87           C  
+ATOM   1864  CG  LYS A 905      25.798  38.010  52.134  1.00 89.24           C  
+ATOM   1865  CD  LYS A 905      24.648  37.914  51.121  1.00100.50           C  
+ATOM   1866  CE  LYS A 905      24.997  38.483  49.745  1.00102.05           C  
+ATOM   1867  NZ  LYS A 905      24.964  39.973  49.704  1.00103.54           N  
+ATOM   1868  N   GLY A 906      25.980  35.907  56.540  1.00 72.04           N  
+ATOM   1869  CA  GLY A 906      25.379  35.602  57.827  1.00 62.99           C  
+ATOM   1870  C   GLY A 906      24.072  34.838  57.756  1.00 63.01           C  
+ATOM   1871  O   GLY A 906      23.455  34.556  58.781  1.00 62.79           O  
+ATOM   1872  N   GLU A 907      23.626  34.519  56.549  1.00 55.28           N  
+ATOM   1873  CA  GLU A 907      22.388  33.768  56.393  1.00 53.60           C  
+ATOM   1874  C   GLU A 907      22.580  32.320  56.883  1.00 59.27           C  
+ATOM   1875  O   GLU A 907      23.708  31.787  56.860  1.00 58.09           O  
+ATOM   1876  CB  GLU A 907      21.969  33.797  54.929  1.00 46.36           C  
+ATOM   1877  CG  GLU A 907      20.601  33.181  54.598  1.00 54.18           C  
+ATOM   1878  CD  GLU A 907      20.147  33.563  53.199  1.00 71.70           C  
+ATOM   1879  OE1 GLU A 907      20.750  34.496  52.618  1.00 68.71           O  
+ATOM   1880  OE2 GLU A 907      19.199  32.937  52.675  1.00 88.46           O  
+ATOM   1881  N   ARG A 908      21.491  31.704  57.352  1.00 48.00           N  
+ATOM   1882  CA  ARG A 908      21.528  30.338  57.847  1.00 40.97           C  
+ATOM   1883  C   ARG A 908      20.252  29.618  57.515  1.00 38.02           C  
+ATOM   1884  O   ARG A 908      19.362  30.198  56.938  1.00 46.84           O  
+ATOM   1885  CB  ARG A 908      21.752  30.313  59.356  1.00 44.56           C  
+ATOM   1886  CG  ARG A 908      23.137  30.772  59.789  1.00 48.20           C  
+ATOM   1887  CD  ARG A 908      24.252  29.854  59.273  1.00 38.82           C  
+ATOM   1888  NE  ARG A 908      25.547  30.254  59.832  1.00 42.22           N  
+ATOM   1889  CZ  ARG A 908      26.303  31.243  59.356  1.00 40.71           C  
+ATOM   1890  NH1 ARG A 908      25.931  31.949  58.289  1.00 32.91           N  
+ATOM   1891  NH2 ARG A 908      27.386  31.599  60.014  1.00 42.84           N  
+ATOM   1892  N   LEU A 909      20.169  28.336  57.852  1.00 46.82           N  
+ATOM   1893  CA  LEU A 909      18.967  27.573  57.552  1.00 50.32           C  
+ATOM   1894  C   LEU A 909      17.854  28.115  58.422  1.00 55.51           C  
+ATOM   1895  O   LEU A 909      18.109  28.615  59.515  1.00 60.61           O  
+ATOM   1896  CB  LEU A 909      19.190  26.069  57.774  1.00 52.53           C  
+ATOM   1897  CG  LEU A 909      20.062  25.393  56.698  1.00 54.68           C  
+ATOM   1898  CD1 LEU A 909      20.346  23.927  57.021  1.00 44.35           C  
+ATOM   1899  CD2 LEU A 909      19.360  25.494  55.356  1.00 46.03           C  
+ATOM   1900  N   PRO A 910      16.614  28.091  57.918  1.00 57.86           N  
+ATOM   1901  CA  PRO A 910      15.462  28.597  58.668  1.00 56.33           C  
+ATOM   1902  C   PRO A 910      14.984  27.694  59.817  1.00 57.65           C  
+ATOM   1903  O   PRO A 910      15.282  26.508  59.852  1.00 58.73           O  
+ATOM   1904  CB  PRO A 910      14.409  28.753  57.573  1.00 53.42           C  
+ATOM   1905  CG  PRO A 910      14.703  27.576  56.684  1.00 55.12           C  
+ATOM   1906  CD  PRO A 910      16.211  27.640  56.570  1.00 47.03           C  
+ATOM   1907  N   GLN A 911      14.242  28.284  60.753  1.00 55.96           N  
+ATOM   1908  CA  GLN A 911      13.697  27.585  61.908  1.00 46.66           C  
+ATOM   1909  C   GLN A 911      12.567  26.662  61.445  1.00 45.18           C  
+ATOM   1910  O   GLN A 911      11.588  27.106  60.876  1.00 55.50           O  
+ATOM   1911  CB  GLN A 911      13.212  28.616  62.956  1.00 40.07           C  
+ATOM   1912  CG  GLN A 911      12.588  28.034  64.242  1.00 35.29           C  
+ATOM   1913  CD  GLN A 911      12.434  29.055  65.415  1.00 53.57           C  
+ATOM   1914  OE1 GLN A 911      12.804  30.240  65.324  1.00 44.84           O  
+ATOM   1915  NE2 GLN A 911      11.891  28.569  66.525  1.00 46.47           N  
+ATOM   1916  N   PRO A 912      12.747  25.344  61.584  1.00 51.11           N  
+ATOM   1917  CA  PRO A 912      11.715  24.388  61.167  1.00 49.52           C  
+ATOM   1918  C   PRO A 912      10.461  24.669  61.973  1.00 54.69           C  
+ATOM   1919  O   PRO A 912      10.545  24.912  63.179  1.00 56.20           O  
+ATOM   1920  CB  PRO A 912      12.316  23.035  61.581  1.00 40.64           C  
+ATOM   1921  CG  PRO A 912      13.777  23.269  61.485  1.00 45.74           C  
+ATOM   1922  CD  PRO A 912      13.936  24.642  62.098  1.00 50.93           C  
+ATOM   1923  N   PRO A 913       9.290  24.685  61.319  1.00 55.41           N  
+ATOM   1924  CA  PRO A 913       8.011  24.942  61.980  1.00 54.44           C  
+ATOM   1925  C   PRO A 913       7.736  24.197  63.271  1.00 50.72           C  
+ATOM   1926  O   PRO A 913       7.132  24.763  64.174  1.00 56.73           O  
+ATOM   1927  CB  PRO A 913       6.973  24.611  60.898  1.00 52.36           C  
+ATOM   1928  CG  PRO A 913       7.762  24.119  59.720  1.00 52.87           C  
+ATOM   1929  CD  PRO A 913       9.108  24.761  59.868  1.00 57.55           C  
+ATOM   1930  N   ILE A 914       8.208  22.961  63.392  1.00 51.85           N  
+ATOM   1931  CA  ILE A 914       7.963  22.189  64.616  1.00 39.36           C  
+ATOM   1932  C   ILE A 914       8.942  22.498  65.746  1.00 35.86           C  
+ATOM   1933  O   ILE A 914       8.796  21.988  66.879  1.00 34.47           O  
+ATOM   1934  CB  ILE A 914       8.021  20.667  64.350  1.00 46.49           C  
+ATOM   1935  CG1 ILE A 914       9.463  20.221  64.142  1.00 41.22           C  
+ATOM   1936  CG2 ILE A 914       7.183  20.294  63.127  1.00 36.42           C  
+ATOM   1937  CD1 ILE A 914       9.629  18.713  64.185  1.00 34.65           C  
+ATOM   1938  N   CYS A 915       9.890  23.388  65.456  1.00 34.44           N  
+ATOM   1939  CA  CYS A 915      10.947  23.727  66.403  1.00 43.79           C  
+ATOM   1940  C   CYS A 915      10.785  24.842  67.394  1.00 47.38           C  
+ATOM   1941  O   CYS A 915      10.647  26.002  67.013  1.00 52.88           O  
+ATOM   1942  CB  CYS A 915      12.254  23.995  65.659  1.00 59.03           C  
+ATOM   1943  SG  CYS A 915      13.108  22.535  65.086  1.00 45.18           S  
+ATOM   1944  N   THR A 916      10.901  24.502  68.673  1.00 43.25           N  
+ATOM   1945  CA  THR A 916      10.841  25.522  69.697  1.00 41.83           C  
+ATOM   1946  C   THR A 916      12.155  26.259  69.542  1.00 40.20           C  
+ATOM   1947  O   THR A 916      13.109  25.725  68.980  1.00 50.55           O  
+ATOM   1948  CB  THR A 916      10.784  24.946  71.120  1.00 42.07           C  
+ATOM   1949  OG1 THR A 916      11.865  24.033  71.312  1.00 48.03           O  
+ATOM   1950  CG2 THR A 916       9.463  24.247  71.379  1.00 42.97           C  
+ATOM   1951  N   ILE A 917      12.209  27.485  70.040  1.00 44.16           N  
+ATOM   1952  CA  ILE A 917      13.423  28.276  69.949  1.00 42.89           C  
+ATOM   1953  C   ILE A 917      14.598  27.564  70.643  1.00 38.64           C  
+ATOM   1954  O   ILE A 917      15.731  27.744  70.247  1.00 38.32           O  
+ATOM   1955  CB  ILE A 917      13.217  29.703  70.547  1.00 44.79           C  
+ATOM   1956  CG1 ILE A 917      14.450  30.564  70.242  1.00 44.21           C  
+ATOM   1957  CG2 ILE A 917      12.880  29.627  72.049  1.00 33.40           C  
+ATOM   1958  CD1 ILE A 917      14.499  31.900  70.920  1.00 50.48           C  
+ATOM   1959  N   ASP A 918      14.303  26.758  71.664  1.00 34.19           N  
+ATOM   1960  CA  ASP A 918      15.291  26.011  72.428  1.00 33.48           C  
+ATOM   1961  C   ASP A 918      16.088  25.078  71.504  1.00 44.55           C  
+ATOM   1962  O   ASP A 918      17.318  25.016  71.566  1.00 41.25           O  
+ATOM   1963  CB  ASP A 918      14.581  25.147  73.474  1.00 34.30           C  
+ATOM   1964  CG  ASP A 918      13.876  25.964  74.533  1.00 50.76           C  
+ATOM   1965  OD1 ASP A 918      12.719  26.387  74.308  1.00 43.90           O  
+ATOM   1966  OD2 ASP A 918      14.466  26.154  75.612  1.00 49.86           O  
+ATOM   1967  N   VAL A 919      15.369  24.312  70.687  1.00 41.36           N  
+ATOM   1968  CA  VAL A 919      15.988  23.379  69.761  1.00 37.02           C  
+ATOM   1969  C   VAL A 919      16.719  24.117  68.642  1.00 44.27           C  
+ATOM   1970  O   VAL A 919      17.839  23.766  68.298  1.00 51.26           O  
+ATOM   1971  CB  VAL A 919      14.936  22.420  69.140  1.00 32.63           C  
+ATOM   1972  CG1 VAL A 919      15.531  21.657  67.948  1.00 26.21           C  
+ATOM   1973  CG2 VAL A 919      14.459  21.420  70.182  1.00 28.40           C  
+ATOM   1974  N   TYR A 920      16.075  25.129  68.068  1.00 44.12           N  
+ATOM   1975  CA  TYR A 920      16.666  25.884  66.979  1.00 40.48           C  
+ATOM   1976  C   TYR A 920      17.936  26.617  67.388  1.00 43.47           C  
+ATOM   1977  O   TYR A 920      18.829  26.842  66.572  1.00 51.05           O  
+ATOM   1978  CB  TYR A 920      15.654  26.866  66.404  1.00 43.40           C  
+ATOM   1979  CG  TYR A 920      16.181  27.634  65.221  1.00 40.15           C  
+ATOM   1980  CD1 TYR A 920      16.713  26.979  64.116  1.00 47.09           C  
+ATOM   1981  CD2 TYR A 920      16.123  29.015  65.194  1.00 50.61           C  
+ATOM   1982  CE1 TYR A 920      17.174  27.697  63.006  1.00 58.98           C  
+ATOM   1983  CE2 TYR A 920      16.574  29.739  64.097  1.00 48.19           C  
+ATOM   1984  CZ  TYR A 920      17.099  29.078  63.014  1.00 53.26           C  
+ATOM   1985  OH  TYR A 920      17.590  29.816  61.971  1.00 45.81           O  
+ATOM   1986  N   MET A 921      18.022  26.970  68.659  1.00 44.36           N  
+ATOM   1987  CA  MET A 921      19.189  27.656  69.185  1.00 45.93           C  
+ATOM   1988  C   MET A 921      20.383  26.682  69.183  1.00 47.62           C  
+ATOM   1989  O   MET A 921      21.546  27.110  69.162  1.00 40.44           O  
+ATOM   1990  CB  MET A 921      18.901  28.107  70.610  1.00 45.87           C  
+ATOM   1991  CG  MET A 921      19.877  29.101  71.158  1.00 57.18           C  
+ATOM   1992  SD  MET A 921      19.133  30.691  71.032  1.00 80.91           S  
+ATOM   1993  CE  MET A 921      20.355  31.474  70.081  1.00 82.49           C  
+ATOM   1994  N   ILE A 922      20.089  25.383  69.283  1.00 40.48           N  
+ATOM   1995  CA  ILE A 922      21.139  24.364  69.263  1.00 49.52           C  
+ATOM   1996  C   ILE A 922      21.713  24.299  67.839  1.00 46.88           C  
+ATOM   1997  O   ILE A 922      22.927  24.342  67.661  1.00 47.97           O  
+ATOM   1998  CB  ILE A 922      20.622  22.946  69.653  1.00 56.34           C  
+ATOM   1999  CG1 ILE A 922      19.955  22.953  71.031  1.00 37.27           C  
+ATOM   2000  CG2 ILE A 922      21.776  21.973  69.682  1.00 48.26           C  
+ATOM   2001  CD1 ILE A 922      20.891  23.229  72.157  1.00 48.32           C  
+ATOM   2002  N   MET A 923      20.830  24.241  66.841  1.00 41.32           N  
+ATOM   2003  CA  MET A 923      21.229  24.190  65.440  1.00 40.08           C  
+ATOM   2004  C   MET A 923      22.004  25.437  65.054  1.00 40.96           C  
+ATOM   2005  O   MET A 923      23.027  25.358  64.389  1.00 50.36           O  
+ATOM   2006  CB  MET A 923      20.004  24.033  64.537  1.00 34.16           C  
+ATOM   2007  CG  MET A 923      19.175  22.782  64.835  1.00 39.27           C  
+ATOM   2008  SD  MET A 923      17.581  22.722  63.984  1.00 53.56           S  
+ATOM   2009  CE  MET A 923      17.994  23.546  62.618  1.00 37.06           C  
+ATOM   2010  N   VAL A 924      21.534  26.590  65.499  1.00 46.48           N  
+ATOM   2011  CA  VAL A 924      22.204  27.854  65.211  1.00 44.40           C  
+ATOM   2012  C   VAL A 924      23.617  27.921  65.812  1.00 42.15           C  
+ATOM   2013  O   VAL A 924      24.541  28.457  65.189  1.00 37.83           O  
+ATOM   2014  CB  VAL A 924      21.321  29.049  65.685  1.00 44.34           C  
+ATOM   2015  CG1 VAL A 924      22.075  30.385  65.628  1.00 35.94           C  
+ATOM   2016  CG2 VAL A 924      20.087  29.106  64.822  1.00 25.11           C  
+ATOM   2017  N   LYS A 925      23.794  27.352  67.001  1.00 43.48           N  
+ATOM   2018  CA  LYS A 925      25.108  27.365  67.657  1.00 40.80           C  
+ATOM   2019  C   LYS A 925      26.141  26.515  66.918  1.00 44.65           C  
+ATOM   2020  O   LYS A 925      27.328  26.804  66.966  1.00 48.08           O  
+ATOM   2021  CB  LYS A 925      25.006  26.874  69.094  1.00 40.04           C  
+ATOM   2022  CG  LYS A 925      24.345  27.819  70.060  1.00 46.03           C  
+ATOM   2023  CD  LYS A 925      24.275  27.160  71.438  1.00 55.99           C  
+ATOM   2024  CE  LYS A 925      23.660  28.087  72.485  1.00 51.98           C  
+ATOM   2025  NZ  LYS A 925      23.552  27.389  73.781  1.00 76.81           N  
+ATOM   2026  N   CYS A 926      25.692  25.454  66.254  1.00 40.92           N  
+ATOM   2027  CA  CYS A 926      26.593  24.584  65.506  1.00 41.05           C  
+ATOM   2028  C   CYS A 926      27.088  25.314  64.246  1.00 46.96           C  
+ATOM   2029  O   CYS A 926      28.036  24.862  63.592  1.00 45.06           O  
+ATOM   2030  CB  CYS A 926      25.872  23.289  65.083  1.00 33.48           C  
+ATOM   2031  SG  CYS A 926      25.267  22.189  66.390  1.00 43.38           S  
+ATOM   2032  N   TRP A 927      26.435  26.436  63.924  1.00 45.45           N  
+ATOM   2033  CA  TRP A 927      26.735  27.235  62.744  1.00 34.61           C  
+ATOM   2034  C   TRP A 927      27.444  28.573  62.966  1.00 37.33           C  
+ATOM   2035  O   TRP A 927      27.432  29.442  62.087  1.00 38.69           O  
+ATOM   2036  CB  TRP A 927      25.463  27.442  61.932  1.00 29.93           C  
+ATOM   2037  CG  TRP A 927      24.792  26.160  61.532  1.00 44.93           C  
+ATOM   2038  CD1 TRP A 927      25.390  24.946  61.346  1.00 42.64           C  
+ATOM   2039  CD2 TRP A 927      23.389  25.950  61.319  1.00 35.04           C  
+ATOM   2040  NE1 TRP A 927      24.450  23.991  61.042  1.00 45.36           N  
+ATOM   2041  CE2 TRP A 927      23.212  24.576  61.020  1.00 40.08           C  
+ATOM   2042  CE3 TRP A 927      22.262  26.783  61.364  1.00 35.22           C  
+ATOM   2043  CZ2 TRP A 927      21.950  24.010  60.762  1.00 45.51           C  
+ATOM   2044  CZ3 TRP A 927      20.986  26.217  61.108  1.00 32.98           C  
+ATOM   2045  CH2 TRP A 927      20.850  24.845  60.811  1.00 41.20           C  
+ATOM   2046  N   MET A 928      28.059  28.736  64.134  1.00 40.15           N  
+ATOM   2047  CA  MET A 928      28.826  29.942  64.452  1.00 47.61           C  
+ATOM   2048  C   MET A 928      30.069  29.919  63.561  1.00 53.00           C  
+ATOM   2049  O   MET A 928      30.506  28.848  63.160  1.00 61.95           O  
+ATOM   2050  CB  MET A 928      29.311  29.893  65.901  1.00 42.38           C  
+ATOM   2051  CG  MET A 928      28.229  29.672  66.947  1.00 60.23           C  
+ATOM   2052  SD  MET A 928      27.304  31.160  67.360  1.00 64.93           S  
+ATOM   2053  CE  MET A 928      28.256  31.741  68.635  1.00 54.96           C  
+ATOM   2054  N   ILE A 929      30.637  31.086  63.259  1.00 62.12           N  
+ATOM   2055  CA  ILE A 929      31.842  31.180  62.430  1.00 54.18           C  
+ATOM   2056  C   ILE A 929      33.024  30.579  63.193  1.00 57.90           C  
+ATOM   2057  O   ILE A 929      33.742  29.730  62.663  1.00 66.53           O  
+ATOM   2058  CB  ILE A 929      32.156  32.670  62.019  1.00 68.40           C  
+ATOM   2059  CG1 ILE A 929      31.554  33.002  60.647  1.00 65.06           C  
+ATOM   2060  CG2 ILE A 929      33.667  32.920  61.938  1.00 84.32           C  
+ATOM   2061  CD1 ILE A 929      30.052  32.974  60.594  1.00 82.00           C  
+ATOM   2062  N   ASP A 930      33.217  31.013  64.435  1.00 56.88           N  
+ATOM   2063  CA  ASP A 930      34.305  30.507  65.274  1.00 60.72           C  
+ATOM   2064  C   ASP A 930      33.981  29.057  65.674  1.00 65.68           C  
+ATOM   2065  O   ASP A 930      33.073  28.810  66.471  1.00 69.29           O  
+ATOM   2066  CB  ASP A 930      34.464  31.396  66.516  1.00 49.19           C  
+ATOM   2067  CG  ASP A 930      35.653  31.008  67.367  1.00 76.52           C  
+ATOM   2068  OD1 ASP A 930      36.796  31.051  66.858  1.00 91.04           O  
+ATOM   2069  OD2 ASP A 930      35.449  30.672  68.554  1.00 85.32           O  
+ATOM   2070  N   ALA A 931      34.725  28.106  65.111  1.00 64.45           N  
+ATOM   2071  CA  ALA A 931      34.500  26.684  65.363  1.00 54.95           C  
+ATOM   2072  C   ALA A 931      34.458  26.271  66.836  1.00 50.32           C  
+ATOM   2073  O   ALA A 931      33.625  25.440  67.206  1.00 44.54           O  
+ATOM   2074  CB  ALA A 931      35.506  25.829  64.578  1.00 55.27           C  
+ATOM   2075  N   ASP A 932      35.327  26.852  67.668  1.00 45.65           N  
+ATOM   2076  CA  ASP A 932      35.351  26.541  69.109  1.00 49.79           C  
+ATOM   2077  C   ASP A 932      34.110  27.039  69.846  1.00 51.78           C  
+ATOM   2078  O   ASP A 932      33.817  26.598  70.951  1.00 56.79           O  
+ATOM   2079  CB  ASP A 932      36.587  27.131  69.795  1.00 63.01           C  
+ATOM   2080  CG  ASP A 932      37.896  26.559  69.261  1.00 84.76           C  
+ATOM   2081  OD1 ASP A 932      38.005  25.320  69.088  1.00 75.16           O  
+ATOM   2082  OD2 ASP A 932      38.823  27.367  69.024  1.00 81.12           O  
+ATOM   2083  N   SER A 933      33.415  28.002  69.259  1.00 49.93           N  
+ATOM   2084  CA  SER A 933      32.211  28.522  69.872  1.00 53.57           C  
+ATOM   2085  C   SER A 933      31.081  27.511  69.739  1.00 55.00           C  
+ATOM   2086  O   SER A 933      30.162  27.491  70.562  1.00 53.86           O  
+ATOM   2087  CB  SER A 933      31.808  29.847  69.227  1.00 53.41           C  
+ATOM   2088  OG  SER A 933      32.645  30.891  69.698  1.00 74.85           O  
+ATOM   2089  N   ARG A 934      31.151  26.669  68.709  1.00 41.41           N  
+ATOM   2090  CA  ARG A 934      30.115  25.672  68.505  1.00 42.43           C  
+ATOM   2091  C   ARG A 934      30.166  24.667  69.635  1.00 39.42           C  
+ATOM   2092  O   ARG A 934      31.171  24.577  70.336  1.00 41.44           O  
+ATOM   2093  CB  ARG A 934      30.315  24.946  67.189  1.00 36.51           C  
+ATOM   2094  CG  ARG A 934      30.461  25.871  66.050  1.00 46.26           C  
+ATOM   2095  CD  ARG A 934      30.808  25.141  64.794  1.00 40.38           C  
+ATOM   2096  NE  ARG A 934      31.186  26.119  63.780  1.00 60.06           N  
+ATOM   2097  CZ  ARG A 934      32.044  25.902  62.794  1.00 46.49           C  
+ATOM   2098  NH1 ARG A 934      32.651  24.729  62.664  1.00 35.72           N  
+ATOM   2099  NH2 ARG A 934      32.230  26.846  61.896  1.00 32.88           N  
+ATOM   2100  N   PRO A 935      29.040  23.997  69.909  1.00 38.15           N  
+ATOM   2101  CA  PRO A 935      29.044  23.006  70.985  1.00 39.62           C  
+ATOM   2102  C   PRO A 935      29.889  21.789  70.607  1.00 46.52           C  
+ATOM   2103  O   PRO A 935      30.304  21.608  69.449  1.00 42.39           O  
+ATOM   2104  CB  PRO A 935      27.563  22.623  71.127  1.00 29.89           C  
+ATOM   2105  CG  PRO A 935      26.919  23.046  69.850  1.00 42.50           C  
+ATOM   2106  CD  PRO A 935      27.670  24.268  69.425  1.00 37.33           C  
+ATOM   2107  N   LYS A 936      30.145  20.968  71.609  1.00 43.51           N  
+ATOM   2108  CA  LYS A 936      30.903  19.756  71.440  1.00 44.28           C  
+ATOM   2109  C   LYS A 936      29.893  18.631  71.435  1.00 44.64           C  
+ATOM   2110  O   LYS A 936      28.814  18.754  72.034  1.00 41.04           O  
+ATOM   2111  CB  LYS A 936      31.893  19.586  72.600  1.00 39.02           C  
+ATOM   2112  CG  LYS A 936      32.971  20.676  72.637  1.00 47.20           C  
+ATOM   2113  CD  LYS A 936      33.993  20.415  73.748  1.00 75.87           C  
+ATOM   2114  CE  LYS A 936      35.002  21.560  73.915  1.00 77.64           C  
+ATOM   2115  NZ  LYS A 936      34.375  22.796  74.471  1.00 85.90           N  
+ATOM   2116  N   PHE A 937      30.223  17.545  70.737  1.00 46.58           N  
+ATOM   2117  CA  PHE A 937      29.336  16.401  70.681  1.00 36.52           C  
+ATOM   2118  C   PHE A 937      28.941  15.916  72.086  1.00 39.44           C  
+ATOM   2119  O   PHE A 937      27.763  15.612  72.328  1.00 40.59           O  
+ATOM   2120  CB  PHE A 937      29.941  15.279  69.838  1.00 35.72           C  
+ATOM   2121  CG  PHE A 937      29.852  15.530  68.364  1.00 35.87           C  
+ATOM   2122  CD1 PHE A 937      28.613  15.652  67.743  1.00 35.97           C  
+ATOM   2123  CD2 PHE A 937      31.006  15.692  67.601  1.00 40.42           C  
+ATOM   2124  CE1 PHE A 937      28.522  15.938  66.381  1.00 42.10           C  
+ATOM   2125  CE2 PHE A 937      30.927  15.981  66.234  1.00 33.24           C  
+ATOM   2126  CZ  PHE A 937      29.678  16.105  65.629  1.00 55.65           C  
+ATOM   2127  N   ARG A 938      29.884  15.922  73.032  1.00 30.91           N  
+ATOM   2128  CA  ARG A 938      29.534  15.483  74.380  1.00 35.47           C  
+ATOM   2129  C   ARG A 938      28.443  16.392  74.989  1.00 38.99           C  
+ATOM   2130  O   ARG A 938      27.590  15.925  75.754  1.00 40.29           O  
+ATOM   2131  CB  ARG A 938      30.766  15.383  75.297  1.00 33.40           C  
+ATOM   2132  CG  ARG A 938      31.543  16.685  75.490  1.00 56.97           C  
+ATOM   2133  CD  ARG A 938      32.552  16.596  76.620  1.00 63.24           C  
+ATOM   2134  NE  ARG A 938      31.968  16.105  77.880  1.00 88.47           N  
+ATOM   2135  CZ  ARG A 938      31.306  16.844  78.776  1.00 84.19           C  
+ATOM   2136  NH1 ARG A 938      30.836  16.271  79.876  1.00 86.37           N  
+ATOM   2137  NH2 ARG A 938      31.098  18.144  78.586  1.00 81.25           N  
+ATOM   2138  N   GLU A 939      28.430  17.670  74.607  1.00 37.26           N  
+ATOM   2139  CA  GLU A 939      27.409  18.594  75.118  1.00 39.02           C  
+ATOM   2140  C   GLU A 939      26.082  18.416  74.397  1.00 42.19           C  
+ATOM   2141  O   GLU A 939      25.022  18.536  75.014  1.00 41.43           O  
+ATOM   2142  CB  GLU A 939      27.848  20.045  74.999  1.00 27.30           C  
+ATOM   2143  CG  GLU A 939      28.987  20.415  75.928  1.00 33.07           C  
+ATOM   2144  CD  GLU A 939      29.757  21.607  75.406  1.00 46.40           C  
+ATOM   2145  OE1 GLU A 939      29.504  21.991  74.235  1.00 38.96           O  
+ATOM   2146  OE2 GLU A 939      30.598  22.160  76.157  1.00 54.12           O  
+ATOM   2147  N   LEU A 940      26.141  18.144  73.094  1.00 44.41           N  
+ATOM   2148  CA  LEU A 940      24.929  17.926  72.314  1.00 35.45           C  
+ATOM   2149  C   LEU A 940      24.155  16.743  72.898  1.00 36.59           C  
+ATOM   2150  O   LEU A 940      22.929  16.760  72.918  1.00 41.71           O  
+ATOM   2151  CB  LEU A 940      25.269  17.627  70.852  1.00 31.78           C  
+ATOM   2152  CG  LEU A 940      25.457  18.719  69.789  1.00 35.75           C  
+ATOM   2153  CD1 LEU A 940      24.419  19.821  69.948  1.00 30.93           C  
+ATOM   2154  CD2 LEU A 940      26.801  19.285  69.834  1.00 45.73           C  
+ATOM   2155  N   ILE A 941      24.881  15.737  73.393  1.00 33.71           N  
+ATOM   2156  CA  ILE A 941      24.288  14.532  73.980  1.00 32.37           C  
+ATOM   2157  C   ILE A 941      23.479  14.880  75.216  1.00 37.88           C  
+ATOM   2158  O   ILE A 941      22.333  14.455  75.342  1.00 48.34           O  
+ATOM   2159  CB  ILE A 941      25.374  13.524  74.380  1.00 34.04           C  
+ATOM   2160  CG1 ILE A 941      26.124  13.043  73.145  1.00 27.29           C  
+ATOM   2161  CG2 ILE A 941      24.778  12.333  75.163  1.00 18.00           C  
+ATOM   2162  CD1 ILE A 941      27.371  12.199  73.497  1.00 28.95           C  
+ATOM   2163  N   ILE A 942      24.093  15.649  76.123  1.00 45.39           N  
+ATOM   2164  CA  ILE A 942      23.469  16.118  77.375  1.00 38.61           C  
+ATOM   2165  C   ILE A 942      22.218  16.939  77.033  1.00 33.47           C  
+ATOM   2166  O   ILE A 942      21.123  16.627  77.482  1.00 34.41           O  
+ATOM   2167  CB  ILE A 942      24.473  17.007  78.179  1.00 41.34           C  
+ATOM   2168  CG1 ILE A 942      25.632  16.146  78.669  1.00 38.77           C  
+ATOM   2169  CG2 ILE A 942      23.795  17.679  79.392  1.00 36.18           C  
+ATOM   2170  CD1 ILE A 942      26.789  16.937  79.223  1.00 30.80           C  
+ATOM   2171  N   GLU A 943      22.391  17.960  76.198  1.00 28.84           N  
+ATOM   2172  CA  GLU A 943      21.291  18.824  75.784  1.00 30.47           C  
+ATOM   2173  C   GLU A 943      20.089  18.096  75.233  1.00 35.87           C  
+ATOM   2174  O   GLU A 943      18.982  18.214  75.772  1.00 40.99           O  
+ATOM   2175  CB  GLU A 943      21.762  19.871  74.779  1.00 35.02           C  
+ATOM   2176  CG  GLU A 943      22.617  20.986  75.404  1.00 39.86           C  
+ATOM   2177  CD  GLU A 943      22.041  21.483  76.733  1.00 77.41           C  
+ATOM   2178  OE1 GLU A 943      20.966  22.134  76.724  1.00 85.94           O  
+ATOM   2179  OE2 GLU A 943      22.660  21.205  77.789  1.00 72.26           O  
+ATOM   2180  N   PHE A 944      20.300  17.320  74.179  1.00 38.26           N  
+ATOM   2181  CA  PHE A 944      19.202  16.581  73.597  1.00 31.16           C  
+ATOM   2182  C   PHE A 944      18.686  15.504  74.553  1.00 41.19           C  
+ATOM   2183  O   PHE A 944      17.497  15.148  74.523  1.00 41.21           O  
+ATOM   2184  CB  PHE A 944      19.590  16.017  72.237  1.00 24.37           C  
+ATOM   2185  CG  PHE A 944      19.595  17.046  71.138  1.00 27.04           C  
+ATOM   2186  CD1 PHE A 944      18.411  17.457  70.537  1.00 28.88           C  
+ATOM   2187  CD2 PHE A 944      20.767  17.593  70.701  1.00 22.64           C  
+ATOM   2188  CE1 PHE A 944      18.416  18.399  69.516  1.00 26.21           C  
+ATOM   2189  CE2 PHE A 944      20.781  18.539  69.678  1.00 30.12           C  
+ATOM   2190  CZ  PHE A 944      19.597  18.942  69.082  1.00 25.91           C  
+ATOM   2191  N   SER A 945      19.532  15.027  75.459  1.00 32.00           N  
+ATOM   2192  CA  SER A 945      19.027  14.020  76.389  1.00 34.64           C  
+ATOM   2193  C   SER A 945      17.989  14.623  77.342  1.00 35.94           C  
+ATOM   2194  O   SER A 945      16.975  13.992  77.616  1.00 40.02           O  
+ATOM   2195  CB  SER A 945      20.150  13.365  77.177  1.00 23.33           C  
+ATOM   2196  OG  SER A 945      19.937  11.977  77.248  1.00 58.22           O  
+ATOM   2197  N   LYS A 946      18.247  15.833  77.850  1.00 37.03           N  
+ATOM   2198  CA  LYS A 946      17.310  16.518  78.758  1.00 32.11           C  
+ATOM   2199  C   LYS A 946      15.985  16.725  78.029  1.00 35.11           C  
+ATOM   2200  O   LYS A 946      14.945  16.394  78.556  1.00 45.42           O  
+ATOM   2201  CB  LYS A 946      17.836  17.890  79.192  1.00 29.76           C  
+ATOM   2202  CG  LYS A 946      19.123  17.913  80.016  1.00 36.53           C  
+ATOM   2203  CD  LYS A 946      19.429  19.361  80.407  1.00 41.91           C  
+ATOM   2204  CE  LYS A 946      20.719  19.533  81.173  1.00 70.01           C  
+ATOM   2205  NZ  LYS A 946      21.235  20.938  81.036  1.00 67.11           N  
+ATOM   2206  N   MET A 947      16.040  17.250  76.805  1.00 31.98           N  
+ATOM   2207  CA  MET A 947      14.850  17.472  75.994  1.00 33.38           C  
+ATOM   2208  C   MET A 947      14.133  16.168  75.714  1.00 37.66           C  
+ATOM   2209  O   MET A 947      12.928  16.142  75.542  1.00 43.14           O  
+ATOM   2210  CB  MET A 947      15.213  18.100  74.639  1.00 27.03           C  
+ATOM   2211  CG  MET A 947      15.830  19.490  74.725  1.00 26.82           C  
+ATOM   2212  SD  MET A 947      16.241  20.172  73.148  1.00 42.66           S  
+ATOM   2213  CE  MET A 947      16.471  21.663  73.619  1.00 27.60           C  
+ATOM   2214  N   ALA A 948      14.874  15.079  75.615  1.00 40.01           N  
+ATOM   2215  CA  ALA A 948      14.223  13.812  75.319  1.00 42.39           C  
+ATOM   2216  C   ALA A 948      13.339  13.324  76.461  1.00 42.96           C  
+ATOM   2217  O   ALA A 948      12.431  12.534  76.234  1.00 42.41           O  
+ATOM   2218  CB  ALA A 948      15.245  12.759  74.944  1.00 38.29           C  
+ATOM   2219  N   ARG A 949      13.589  13.814  77.673  1.00 42.09           N  
+ATOM   2220  CA  ARG A 949      12.806  13.409  78.839  1.00 47.73           C  
+ATOM   2221  C   ARG A 949      11.431  14.074  78.847  1.00 50.58           C  
+ATOM   2222  O   ARG A 949      10.515  13.617  79.536  1.00 51.13           O  
+ATOM   2223  CB  ARG A 949      13.547  13.738  80.138  1.00 49.42           C  
+ATOM   2224  CG  ARG A 949      14.915  13.105  80.262  1.00 63.41           C  
+ATOM   2225  CD  ARG A 949      15.643  13.621  81.489  1.00 71.71           C  
+ATOM   2226  NE  ARG A 949      15.167  12.973  82.704  1.00 89.72           N  
+ATOM   2227  CZ  ARG A 949      15.696  11.865  83.216  1.00100.01           C  
+ATOM   2228  NH1 ARG A 949      16.727  11.278  82.617  1.00 83.06           N  
+ATOM   2229  NH2 ARG A 949      15.202  11.351  84.336  1.00 95.80           N  
+ATOM   2230  N   ASP A 950      11.286  15.132  78.052  1.00 43.83           N  
+ATOM   2231  CA  ASP A 950      10.025  15.859  77.960  1.00 42.05           C  
+ATOM   2232  C   ASP A 950       9.888  16.435  76.560  1.00 39.84           C  
+ATOM   2233  O   ASP A 950       9.825  17.652  76.389  1.00 39.55           O  
+ATOM   2234  CB  ASP A 950      10.005  16.983  78.998  1.00 51.48           C  
+ATOM   2235  CG  ASP A 950       8.639  17.615  79.156  1.00 58.95           C  
+ATOM   2236  OD1 ASP A 950       7.624  16.976  78.793  1.00 55.22           O  
+ATOM   2237  OD2 ASP A 950       8.589  18.759  79.655  1.00 62.28           O  
+ATOM   2238  N   PRO A 951       9.739  15.551  75.551  1.00 40.81           N  
+ATOM   2239  CA  PRO A 951       9.599  15.784  74.103  1.00 36.20           C  
+ATOM   2240  C   PRO A 951       8.714  16.936  73.658  1.00 37.25           C  
+ATOM   2241  O   PRO A 951       9.136  17.804  72.904  1.00 45.03           O  
+ATOM   2242  CB  PRO A 951       9.006  14.466  73.591  1.00 38.69           C  
+ATOM   2243  CG  PRO A 951       9.428  13.443  74.585  1.00 30.83           C  
+ATOM   2244  CD  PRO A 951       9.386  14.157  75.897  1.00 30.56           C  
+ATOM   2245  N   GLN A 952       7.462  16.904  74.098  1.00 48.37           N  
+ATOM   2246  CA  GLN A 952       6.474  17.902  73.714  1.00 47.07           C  
+ATOM   2247  C   GLN A 952       6.749  19.343  74.138  1.00 44.39           C  
+ATOM   2248  O   GLN A 952       6.193  20.273  73.559  1.00 49.87           O  
+ATOM   2249  CB  GLN A 952       5.099  17.426  74.141  1.00 58.06           C  
+ATOM   2250  CG  GLN A 952       4.902  15.952  73.801  1.00 64.13           C  
+ATOM   2251  CD  GLN A 952       3.465  15.569  73.547  1.00 69.01           C  
+ATOM   2252  OE1 GLN A 952       3.191  14.495  73.009  1.00 72.48           O  
+ATOM   2253  NE2 GLN A 952       2.533  16.442  73.929  1.00 77.08           N  
+ATOM   2254  N   ARG A 953       7.642  19.536  75.103  1.00 38.38           N  
+ATOM   2255  CA  ARG A 953       8.006  20.885  75.526  1.00 41.33           C  
+ATOM   2256  C   ARG A 953       8.999  21.472  74.539  1.00 46.11           C  
+ATOM   2257  O   ARG A 953       9.222  22.690  74.520  1.00 41.69           O  
+ATOM   2258  CB  ARG A 953       8.656  20.859  76.913  1.00 42.06           C  
+ATOM   2259  CG  ARG A 953       9.232  22.194  77.380  1.00 40.58           C  
+ATOM   2260  CD  ARG A 953       9.817  22.082  78.784  1.00 45.08           C  
+ATOM   2261  NE  ARG A 953      10.380  23.346  79.259  1.00 54.96           N  
+ATOM   2262  CZ  ARG A 953      10.877  23.539  80.480  1.00 53.15           C  
+ATOM   2263  NH1 ARG A 953      10.872  22.559  81.373  1.00 54.51           N  
+ATOM   2264  NH2 ARG A 953      11.461  24.687  80.782  1.00 56.52           N  
+ATOM   2265  N   TYR A 954       9.595  20.604  73.717  1.00 45.84           N  
+ATOM   2266  CA  TYR A 954      10.605  21.050  72.768  1.00 45.23           C  
+ATOM   2267  C   TYR A 954      10.288  20.963  71.285  1.00 42.43           C  
+ATOM   2268  O   TYR A 954      10.906  21.671  70.509  1.00 40.53           O  
+ATOM   2269  CB  TYR A 954      11.936  20.393  73.097  1.00 41.53           C  
+ATOM   2270  CG  TYR A 954      12.363  20.693  74.503  1.00 32.06           C  
+ATOM   2271  CD1 TYR A 954      12.926  21.926  74.837  1.00 36.24           C  
+ATOM   2272  CD2 TYR A 954      12.170  19.763  75.507  1.00 33.08           C  
+ATOM   2273  CE1 TYR A 954      13.286  22.217  76.148  1.00 48.55           C  
+ATOM   2274  CE2 TYR A 954      12.515  20.041  76.822  1.00 30.78           C  
+ATOM   2275  CZ  TYR A 954      13.076  21.269  77.141  1.00 48.37           C  
+ATOM   2276  OH  TYR A 954      13.429  21.530  78.454  1.00 43.57           O  
+ATOM   2277  N   LEU A 955       9.380  20.071  70.885  1.00 36.81           N  
+ATOM   2278  CA  LEU A 955       8.962  19.977  69.478  1.00 44.26           C  
+ATOM   2279  C   LEU A 955       7.430  19.979  69.438  1.00 47.79           C  
+ATOM   2280  O   LEU A 955       6.788  19.266  70.208  1.00 53.16           O  
+ATOM   2281  CB  LEU A 955       9.513  18.710  68.808  1.00 44.08           C  
+ATOM   2282  CG  LEU A 955      11.042  18.649  68.728  1.00 45.99           C  
+ATOM   2283  CD1 LEU A 955      11.513  17.281  68.294  1.00 37.54           C  
+ATOM   2284  CD2 LEU A 955      11.549  19.735  67.798  1.00 31.30           C  
+ATOM   2285  N   VAL A 956       6.836  20.779  68.560  1.00 45.47           N  
+ATOM   2286  CA  VAL A 956       5.375  20.832  68.486  1.00 52.78           C  
+ATOM   2287  C   VAL A 956       4.863  20.158  67.203  1.00 53.17           C  
+ATOM   2288  O   VAL A 956       4.915  20.717  66.101  1.00 55.14           O  
+ATOM   2289  CB  VAL A 956       4.854  22.303  68.681  1.00 53.97           C  
+ATOM   2290  CG1 VAL A 956       5.584  22.941  69.856  1.00 45.35           C  
+ATOM   2291  CG2 VAL A 956       5.101  23.162  67.451  1.00 75.38           C  
+ATOM   2292  N   ILE A 957       4.401  18.924  67.343  1.00 56.03           N  
+ATOM   2293  CA  ILE A 957       3.944  18.169  66.179  1.00 57.87           C  
+ATOM   2294  C   ILE A 957       2.466  17.847  66.285  1.00 66.18           C  
+ATOM   2295  O   ILE A 957       2.038  17.212  67.258  1.00 66.05           O  
+ATOM   2296  CB  ILE A 957       4.765  16.874  66.035  1.00 53.85           C  
+ATOM   2297  CG1 ILE A 957       6.244  17.213  65.849  1.00 54.12           C  
+ATOM   2298  CG2 ILE A 957       4.263  16.042  64.873  1.00 54.82           C  
+ATOM   2299  CD1 ILE A 957       7.150  16.007  66.038  1.00 51.62           C  
+ATOM   2300  N   GLN A 958       1.709  18.223  65.249  1.00 71.66           N  
+ATOM   2301  CA  GLN A 958       0.257  18.028  65.226  1.00 73.95           C  
+ATOM   2302  C   GLN A 958      -0.255  16.757  65.881  1.00 73.71           C  
+ATOM   2303  O   GLN A 958      -0.976  16.824  66.878  1.00 85.17           O  
+ATOM   2304  CB  GLN A 958      -0.311  18.205  63.814  1.00 86.01           C  
+ATOM   2305  CG  GLN A 958      -0.287  19.673  63.331  1.00 96.70           C  
+ATOM   2306  CD  GLN A 958      -0.889  19.883  61.938  1.00109.06           C  
+ATOM   2307  OE1 GLN A 958      -1.102  21.024  61.501  1.00 92.87           O  
+ATOM   2308  NE2 GLN A 958      -1.157  18.782  61.234  1.00108.78           N  
+ATOM   2309  N   GLY A 959       0.175  15.606  65.394  1.00 67.82           N  
+ATOM   2310  CA  GLY A 959      -0.286  14.372  65.993  1.00 75.47           C  
+ATOM   2311  C   GLY A 959       0.354  14.001  67.311  1.00 83.33           C  
+ATOM   2312  O   GLY A 959      -0.306  13.944  68.348  1.00 85.18           O  
+ATOM   2313  N   ASP A 960       1.659  13.769  67.258  1.00 91.00           N  
+ATOM   2314  CA  ASP A 960       2.460  13.364  68.408  1.00 97.35           C  
+ATOM   2315  C   ASP A 960       1.929  12.134  69.151  1.00104.78           C  
+ATOM   2316  O   ASP A 960       1.663  12.148  70.363  1.00105.25           O  
+ATOM   2317  CB  ASP A 960       2.754  14.536  69.337  1.00 88.07           C  
+ATOM   2318  CG  ASP A 960       4.243  14.778  69.480  1.00 82.75           C  
+ATOM   2319  OD1 ASP A 960       4.663  15.953  69.615  1.00 94.90           O  
+ATOM   2320  OD2 ASP A 960       4.991  13.776  69.441  1.00 44.80           O  
+ATOM   2321  N   GLU A 961       1.813  11.070  68.357  1.00110.50           N  
+ATOM   2322  CA  GLU A 961       1.346   9.741  68.738  1.00113.27           C  
+ATOM   2323  C   GLU A 961       1.223   9.033  67.376  1.00116.78           C  
+ATOM   2324  O   GLU A 961       2.233   8.581  66.814  1.00115.73           O  
+ATOM   2325  CB  GLU A 961      -0.007   9.818  69.456  0.00107.62           C  
+ATOM   2326  CG  GLU A 961      -0.443   8.523  70.136  0.00103.48           C  
+ATOM   2327  CD  GLU A 961      -1.365   7.680  69.274  0.00107.05           C  
+ATOM   2328  OE1 GLU A 961      -2.389   8.215  68.800  0.00103.70           O  
+ATOM   2329  OE2 GLU A 961      -1.070   6.483  69.077  0.00111.53           O  
+ATOM   2330  N   ARG A 962       0.014   9.028  66.808  1.00116.88           N  
+ATOM   2331  CA  ARG A 962      -0.230   8.407  65.500  1.00116.76           C  
+ATOM   2332  C   ARG A 962      -1.170   9.182  64.565  1.00116.92           C  
+ATOM   2333  O   ARG A 962      -0.910   9.277  63.358  1.00117.27           O  
+ATOM   2334  CB  ARG A 962      -0.771   6.982  65.655  0.00110.04           C  
+ATOM   2335  CG  ARG A 962       0.287   5.908  65.839  0.00112.94           C  
+ATOM   2336  CD  ARG A 962      -0.228   4.561  65.346  0.00104.53           C  
+ATOM   2337  NE  ARG A 962      -0.509   4.587  63.911  0.00110.32           N  
+ATOM   2338  CZ  ARG A 962      -1.144   3.627  63.244  0.00109.74           C  
+ATOM   2339  NH1 ARG A 962      -1.347   3.751  61.939  0.00111.50           N  
+ATOM   2340  NH2 ARG A 962      -1.581   2.546  63.876  0.00106.68           N  
+ATOM   2341  N   MET A 963      -2.247   9.735  65.129  1.00116.91           N  
+ATOM   2342  CA  MET A 963      -3.268  10.474  64.371  1.00115.26           C  
+ATOM   2343  C   MET A 963      -4.108   9.501  63.556  1.00115.17           C  
+ATOM   2344  O   MET A 963      -4.240   9.645  62.335  1.00114.82           O  
+ATOM   2345  CB  MET A 963      -2.650  11.521  63.434  0.00107.81           C  
+ATOM   2346  CG  MET A 963      -2.284  12.822  64.096  0.00109.34           C  
+ATOM   2347  SD  MET A 963      -1.739  14.074  62.916  0.00105.34           S  
+ATOM   2348  CE  MET A 963      -3.220  15.074  62.781  0.00108.60           C  
+ATOM   2349  N   HIS A 964      -4.647   8.496  64.241  1.00112.44           N  
+ATOM   2350  CA  HIS A 964      -5.470   7.475  63.606  1.00115.68           C  
+ATOM   2351  C   HIS A 964      -6.806   8.052  63.112  1.00116.16           C  
+ATOM   2352  O   HIS A 964      -7.013   8.227  61.906  1.00114.87           O  
+ATOM   2353  CB  HIS A 964      -5.725   6.329  64.593  1.00113.98           C  
+ATOM   2354  CG  HIS A 964      -5.734   4.971  63.957  1.00112.53           C  
+ATOM   2355  ND1 HIS A 964      -5.380   3.830  64.649  1.00113.68           N  
+ATOM   2356  CD2 HIS A 964      -6.032   4.572  62.699  1.00105.38           C  
+ATOM   2357  CE1 HIS A 964      -5.457   2.788  63.840  1.00114.57           C  
+ATOM   2358  NE2 HIS A 964      -5.850   3.209  62.651  1.00113.82           N  
+ATOM   2359  N   LEU A 977     -11.036   6.578  61.901  1.00 98.67           N  
+ATOM   2360  CA  LEU A 977     -12.096   6.763  60.910  1.00 97.99           C  
+ATOM   2361  C   LEU A 977     -11.702   7.833  59.892  1.00100.95           C  
+ATOM   2362  O   LEU A 977     -12.067   9.012  60.039  1.00100.25           O  
+ATOM   2363  CB  LEU A 977     -13.399   7.183  61.600  1.00105.55           C  
+ATOM   2364  CG  LEU A 977     -13.984   6.218  62.637  1.00111.80           C  
+ATOM   2365  CD1 LEU A 977     -15.169   6.866  63.378  1.00108.54           C  
+ATOM   2366  CD2 LEU A 977     -14.414   4.929  61.930  1.00109.36           C  
+ATOM   2367  N   MET A 978     -10.962   7.413  58.867  1.00102.70           N  
+ATOM   2368  CA  MET A 978     -10.504   8.315  57.817  1.00103.31           C  
+ATOM   2369  C   MET A 978     -11.650   9.145  57.237  1.00106.84           C  
+ATOM   2370  O   MET A 978     -12.444   8.661  56.414  1.00109.14           O  
+ATOM   2371  CB  MET A 978      -9.778   7.537  56.713  0.00100.10           C  
+ATOM   2372  CG  MET A 978      -8.293   7.385  56.958  0.00 98.27           C  
+ATOM   2373  SD  MET A 978      -7.570   5.997  56.069  0.00 98.15           S  
+ATOM   2374  CE  MET A 978      -7.350   6.699  54.437  0.00 96.91           C  
+ATOM   2375  N   ASP A 979     -11.720  10.400  57.681  1.00106.02           N  
+ATOM   2376  CA  ASP A 979     -12.744  11.335  57.231  1.00104.82           C  
+ATOM   2377  C   ASP A 979     -12.565  11.582  55.749  1.00106.55           C  
+ATOM   2378  O   ASP A 979     -13.533  11.544  54.977  1.00111.17           O  
+ATOM   2379  CB  ASP A 979     -12.606  12.675  57.961  1.00100.55           C  
+ATOM   2380  CG  ASP A 979     -12.518  12.517  59.463  1.00107.51           C  
+ATOM   2381  OD1 ASP A 979     -13.409  13.052  60.162  1.00107.84           O  
+ATOM   2382  OD2 ASP A 979     -11.546  11.879  59.938  1.00103.86           O  
+ATOM   2383  N   GLU A 980     -11.314  11.834  55.363  1.00104.79           N  
+ATOM   2384  CA  GLU A 980     -10.977  12.138  53.975  1.00104.15           C  
+ATOM   2385  C   GLU A 980     -11.654  13.478  53.594  1.00107.13           C  
+ATOM   2386  O   GLU A 980     -11.901  13.769  52.411  1.00105.70           O  
+ATOM   2387  CB  GLU A 980     -11.416  10.988  53.045  1.00 95.70           C  
+ATOM   2388  CG  GLU A 980     -10.265  10.243  52.348  1.00 86.65           C  
+ATOM   2389  CD  GLU A 980      -9.884  10.848  50.990  1.00 99.25           C  
+ATOM   2390  OE1 GLU A 980     -10.798  11.111  50.165  1.00 88.90           O  
+ATOM   2391  OE2 GLU A 980      -8.668  11.043  50.740  1.00100.15           O  
+ATOM   2392  N   GLU A 981     -11.939  14.284  54.623  1.00108.13           N  
+ATOM   2393  CA  GLU A 981     -12.582  15.594  54.474  1.00109.23           C  
+ATOM   2394  C   GLU A 981     -12.015  16.586  55.498  1.00109.07           C  
+ATOM   2395  O   GLU A 981     -11.388  16.190  56.488  1.00110.13           O  
+ATOM   2396  CB  GLU A 981     -14.106  15.483  54.675  1.00111.55           C  
+ATOM   2397  CG  GLU A 981     -14.828  14.476  53.763  1.00108.91           C  
+ATOM   2398  CD  GLU A 981     -14.838  14.889  52.290  1.00111.28           C  
+ATOM   2399  OE1 GLU A 981     -15.248  16.034  51.989  1.00113.42           O  
+ATOM   2400  OE2 GLU A 981     -14.446  14.063  51.434  1.00107.58           O  
+ATOM   2401  N   ASP A 982     -12.282  17.872  55.273  1.00106.21           N  
+ATOM   2402  CA  ASP A 982     -11.790  18.937  56.150  1.00101.89           C  
+ATOM   2403  C   ASP A 982     -12.920  19.459  57.050  1.00101.15           C  
+ATOM   2404  O   ASP A 982     -13.310  20.632  56.965  1.00 97.90           O  
+ATOM   2405  CB  ASP A 982     -11.207  20.084  55.301  1.00100.37           C  
+ATOM   2406  CG  ASP A 982     -10.352  19.582  54.120  1.00104.53           C  
+ATOM   2407  OD1 ASP A 982      -9.101  19.526  54.251  1.00 92.22           O  
+ATOM   2408  OD2 ASP A 982     -10.940  19.251  53.058  1.00 94.95           O  
+ATOM   2409  N   MET A 983     -13.411  18.600  57.944  1.00100.30           N  
+ATOM   2410  CA  MET A 983     -14.513  18.983  58.831  1.00 95.98           C  
+ATOM   2411  C   MET A 983     -14.442  18.547  60.291  1.00 89.83           C  
+ATOM   2412  O   MET A 983     -14.298  17.364  60.589  1.00 85.08           O  
+ATOM   2413  CB  MET A 983     -15.836  18.509  58.233  1.00 93.83           C  
+ATOM   2414  CG  MET A 983     -16.482  19.534  57.333  1.00 98.24           C  
+ATOM   2415  SD  MET A 983     -16.887  21.091  58.209  1.00115.20           S  
+ATOM   2416  CE  MET A 983     -17.448  20.486  59.827  1.00 75.13           C  
+ATOM   2417  N   ASP A 984     -14.630  19.503  61.197  1.00 89.69           N  
+ATOM   2418  CA  ASP A 984     -14.585  19.196  62.624  1.00 92.07           C  
+ATOM   2419  C   ASP A 984     -15.917  19.307  63.369  1.00 88.52           C  
+ATOM   2420  O   ASP A 984     -15.954  19.294  64.605  1.00 93.52           O  
+ATOM   2421  CB  ASP A 984     -13.462  19.980  63.334  1.00101.91           C  
+ATOM   2422  CG  ASP A 984     -13.486  21.471  63.026  1.00100.65           C  
+ATOM   2423  OD1 ASP A 984     -13.756  22.263  63.962  1.00 92.14           O  
+ATOM   2424  OD2 ASP A 984     -13.217  21.845  61.858  1.00 96.89           O  
+ATOM   2425  N   ASP A 985     -17.003  19.442  62.612  1.00 80.70           N  
+ATOM   2426  CA  ASP A 985     -18.350  19.482  63.184  1.00 73.66           C  
+ATOM   2427  C   ASP A 985     -19.064  18.162  62.828  1.00 66.19           C  
+ATOM   2428  O   ASP A 985     -20.287  18.042  62.888  1.00 57.52           O  
+ATOM   2429  CB  ASP A 985     -19.144  20.697  62.689  1.00 80.53           C  
+ATOM   2430  CG  ASP A 985     -18.979  21.918  63.593  1.00 85.08           C  
+ATOM   2431  OD1 ASP A 985     -19.469  21.897  64.742  1.00 84.24           O  
+ATOM   2432  OD2 ASP A 985     -18.365  22.911  63.149  1.00113.46           O  
+ATOM   2433  N   VAL A 986     -18.270  17.171  62.444  1.00 60.54           N  
+ATOM   2434  CA  VAL A 986     -18.783  15.857  62.110  1.00 61.25           C  
+ATOM   2435  C   VAL A 986     -19.165  15.143  63.404  1.00 63.60           C  
+ATOM   2436  O   VAL A 986     -18.457  15.231  64.413  1.00 68.55           O  
+ATOM   2437  CB  VAL A 986     -17.728  15.022  61.328  1.00 56.02           C  
+ATOM   2438  CG1 VAL A 986     -16.358  15.187  61.944  1.00 72.01           C  
+ATOM   2439  CG2 VAL A 986     -18.114  13.549  61.314  1.00 56.88           C  
+ATOM   2440  N   VAL A 987     -20.316  14.485  63.389  1.00 57.43           N  
+ATOM   2441  CA  VAL A 987     -20.781  13.749  64.551  1.00 57.07           C  
+ATOM   2442  C   VAL A 987     -21.338  12.423  64.059  1.00 49.36           C  
+ATOM   2443  O   VAL A 987     -21.979  12.352  63.029  1.00 50.06           O  
+ATOM   2444  CB  VAL A 987     -21.826  14.558  65.384  1.00 62.51           C  
+ATOM   2445  CG1 VAL A 987     -23.176  14.602  64.699  1.00 72.99           C  
+ATOM   2446  CG2 VAL A 987     -21.950  13.973  66.764  1.00 68.30           C  
+ATOM   2447  N   ASP A 988     -21.030  11.357  64.768  1.00 51.01           N  
+ATOM   2448  CA  ASP A 988     -21.487  10.043  64.369  1.00 51.26           C  
+ATOM   2449  C   ASP A 988     -22.997   9.890  64.579  1.00 51.75           C  
+ATOM   2450  O   ASP A 988     -23.565  10.436  65.525  1.00 38.97           O  
+ATOM   2451  CB  ASP A 988     -20.704   8.991  65.148  1.00 64.52           C  
+ATOM   2452  CG  ASP A 988     -20.941   7.601  64.643  1.00 72.88           C  
+ATOM   2453  OD1 ASP A 988     -22.008   7.045  64.958  1.00 73.00           O  
+ATOM   2454  OD2 ASP A 988     -20.065   7.065  63.934  1.00 79.97           O  
+ATOM   2455  N   ALA A 989     -23.641   9.147  63.682  1.00 53.68           N  
+ATOM   2456  CA  ALA A 989     -25.078   8.923  63.748  1.00 54.78           C  
+ATOM   2457  C   ALA A 989     -25.592   8.400  65.086  1.00 53.06           C  
+ATOM   2458  O   ALA A 989     -26.638   8.838  65.550  1.00 40.10           O  
+ATOM   2459  CB  ALA A 989     -25.523   8.009  62.625  1.00 71.08           C  
+ATOM   2460  N   ASP A 990     -24.909   7.451  65.714  1.00 56.09           N  
+ATOM   2461  CA  ASP A 990     -25.451   7.012  66.988  1.00 65.16           C  
+ATOM   2462  C   ASP A 990     -25.320   7.992  68.161  1.00 65.80           C  
+ATOM   2463  O   ASP A 990     -25.670   7.672  69.293  1.00 75.94           O  
+ATOM   2464  CB  ASP A 990     -25.102   5.557  67.342  1.00 65.84           C  
+ATOM   2465  CG  ASP A 990     -23.709   5.159  66.952  1.00 83.21           C  
+ATOM   2466  OD1 ASP A 990     -22.766   5.908  67.269  1.00105.89           O  
+ATOM   2467  OD2 ASP A 990     -23.555   4.061  66.372  1.00 50.58           O  
+ATOM   2468  N   GLU A 991     -24.898   9.218  67.854  1.00 68.05           N  
+ATOM   2469  CA  GLU A 991     -24.777  10.297  68.836  1.00 61.35           C  
+ATOM   2470  C   GLU A 991     -25.731  11.436  68.462  1.00 63.63           C  
+ATOM   2471  O   GLU A 991     -25.868  12.407  69.196  1.00 70.81           O  
+ATOM   2472  CB  GLU A 991     -23.355  10.840  68.920  1.00 69.24           C  
+ATOM   2473  CG  GLU A 991     -22.473  10.174  69.951  1.00 75.90           C  
+ATOM   2474  CD  GLU A 991     -21.844   8.900  69.449  1.00 87.85           C  
+ATOM   2475  OE1 GLU A 991     -22.203   7.816  69.952  1.00 86.52           O  
+ATOM   2476  OE2 GLU A 991     -20.981   8.983  68.553  1.00101.63           O  
+ATOM   2477  N   TYR A 992     -26.373  11.323  67.303  1.00 64.88           N  
+ATOM   2478  CA  TYR A 992     -27.326  12.326  66.853  1.00 66.42           C  
+ATOM   2479  C   TYR A 992     -28.730  11.752  67.046  1.00 71.04           C  
+ATOM   2480  O   TYR A 992     -29.200  10.939  66.238  1.00 72.58           O  
+ATOM   2481  CB  TYR A 992     -27.088  12.685  65.388  1.00 59.44           C  
+ATOM   2482  CG  TYR A 992     -27.873  13.890  64.961  1.00 51.29           C  
+ATOM   2483  CD1 TYR A 992     -29.020  13.766  64.189  1.00 48.15           C  
+ATOM   2484  CD2 TYR A 992     -27.513  15.150  65.402  1.00 67.10           C  
+ATOM   2485  CE1 TYR A 992     -29.792  14.874  63.881  1.00 59.76           C  
+ATOM   2486  CE2 TYR A 992     -28.275  16.264  65.099  1.00 68.08           C  
+ATOM   2487  CZ  TYR A 992     -29.411  16.123  64.345  1.00 57.75           C  
+ATOM   2488  OH  TYR A 992     -30.170  17.240  64.079  1.00 84.13           O  
+ATOM   2489  N   LEU A 993     -29.392  12.186  68.119  1.00 76.45           N  
+ATOM   2490  CA  LEU A 993     -30.731  11.698  68.469  1.00 77.52           C  
+ATOM   2491  C   LEU A 993     -31.900  12.635  68.142  1.00 81.92           C  
+ATOM   2492  O   LEU A 993     -31.709  13.828  67.872  1.00 80.06           O  
+ATOM   2493  CB  LEU A 993     -30.756  11.271  69.945  1.00 70.42           C  
+ATOM   2494  CG  LEU A 993     -29.680  10.238  70.327  1.00 72.50           C  
+ATOM   2495  CD1 LEU A 993     -29.626  10.037  71.805  1.00 68.90           C  
+ATOM   2496  CD2 LEU A 993     -29.940   8.920  69.632  1.00 76.90           C  
+ATOM   2497  N   ILE A 994     -33.105  12.061  68.191  1.00 88.40           N  
+ATOM   2498  CA  ILE A 994     -34.387  12.712  67.878  1.00 89.65           C  
+ATOM   2499  C   ILE A 994     -34.482  14.259  67.897  1.00 97.21           C  
+ATOM   2500  O   ILE A 994     -34.504  14.892  68.960  1.00104.38           O  
+ATOM   2501  CB  ILE A 994     -35.581  12.038  68.674  0.00 85.68           C  
+ATOM   2502  CG1 ILE A 994     -35.951  12.802  69.950  0.00 82.73           C  
+ATOM   2503  CG2 ILE A 994     -35.222  10.605  69.055  0.00 78.46           C  
+ATOM   2504  CD1 ILE A 994     -37.197  13.669  69.803  0.00 89.21           C  
+ATOM   2505  N   PRO A 995     -34.413  14.890  66.708  1.00 96.35           N  
+ATOM   2506  CA  PRO A 995     -34.506  16.354  66.608  1.00 96.33           C  
+ATOM   2507  C   PRO A 995     -35.968  16.813  66.584  1.00 96.89           C  
+ATOM   2508  O   PRO A 995     -36.887  16.005  66.390  1.00 98.69           O  
+ATOM   2509  CB  PRO A 995     -33.814  16.651  65.275  1.00 97.60           C  
+ATOM   2510  CG  PRO A 995     -34.154  15.455  64.454  1.00 95.62           C  
+ATOM   2511  CD  PRO A 995     -33.927  14.315  65.439  1.00 98.63           C  
+TER    2512      PRO A 995                                                      
+HETATM 2513  C1  AQ4 A 999      29.552  -1.989  53.496  1.00 82.82           C  
+HETATM 2514  C2  AQ4 A 999      28.841  -1.022  53.432  1.00 79.21           C  
+HETATM 2515  C3  AQ4 A 999      27.989   0.094  53.366  1.00 77.10           C  
+HETATM 2516  C4  AQ4 A 999      26.606  -0.119  53.323  1.00 78.64           C  
+HETATM 2517  C5  AQ4 A 999      25.725   0.972  53.258  1.00 75.72           C  
+HETATM 2518  N1  AQ4 A 999      24.289   0.712  53.215  1.00 63.33           N  
+HETATM 2519  C6  AQ4 A 999      23.410  -0.217  53.908  1.00 56.92           C  
+HETATM 2520  C7  AQ4 A 999      22.037  -0.309  53.572  1.00 52.23           C  
+HETATM 2521  C8  AQ4 A 999      21.501   0.476  52.546  1.00 48.18           C  
+HETATM 2522  C9  AQ4 A 999      20.143   0.376  52.218  1.00 52.11           C  
+HETATM 2523  O1  AQ4 A 999      19.589   1.220  51.120  1.00 82.48           O  
+HETATM 2524  C10 AQ4 A 999      20.550   1.362  50.041  1.00 83.98           C  
+HETATM 2525  C11 AQ4 A 999      20.235   2.645  49.262  1.00 91.80           C  
+HETATM 2526  O2  AQ4 A 999      18.990   2.485  48.543  1.00 96.57           O  
+HETATM 2527  C12 AQ4 A 999      17.712   2.618  49.399  1.00 88.53           C  
+HETATM 2528  C13 AQ4 A 999      19.301  -0.535  52.923  1.00 52.73           C  
+HETATM 2529  O3  AQ4 A 999      17.828  -0.679  52.597  1.00 83.95           O  
+HETATM 2530  C14 AQ4 A 999      17.227   0.601  52.220  1.00 98.66           C  
+HETATM 2531  C15 AQ4 A 999      15.703   0.494  52.066  1.00102.19           C  
+HETATM 2532  O4  AQ4 A 999      15.108   0.167  53.335  1.00 79.31           O  
+HETATM 2533  C16 AQ4 A 999      13.843  -0.695  53.221  1.00 92.17           C  
+HETATM 2534  C17 AQ4 A 999      19.845  -1.318  53.942  1.00 59.83           C  
+HETATM 2535  C18 AQ4 A 999      21.199  -1.222  54.264  1.00 53.51           C  
+HETATM 2536  N2  AQ4 A 999      21.747  -2.039  55.319  1.00 50.53           N  
+HETATM 2537  C19 AQ4 A 999      23.117  -1.934  55.642  1.00 65.28           C  
+HETATM 2538  N3  AQ4 A 999      23.943  -1.023  54.940  1.00 44.57           N  
+HETATM 2539  C20 AQ4 A 999      26.234   2.292  53.236  1.00 77.38           C  
+HETATM 2540  C21 AQ4 A 999      27.625   2.509  53.279  1.00 70.00           C  
+HETATM 2541  C22 AQ4 A 999      28.508   1.410  53.344  1.00 71.32           C  
+HETATM 2542  O   HOH A   1      32.732  20.638  57.020  1.00 49.98           O  
+HETATM 2543  O   HOH A   2      32.882   9.700  55.317  1.00 47.81           O  
+HETATM 2544  O   HOH A   3      27.504  -1.066  65.946  1.00 58.30           O  
+HETATM 2545  O   HOH A   4      25.698  20.050  48.908  1.00 59.48           O  
+HETATM 2546  O   HOH A   5      23.562  36.184  60.778  1.00 53.83           O  
+HETATM 2547  O   HOH A   6      33.892  18.248  58.731  1.00 38.37           O  
+HETATM 2548  O   HOH A   7      10.334  25.073  74.952  1.00 39.68           O  
+HETATM 2549  O   HOH A   8      27.903  24.827  53.992  1.00 43.63           O  
+HETATM 2550  O   HOH A   9      18.941  -2.491  68.885  1.00 52.41           O  
+HETATM 2551  O   HOH A  10      25.979  -0.494  56.755  1.00 80.23           O  
+HETATM 2552  O   HOH A  11      28.366  -5.361  64.274  1.00 82.86           O  
+HETATM 2553  O   HOH A  12      22.492  -8.282  61.348  1.00 38.44           O  
+HETATM 2554  O   HOH A  13      13.333  18.933  80.447  1.00 54.89           O  
+HETATM 2555  O   HOH A  14      25.457  24.140  55.088  1.00 50.80           O  
+HETATM 2556  O   HOH A  15      18.280  33.231  57.782  1.00 78.01           O  
+HETATM 2557  O   HOH A  16      30.582  -0.221  65.350  1.00 40.66           O  
+HETATM 2558  O   HOH A  17      32.987  24.038  72.100  1.00 63.73           O  
+HETATM 2559  O   HOH A  18       9.251  21.560  60.778  1.00 45.40           O  
+HETATM 2560  O   HOH A  19     -21.187   4.756  70.193  1.00 66.85           O  
+HETATM 2561  O   HOH A  20      18.877  25.444  74.214  1.00 60.04           O  
+CONECT 2513 2514                                                                
+CONECT 2514 2513 2515                                                           
+CONECT 2515 2514 2516 2541                                                      
+CONECT 2516 2515 2517                                                           
+CONECT 2517 2516 2518 2539                                                      
+CONECT 2518 2517 2519                                                           
+CONECT 2519 2518 2520 2538                                                      
+CONECT 2520 2519 2521 2535                                                      
+CONECT 2521 2520 2522                                                           
+CONECT 2522 2521 2523 2528                                                      
+CONECT 2523 2522 2524                                                           
+CONECT 2524 2523 2525                                                           
+CONECT 2525 2524 2526                                                           
+CONECT 2526 2525 2527                                                           
+CONECT 2527 2526                                                                
+CONECT 2528 2522 2529 2534                                                      
+CONECT 2529 2528 2530                                                           
+CONECT 2530 2529 2531                                                           
+CONECT 2531 2530 2532                                                           
+CONECT 2532 2531 2533                                                           
+CONECT 2533 2532                                                                
+CONECT 2534 2528 2535                                                           
+CONECT 2535 2520 2534 2536                                                      
+CONECT 2536 2535 2537                                                           
+CONECT 2537 2536 2538                                                           
+CONECT 2538 2519 2537                                                           
+CONECT 2539 2517 2540                                                           
+CONECT 2540 2539 2541                                                           
+CONECT 2541 2515 2540                                                           
+MASTER      416    0    1   15   11    0    4    6 2546    1   29   26          
+END                                                                             

--- a/nim-skills/molmim-nim/evals/config.yml
+++ b/nim-skills/molmim-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/molmim-nim/evals/evals.json
+++ b/nim-skills/molmim-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "Use the hosted MolMIM NIM to generate 10 analogs from caffeine SMILES CN1C=NC2=C1C(=O)N(C(=O)N2C)C. Optimize for QED with CMA-ES, keep at least moderate seed similarity, and save the generated SMILES.",
-      "expected_output": "A Python script that calls the hosted MolMIM /generate endpoint with Bearer auth from NGC_API_KEY, uses smi not smiles, algorithm CMA-ES, property_name QED, minimize false, min_similarity, iterations, particles, num_molecules, parses hosted molecules/sample responses with generated fallback, and writes molmim_generated.smi.",
+      "prompt": "Use the hosted MolMIM NIM to generate 10 analogs from caffeine SMILES CN1C=NC2=C1C(=O)N(C(=O)N2C)C. Optimize for QED with CMA-ES, keep at least moderate seed similarity, and save the generated SMILES. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted MolMIM /generate request with Bearer auth, smi, CMA-ES, QED maximization, similarity and sampling controls, plus actual returned analogs saved to molmim_generated.smi and reported with response-derived values.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived analogs and the saved .smi path"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted MolMIM generate endpoint",
@@ -38,7 +43,9 @@
           "check": "Script writes generated molecules to '.smi'"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I want unguided MolMIM sampling around ibuprofen SMILES CC(C)Cc1ccc(cc1)C(C)C(=O)O using the hosted API. Use algorithm none, a modest scaled_radius, and make clear that hosted MolMIM is generation-only.",
@@ -78,6 +85,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me run MolMIM locally with Docker and do an embedding smoke test. My environment may have NGC_API_KEY or NVIDIA_API_KEY, but the MolMIM docs mention NGC_CLI_API_KEY. LOCAL_NIM_CACHE is set.",
       "expected_output": "Docker setup commands that source optional .env, map NVIDIA_API_KEY to NGC_API_KEY and NGC_API_KEY to NGC_CLI_API_KEY, docker login to nvcr.io without printing secrets, run nvcr.io/nim/nvidia/molmim:1.0.0 with cache mount /home/nvs/.cache/nim, poll /v1/health/ready, and POST no-auth to localhost:8000/embedding with sequences.",
@@ -116,6 +124,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "4",
       "prompt": "For a locally hosted MolMIM container, show a latent workflow that obtains hidden states for a seed SMILES, decodes them back to SMILES, and optionally samples nearby molecules. Save the intermediate JSON and validate the generated molecules.",
       "expected_output": "A local no-auth Python workflow using /hidden with sequences, saving hiddens and mask, POSTing those to /decode, optionally calling /sampling with scaled_radius and num_molecules, saving generated SMILES, and validating parseability/duplicates with RDKit if installed.",

--- a/nim-skills/msa-search-nim/evals/config.yml
+++ b/nim-skills/msa-search-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/msa-search-nim/evals/evals.json
+++ b/nim-skills/msa-search-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to generate a multiple sequence alignment for my protein sequence using the MSA-Search NIM. My sequence is SGSMKTAISLPDETFDRVSRRASELGMSRSEFFTKAAQR. Search against UniRef30 and ColabFold environmental databases and return the alignment in A3M format. Use the hosted NVIDIA API.",
-      "expected_output": "A Python script that calls the hosted MSA-Search endpoint with Bearer auth, sends the sequence with databases=['Uniref30_2302','colabfold_envdb_202108'] and output_alignment_formats=['a3m'], extracts alignments using the same case-sensitive response keys, and saves the returned A3M alignment to a file.",
+      "prompt": "I want to generate a multiple sequence alignment for my protein sequence using the MSA-Search NIM. My sequence is SGSMKTAISLPDETFDRVSRRASELGMSRSEFFTKAAQR. Search against UniRef30 and ColabFold environmental databases and return the alignment in A3M format using the hosted NVIDIA API. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted MSA-Search request with Bearer auth, case-correct database names, and A3M output format, plus the actual returned alignment saved to a file and summarized from the response.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived alignment information and the saved A3M path"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted MSA-Search endpoint URL",
@@ -38,7 +43,9 @@
           "check": "Script writes alignment content from 'alignments' in the response to a file"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I have a protein complex with two chains and I need paired MSA alignments for it. Chain 1 (hemoglobin alpha): VLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHGKKVADALTNAVA. Chain 2 (hemoglobin beta): MHLTPEEKSAVTALWGKVNVDEVGGEALGRLLVVYPYTQRFFESFGDLSTPDAVMGNPKVKAHGKKVLGAF. Use the hosted API.",
@@ -78,6 +85,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me set up the MSA-Search NIM locally with Docker and then search for MSA for my protein sequence: MTEYKLVVVGACGVGKSALTIQLIQNHFVDE. I have an A100 GPU. My NGC_API_KEY is set.",
       "expected_output": "Docker setup instructions using shell env first and optional repo-root .env overrides, requiring NGC_API_KEY or NVIDIA_API_KEY fallback plus LOCAL_NIM_CACHE, warning about the 1.4 TB database cache, health-checking the service, then sending a no-auth request to localhost:8000 without a /v1/ prefix.",
@@ -116,6 +124,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "4",
       "prompt": "I need structural templates for my protein sequence to use as input to a structure prediction model. Can you search for structural templates using a local MSA-Search NIM? Sequence: VLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHGKKVADALTNAVA. Return up to 20 structures.",
       "expected_output": "A Python script targeting the local /biology/colabfold/msa-search/structure-templates/predict endpoint because the hosted health.api template path returned HTTP 404 in validation, with structural_template_databases=['pdb70_220313'], the sequence, max_structures=20, max_msa_sequences=500 to match NIM_GLOBAL_MAX_MSA_DEPTH, no Authorization header for localhost inference, and parsing/saving both returned mmCIF template structures and search_hits M8 tables.",

--- a/nim-skills/openfold2-nim/evals/config.yml
+++ b/nim-skills/openfold2-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/openfold2-nim/evals/evals.json
+++ b/nim-skills/openfold2-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to predict a monomer protein structure with OpenFold2 using the hosted NVIDIA API. The sequence is MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPT. Use selected model 1, skip relaxation for a quick smoke test, and save any returned structure artifacts.",
-      "expected_output": "A Python script that calls the hosted OpenFold2 predict-structure-from-msa-and-template endpoint with Bearer auth from NGC_API_KEY, sends sequence/input_id/selected_models/relax_prediction, includes a minimal A3M alignment, saves the full JSON response, and saves any PDB or mmCIF structure-like text fields.",
+      "prompt": "I want to predict a monomer protein structure with OpenFold2 using the hosted NVIDIA API. The sequence is MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPT. Use selected model 1, skip relaxation for a quick smoke test, and save any returned structure artifacts. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted OpenFold2 request using Bearer auth from NGC_API_KEY, with sequence/input_id/selected_models/relax_prediction and a minimal A3M alignment, plus the actual response summary, full JSON response, and any returned PDB or mmCIF structure artifacts.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived values and saved artifact paths"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted OpenFold2 endpoint URL",
@@ -38,7 +43,9 @@
           "check": "Script writes JSON response and saves structure text containing 'ATOM' or 'data_' to '.pdb' or '.cif' files"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "Use OpenFold2 hosted API for a monomer with my own MSA and an explicit template. Sequence: ACDEFGHIKLMNPQRSTVWY. I have A3M text and an mmCIF template string in Python variables. Please show the correct payload shape, note any template-format gotchas, and mention that MSA Search is the handoff if I need to generate a deeper A3M alignment.",
@@ -78,6 +85,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me launch the OpenFold2 NIM locally with Docker and then run a no-auth localhost inference. My NGC_API_KEY is set, or NVIDIA_API_KEY may be set instead, and I want to use LOCAL_NIM_CACHE.",
       "expected_output": "Docker setup commands that source optional repo-root .env, support NVIDIA_API_KEY fallback to NGC_API_KEY, require LOCAL_NIM_CACHE, docker login to nvcr.io, run nvcr.io/nim/openfold/openfold2:latest with --gpus device=0 and cache mount /opt/nim/.cache, poll /v1/health/ready, and call localhost:8000/biology/openfold/openfold2/predict-structure-from-msa-and-template with no Authorization.",

--- a/nim-skills/proteinmpnn-nim/evals/config.yml
+++ b/nim-skills/proteinmpnn-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/proteinmpnn-nim/evals/evals.json
+++ b/nim-skills/proteinmpnn-nim/evals/evals.json
@@ -3,10 +3,17 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I have a protein backbone PDB file (1R42.pdb) and I want to design 10 protein sequences that will fold into it using ProteinMPNN. Use the hosted NVIDIA API. My NGC_API_KEY is set.",
-      "expected_output": "A Python script that reads 1R42.pdb, calls the hosted ProteinMPNN endpoint with Bearer auth, sends the PDB content as input_pdb with num_seq_per_target=10, and saves the returned multi-FASTA to a .fa file.",
-      "files": [],
+      "prompt": "Use the staged protein backbone at /workspace/input/1R42.pdb to design 10 protein sequences that will fold into it using the hosted NVIDIA ProteinMPNN API. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted ProteinMPNN request that reads the staged 1R42.pdb, uses Bearer auth and num_seq_per_target=10, plus the actual returned designed sequences and scores saved as a multi-FASTA artifact.",
+      "files": [
+        "evals/files/1R42.pdb"
+      ],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived designed sequences, scores, and the saved FASTA path"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted ProteinMPNN endpoint URL",
@@ -38,7 +45,9 @@
           "check": "Script accounts for the native/WT FASTA row when present and pairs scores with designed sequences, not the WT row"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I want to redesign chain A of my protein structure (structure.pdb) while keeping chain B fixed. Generate 5 sequences at sampling temperature 0.2, excluding cysteines. Use the hosted ProteinMPNN API.",
@@ -78,6 +87,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "3",
       "prompt": "Help me set up ProteinMPNN locally with Docker and design sequences for my structure file backbone.pdb. I have an RTX A6000 GPU. My NGC_API_KEY is set.",
       "expected_output": "Docker setup commands using shell env first and optional repo-root .env overrides, requiring NGC_API_KEY or NVIDIA_API_KEY fallback plus LOCAL_NIM_CACHE, using the correct image tag, single GPU flag, and the unique cache mount path /home/nvs/.cache/nim (not /opt/nim/.cache), then a health check and no-auth request script to localhost:8000.",

--- a/nim-skills/proteinmpnn-nim/evals/files/1R42.pdb
+++ b/nim-skills/proteinmpnn-nim/evals/files/1R42.pdb
@@ -1,0 +1,6231 @@
+HEADER    HYDROLASE                               07-OCT-03   1R42              
+TITLE     NATIVE HUMAN ANGIOTENSIN CONVERTING ENZYME-RELATED CARBOXYPEPTIDASE   
+TITLE    2 (ACE2)                                                               
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: ANGIOTENSIN I CONVERTING ENZYME 2;                         
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: EXTRACELLULAR DOMAINS;                                     
+COMPND   5 SYNONYM: ANGIOTENSIN CONVERTING ENZYME-LIKE PROTEIN, ANGIOTENSIN     
+COMPND   6 CONVERTING ENZYME-RELATED CARBOXYPEPTIDASE;                          
+COMPND   7 ENGINEERED: YES;                                                     
+COMPND   8 MOL_ID: 2;                                                           
+COMPND   9 MOLECULE: DISORDERED SEGMENT OF COLLECTRIN HOMOLOGY DOMAIN;          
+COMPND  10 CHAIN: B;                                                            
+COMPND  11 ENGINEERED: YES;                                                     
+COMPND  12 MOL_ID: 3;                                                           
+COMPND  13 MOLECULE: DISORDERED SEGMENT OF COLLECTRIN HOMOLOGY DOMAIN;          
+COMPND  14 CHAIN: C;                                                            
+COMPND  15 ENGINEERED: YES;                                                     
+COMPND  16 MOL_ID: 4;                                                           
+COMPND  17 MOLECULE: DISORDERED SEGMENT OF COLLECTRIN HOMOLOGY DOMAIN;          
+COMPND  18 CHAIN: D;                                                            
+COMPND  19 ENGINEERED: YES;                                                     
+COMPND  20 MOL_ID: 5;                                                           
+COMPND  21 MOLECULE: DISORDERED SEGMENT OF COLLECTRIN HOMOLOGY DOMAIN;          
+COMPND  22 CHAIN: E;                                                            
+COMPND  23 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: ACE2;                                                          
+SOURCE   6 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE   7 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE   8 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE   9 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  10 EXPRESSION_SYSTEM_VECTOR_TYPE: BACULOVIRUS;                          
+SOURCE  11 EXPRESSION_SYSTEM_VECTOR: PBAC PAK9;                                 
+SOURCE  12 MOL_ID: 2;                                                           
+SOURCE  13 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  14 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  15 ORGANISM_TAXID: 9606;                                                
+SOURCE  16 GENE: ACE2;                                                          
+SOURCE  17 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE  18 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE  19 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE  20 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  21 EXPRESSION_SYSTEM_VECTOR_TYPE: BACULOVIRUS;                          
+SOURCE  22 EXPRESSION_SYSTEM_VECTOR: PBAC PAK9;                                 
+SOURCE  23 MOL_ID: 3;                                                           
+SOURCE  24 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  25 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  26 ORGANISM_TAXID: 9606;                                                
+SOURCE  27 GENE: ACE2;                                                          
+SOURCE  28 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE  29 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE  30 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE  31 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  32 EXPRESSION_SYSTEM_VECTOR_TYPE: BACULOVIRUS;                          
+SOURCE  33 EXPRESSION_SYSTEM_VECTOR: PBAC PAK9;                                 
+SOURCE  34 MOL_ID: 4;                                                           
+SOURCE  35 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  36 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  37 ORGANISM_TAXID: 9606;                                                
+SOURCE  38 GENE: ACE2;                                                          
+SOURCE  39 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE  40 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE  41 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE  42 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  43 EXPRESSION_SYSTEM_VECTOR_TYPE: BACULOVIRUS;                          
+SOURCE  44 EXPRESSION_SYSTEM_VECTOR: PBAC PAK9;                                 
+SOURCE  45 MOL_ID: 5;                                                           
+SOURCE  46 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  47 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  48 ORGANISM_TAXID: 9606;                                                
+SOURCE  49 GENE: ACE2;                                                          
+SOURCE  50 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE  51 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE  52 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE  53 EXPRESSION_SYSTEM_CELL_LINE: SF9;                                    
+SOURCE  54 EXPRESSION_SYSTEM_VECTOR_TYPE: BACULOVIRUS;                          
+SOURCE  55 EXPRESSION_SYSTEM_VECTOR: PBAC PAK9                                  
+KEYWDS    ZINC METALLOPEPTIDASE DOMAIN, COLLECTRIN HOMOLOGY DOMAIN, NATIVE OR   
+KEYWDS   2 OPEN CONFORMATION, CHLORIDE ION BINDING SITE, ZINC BINDING SITE,     
+KEYWDS   3 HYDROLASE                                                            
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    P.TOWLER,B.STAKER,S.G.PRASAD,S.MENON,D.RYAN,J.TANG,T.PARSONS,         
+AUTHOR   2 M.FISHER,D.WILLIAMS,N.A.DALES,M.A.PATANE,M.W.PANTOLIANO              
+REVDAT   7   16-OCT-24 1R42    1       HETSYN                                   
+REVDAT   6   29-JUL-20 1R42    1       COMPND REMARK HETNAM LINK                
+REVDAT   6 2                   1       SITE                                     
+REVDAT   5   24-JAN-18 1R42    1       JRNL                                     
+REVDAT   4   13-JUL-11 1R42    1       VERSN                                    
+REVDAT   3   24-FEB-09 1R42    1       VERSN                                    
+REVDAT   2   27-APR-04 1R42    1       JRNL                                     
+REVDAT   1   03-FEB-04 1R42    0                                                
+JRNL        AUTH   P.TOWLER,B.STAKER,S.G.PRASAD,S.MENON,J.TANG,T.PARSONS,       
+JRNL        AUTH 2 D.RYAN,M.FISHER,D.WILLIAMS,N.A.DALES,M.A.PATANE,             
+JRNL        AUTH 3 M.W.PANTOLIANO                                               
+JRNL        TITL   ACE2 X-RAY STRUCTURES REVEAL A LARGE HINGE-BENDING MOTION    
+JRNL        TITL 2 IMPORTANT FOR INHIBITOR BINDING AND CATALYSIS.               
+JRNL        REF    J.BIOL.CHEM.                  V. 279 17996 2004              
+JRNL        REFN                   ISSN 0021-9258                               
+JRNL        PMID   14754895                                                     
+JRNL        DOI    10.1074/JBC.M311191200                                       
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   N.A DALES,A.E.GOULD,J.A.BROWN,E.F.CALDERWOOD,B.GUAN,         
+REMARK   1  AUTH 2 C.A.MINOR,J.M.GAVIN,P.HALES,V.K.KAUSHIK,M.STEWART,           
+REMARK   1  AUTH 3 P.J.TUMMINO,C.S.VICKERS,T.D.OCAIN,M.A.PANTANE                
+REMARK   1  TITL   SUBSTRATE-BASED DESIGN OF THE FIRST CLASS OF                 
+REMARK   1  TITL 2 ANGIOTENSIN-CONVERTING ENZYME-RELATED CARBOXYPEPTIDASE       
+REMARK   1  TITL 3 (ACE2) INHIBITORS                                            
+REMARK   1  REF    J.AM.CHEM.SOC.                V. 124 11852 2002              
+REMARK   1  REFN                   ISSN 0002-7863                               
+REMARK   1  DOI    10.1021/JA0277226                                            
+REMARK   1 REFERENCE 2                                                          
+REMARK   1  AUTH   C.VICKERS,P.HALES,V.KAUSHIK,L.DICK,J.GAVIN,J.TANG,K.GODBOUT, 
+REMARK   1  AUTH 2 T.PARSONS,E.BARONAS,F.HSIEH,S.ACTON,M.PATANE,A.NICHOLS,      
+REMARK   1  AUTH 3 P.TUMMINO                                                    
+REMARK   1  TITL   HYDROLYSIS OF BIOLOGICAL PEPTIDES BY HUMAN                   
+REMARK   1  TITL 2 ANGIOTENSIN-CONVERTING ENZYME-RELATED CARBOXYPEPTIDASE       
+REMARK   1  REF    J.BIOL.CHEM.                  V. 277 14838 2002              
+REMARK   1  REFN                   ISSN 0021-9258                               
+REMARK   1  DOI    10.1074/JBC.M200581200                                       
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.20 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : CNX 2002                                             
+REMARK   3   AUTHORS     : BRUNGER,ADAMS,CLORE,DELANO,GROS,GROSSE-              
+REMARK   3               : KUNSTLEVE,JIANG,KUSZEWSKI,NILGES,PANNU,              
+REMARK   3               : READ,RICE,SIMONSON,WARREN,ACCELRYS                   
+REMARK   3               : SOFTWARE INC.(BADGER,BERARD,KUMAR,SZALMA,            
+REMARK   3               : YIP,DZAKULA)                                         
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.20                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 46.74                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : 2383730.950                    
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : 0.0000                         
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 96.3                           
+REMARK   3   NUMBER OF REFLECTIONS             : 47465                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.235                           
+REMARK   3   R VALUE            (WORKING SET) : 0.235                           
+REMARK   3   FREE R VALUE                     : 0.287                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 10.100                          
+REMARK   3   FREE R VALUE TEST SET COUNT      : 4798                            
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : 0.004                           
+REMARK   3                                                                      
+REMARK   3  FIT/AGREEMENT OF MODEL WITH ALL DATA.                               
+REMARK   3   R VALUE     (WORKING + TEST SET, NO CUTOFF) : NULL                 
+REMARK   3   R VALUE            (WORKING SET, NO CUTOFF) : NULL                 
+REMARK   3   FREE R VALUE                    (NO CUTOFF) : NULL                 
+REMARK   3   FREE R VALUE TEST SET SIZE   (%, NO CUTOFF) : NULL                 
+REMARK   3   FREE R VALUE TEST SET COUNT     (NO CUTOFF) : NULL                 
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE (NO CUTOFF) : NULL                 
+REMARK   3   TOTAL NUMBER OF REFLECTIONS     (NO CUTOFF) : NULL                 
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 6                            
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.20                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 2.34                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 81.80                        
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 5982                         
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.3790                       
+REMARK   3   BIN FREE R VALUE                    : 0.3980                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : 9.90                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : 659                          
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : 0.015                        
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 5165                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 44                                      
+REMARK   3   SOLVENT ATOMS            : 302                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 52.80                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 59.90                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : -6.61000                                             
+REMARK   3    B22 (A**2) : 6.46000                                              
+REMARK   3    B33 (A**2) : 0.14000                                              
+REMARK   3    B12 (A**2) : 0.00000                                              
+REMARK   3    B13 (A**2) : 11.31000                                             
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.33                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.40                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : 5.00                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.41                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.43                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.008                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.400                           
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : 21.70                           
+REMARK   3   IMPROPER ANGLES        (DEGREES) : 0.920                           
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : RESTRAINED                                
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : 2.040 ; 1.500                
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : 3.090 ; 2.000                
+REMARK   3   SIDE-CHAIN BOND              (A**2) : 3.300 ; 2.000                
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : 4.420 ; 2.500                
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : FLAT MODEL                                           
+REMARK   3   KSOL        : 0.34                                                 
+REMARK   3   BSOL        : 64.55                                                
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : PROTEIN_REP.PARAM                              
+REMARK   3  PARAMETER FILE  2  : DNA-RNA_REP.PARAM                              
+REMARK   3  PARAMETER FILE  3  : WATER_REP.PARAM                                
+REMARK   3  PARAMETER FILE  4  : ION.PARAM                                      
+REMARK   3  PARAMETER FILE  5  : CARBOHYDRATE.PARAM                             
+REMARK   3  PARAMETER FILE  6  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : PROTEIN.TOP                                    
+REMARK   3  TOPOLOGY FILE  2   : CARBOHYDRATE.TOP                               
+REMARK   3  TOPOLOGY FILE  3   : WATER.TOP                                      
+REMARK   3  TOPOLOGY FILE  4   : ION.TOP                                        
+REMARK   3  TOPOLOGY FILE  5   : NULL                                           
+REMARK   3  TOPOLOGY FILE  6   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1R42 COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 07-OCT-03.                  
+REMARK 100 THE DEPOSITION ID IS D_1000020410.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 21-JUN-01                          
+REMARK 200  TEMPERATURE           (KELVIN) : 140                                
+REMARK 200  PH                             : 8.5                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : NSLS                               
+REMARK 200  BEAMLINE                       : X25                                
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.28                               
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : AREA DETECTOR                      
+REMARK 200  DETECTOR MANUFACTURER          : NULL                               
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO                              
+REMARK 200  DATA SCALING SOFTWARE          : SCALEPACK                          
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 49286                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.200                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 40.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 0.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 96.3                               
+REMARK 200  DATA REDUNDANCY                : 15.90                              
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : 0.05700                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 21.4000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : NULL                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : NULL                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MIR                          
+REMARK 200 SOFTWARE USED: MLPHARE                                               
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 53.00                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 3.24                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 100 MM TRIS-HCL, 200 MM MGCL2, 14% PEG   
+REMARK 280  8000, PH 8.5, VAPOR DIFFUSION, HANGING DROP, TEMPERATURE 291K       
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: C 1 2 1                          
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y,-Z                                                 
+REMARK 290       3555   X+1/2,Y+1/2,Z                                           
+REMARK 290       4555   -X+1/2,Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   3  1.000000  0.000000  0.000000       51.81900            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       44.73900            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   4 -1.000000  0.000000  0.000000       51.81900            
+REMARK 290   SMTRY2   4  0.000000  1.000000  0.000000       44.73900            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: PENTAMERIC                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, C, D, E                         
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     MET A     1                                                      
+REMARK 465     SER A     2                                                      
+REMARK 465     SER A     3                                                      
+REMARK 465     SER A     4                                                      
+REMARK 465     SER A     5                                                      
+REMARK 465     TRP A     6                                                      
+REMARK 465     LEU A     7                                                      
+REMARK 465     LEU A     8                                                      
+REMARK 465     LEU A     9                                                      
+REMARK 465     SER A    10                                                      
+REMARK 465     LEU A    11                                                      
+REMARK 465     VAL A    12                                                      
+REMARK 465     ALA A    13                                                      
+REMARK 465     VAL A    14                                                      
+REMARK 465     THR A    15                                                      
+REMARK 465     ALA A    16                                                      
+REMARK 465     ALA A    17                                                      
+REMARK 465     GLN A    18                                                      
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   O    GLY A   605     O    HOH A   915              2.19            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS                                             
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS THAT ARE RELATED BY CRYSTALLOGRAPHIC             
+REMARK 500 SYMMETRY ARE IN CLOSE CONTACT.  AN ATOM LOCATED WITHIN 0.15          
+REMARK 500 ANGSTROMS OF A SYMMETRY RELATED ATOM IS ASSUMED TO BE ON A           
+REMARK 500 SPECIAL POSITION AND IS, THEREFORE, LISTED IN REMARK 375             
+REMARK 500 INSTEAD OF REMARK 500.  ATOMS WITH NON-BLANK ALTERNATE               
+REMARK 500 LOCATION INDICATORS ARE NOT INCLUDED IN THE CALCULATIONS.            
+REMARK 500                                                                      
+REMARK 500 DISTANCE CUTOFF:                                                     
+REMARK 500 2.2 ANGSTROMS FOR CONTACTS NOT INVOLVING HYDROGEN ATOMS              
+REMARK 500 1.6 ANGSTROMS FOR CONTACTS INVOLVING HYDROGEN ATOMS                  
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI  SSYMOP   DISTANCE          
+REMARK 500   OE1  GLN A    89     OE1  GLN A    89     2756     2.15            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    LEU A 456   CA  -  CB  -  CG  ANGL. DEV. =  15.3 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ILE A  21       36.02    -66.62                                   
+REMARK 500    GLU A  22      -49.48   -134.41                                   
+REMARK 500    MET A  82      -35.67    -38.35                                   
+REMARK 500    GLU A  87        3.92    -69.15                                   
+REMARK 500    ASN A  90       91.77    -57.37                                   
+REMARK 500    GLN A 101       40.27    -82.78                                   
+REMARK 500    ASN A 137       89.44   -166.42                                   
+REMARK 500    HIS A 195       37.14     74.12                                   
+REMARK 500    THR A 294        3.36    -61.74                                   
+REMARK 500    LYS A 353       49.36     38.53                                   
+REMARK 500    ASN A 546      -13.39     79.81                                   
+REMARK 500    UNK B 905     -129.45    -86.72                                   
+REMARK 500    UNK C 908      114.29   -175.16                                   
+REMARK 500    UNK C 913     -118.67   -114.93                                   
+REMARK 500    UNK C 914       17.26   -179.41                                   
+REMARK 500    UNK C 915       34.24     71.09                                   
+REMARK 500    UNK C 916       63.48   -172.12                                   
+REMARK 500    UNK C 917       -7.98    -17.99                                   
+REMARK 500    UNK C 919     -163.14    168.17                                   
+REMARK 500    UNK C 920      111.81    178.64                                   
+REMARK 500    UNK C 921      130.01    -18.13                                   
+REMARK 500    UNK C 922     -149.93    -79.68                                   
+REMARK 500    UNK C 923      -94.86     52.86                                   
+REMARK 500    UNK C 924       60.70     20.39                                   
+REMARK 500    UNK E 946      105.00    -54.13                                   
+REMARK 500    UNK E 948      172.40    -53.82                                   
+REMARK 500    UNK E 957     -139.85     55.40                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN A 804  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 HIS A 374   NE2                                                    
+REMARK 620 2 HIS A 378   NE2  93.0                                              
+REMARK 620 3 GLU A 402   OE2  93.0 113.1                                        
+REMARK 620 4 GLU A 402   OE1 151.6  90.3  60.0                                  
+REMARK 620 5 HOH A 823   O   118.5  96.8 135.5  89.1                            
+REMARK 620 N                    1     2     3     4                             
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 1R4L   RELATED DB: PDB                                   
+REMARK 900 INHIBITOR BOUND HUMAN ANGIOTENSIN CONVERTING ENZYME-RELATED          
+REMARK 900 CARBOXYPEPTIDASE (ACE2)                                              
+REMARK 999                                                                      
+REMARK 999 SEQUENCE                                                             
+REMARK 999 THE COMPLETE SEQUENCE CRYSTALLIZED BY THE AUTHORS                    
+REMARK 999 (RESIDUES 1-740 OF REFERENCE SEQUENCE GB 11225609)                   
+REMARK 999 IS AS FOLLOWS:                                                       
+REMARK 999 MSSSSWLLLSLVAVTAAQSTIEEQAKTFLDKFNHEAEDLFYQSSLASWNY                   
+REMARK 999 NTNITEENVQNMNNAGDKWSAFLKEQSTLAQMYPLQEIQNLTVKLQLQALQ                  
+REMARK 999 QNGSSVLSEDKSKRLNTILNTMSTIYSTGKVCNPDNPQECLLLEPGLNEIM                  
+REMARK 999 ANSLDYNERLWAWESWRSEVGKQLRPLYEEYVVLKNEMARANHYEDYGDYW                  
+REMARK 999 RGDYEVNGVDGYDYSRGQLIEDVEHTFEEIKPLYEHLHAYVRAKLMNAYPS                  
+REMARK 999 YISPIGCLPAHLLGDMWGRFWTNLYSLTVPFGQKPNIDVTDAMVDQAWDAQ                  
+REMARK 999 RIFKEAEKFFVSVGLPNMTQGFWENSMLTDPGNVQKAVCHPTAWDLGKGDF                  
+REMARK 999 RILMCTKVTMDDFLTAHHEMGHIQYDMAYAAQPFLLRNGANEGFHEAVGEI                  
+REMARK 999 MSLSAATPKHLKSIGLLSPDFQEDNETEINFLLKQALTIVGTLPFTYMLEK                  
+REMARK 999 WRWMVFKGEIPKDQWMKKWWEMKREIVGVVEPVPHDETYCDPASLFHVSND                  
+REMARK 999 YSFIRYYTRTLYQFQFQEALCQAAKHEGPLHKCDISNSTEAGQKLFNMLRL                  
+REMARK 999 GKSEPWTLALENVVGAKNMNVRPLLNYFEPLFTWLKDQNKNSFVGWSTDWS                  
+REMARK 999 PYADQSIKVRISLKSALGDKAYEWNDNEMYLFRSSVAYAMRQYFLKVKNQ                   
+REMARK 999 MILFGEEDVRVANLKPRISFNFFVTAPKNVSDIIPRTEVEKAIRMSRSRIN                  
+REMARK 999 DAFRLNDNSLEFLGIQPTLGPPNQPPVS                                         
+REMARK 999 THE ELECTRON DENSITY MAP FOR MUCH OF THE COLLECTRIN                  
+REMARK 999 HOMOLOGY DOMAIN (RESIDUES 616-740) IS WEAK.  ONLY                    
+REMARK 999 ABOUT HALF OF THIS DOMAIN WAS VISIBLE IN THE ELECTRON                
+REMARK 999 DENSITY MAP, AND WHAT CAN BE SEEN IS AMBIGUOUS DUE TO                
+REMARK 999 TOPOLOGY AND CONNECTIVITY ISSUES.  FOR THIS REASON,                  
+REMARK 999 RESIDUES BEGINNING AT 901 ARE LABELED AS UNKNOWN (UNK).              
+REMARK 999 EACH FRAGMENT OF UNKNOWN RESIDUES HAS BEEN ASSIGNED                  
+REMARK 999 A UNIQUE CHAIN ID. HOWEVER, IT SHOULD BE UNDERSTOOD                  
+REMARK 999 THAT ONLY ONE SEQUENCE (RESIDUES 1-740) WAS CRYSTALLIZED.            
+DBREF  1R42 A    1   615  GB     11225609 NP_068576        1    615             
+DBREF  1R42 B  901   906  PDB    1R42     1R42           901    906             
+DBREF  1R42 C  907   926  PDB    1R42     1R42           907    926             
+DBREF  1R42 D  927   944  PDB    1R42     1R42           927    944             
+DBREF  1R42 E  945   958  PDB    1R42     1R42           945    958             
+SEQRES   1 A  615  MET SER SER SER SER TRP LEU LEU LEU SER LEU VAL ALA          
+SEQRES   2 A  615  VAL THR ALA ALA GLN SER THR ILE GLU GLU GLN ALA LYS          
+SEQRES   3 A  615  THR PHE LEU ASP LYS PHE ASN HIS GLU ALA GLU ASP LEU          
+SEQRES   4 A  615  PHE TYR GLN SER SER LEU ALA SER TRP ASN TYR ASN THR          
+SEQRES   5 A  615  ASN ILE THR GLU GLU ASN VAL GLN ASN MET ASN ASN ALA          
+SEQRES   6 A  615  GLY ASP LYS TRP SER ALA PHE LEU LYS GLU GLN SER THR          
+SEQRES   7 A  615  LEU ALA GLN MET TYR PRO LEU GLN GLU ILE GLN ASN LEU          
+SEQRES   8 A  615  THR VAL LYS LEU GLN LEU GLN ALA LEU GLN GLN ASN GLY          
+SEQRES   9 A  615  SER SER VAL LEU SER GLU ASP LYS SER LYS ARG LEU ASN          
+SEQRES  10 A  615  THR ILE LEU ASN THR MET SER THR ILE TYR SER THR GLY          
+SEQRES  11 A  615  LYS VAL CYS ASN PRO ASP ASN PRO GLN GLU CYS LEU LEU          
+SEQRES  12 A  615  LEU GLU PRO GLY LEU ASN GLU ILE MET ALA ASN SER LEU          
+SEQRES  13 A  615  ASP TYR ASN GLU ARG LEU TRP ALA TRP GLU SER TRP ARG          
+SEQRES  14 A  615  SER GLU VAL GLY LYS GLN LEU ARG PRO LEU TYR GLU GLU          
+SEQRES  15 A  615  TYR VAL VAL LEU LYS ASN GLU MET ALA ARG ALA ASN HIS          
+SEQRES  16 A  615  TYR GLU ASP TYR GLY ASP TYR TRP ARG GLY ASP TYR GLU          
+SEQRES  17 A  615  VAL ASN GLY VAL ASP GLY TYR ASP TYR SER ARG GLY GLN          
+SEQRES  18 A  615  LEU ILE GLU ASP VAL GLU HIS THR PHE GLU GLU ILE LYS          
+SEQRES  19 A  615  PRO LEU TYR GLU HIS LEU HIS ALA TYR VAL ARG ALA LYS          
+SEQRES  20 A  615  LEU MET ASN ALA TYR PRO SER TYR ILE SER PRO ILE GLY          
+SEQRES  21 A  615  CYS LEU PRO ALA HIS LEU LEU GLY ASP MET TRP GLY ARG          
+SEQRES  22 A  615  PHE TRP THR ASN LEU TYR SER LEU THR VAL PRO PHE GLY          
+SEQRES  23 A  615  GLN LYS PRO ASN ILE ASP VAL THR ASP ALA MET VAL ASP          
+SEQRES  24 A  615  GLN ALA TRP ASP ALA GLN ARG ILE PHE LYS GLU ALA GLU          
+SEQRES  25 A  615  LYS PHE PHE VAL SER VAL GLY LEU PRO ASN MET THR GLN          
+SEQRES  26 A  615  GLY PHE TRP GLU ASN SER MET LEU THR ASP PRO GLY ASN          
+SEQRES  27 A  615  VAL GLN LYS ALA VAL CYS HIS PRO THR ALA TRP ASP LEU          
+SEQRES  28 A  615  GLY LYS GLY ASP PHE ARG ILE LEU MET CYS THR LYS VAL          
+SEQRES  29 A  615  THR MET ASP ASP PHE LEU THR ALA HIS HIS GLU MET GLY          
+SEQRES  30 A  615  HIS ILE GLN TYR ASP MET ALA TYR ALA ALA GLN PRO PHE          
+SEQRES  31 A  615  LEU LEU ARG ASN GLY ALA ASN GLU GLY PHE HIS GLU ALA          
+SEQRES  32 A  615  VAL GLY GLU ILE MET SER LEU SER ALA ALA THR PRO LYS          
+SEQRES  33 A  615  HIS LEU LYS SER ILE GLY LEU LEU SER PRO ASP PHE GLN          
+SEQRES  34 A  615  GLU ASP ASN GLU THR GLU ILE ASN PHE LEU LEU LYS GLN          
+SEQRES  35 A  615  ALA LEU THR ILE VAL GLY THR LEU PRO PHE THR TYR MET          
+SEQRES  36 A  615  LEU GLU LYS TRP ARG TRP MET VAL PHE LYS GLY GLU ILE          
+SEQRES  37 A  615  PRO LYS ASP GLN TRP MET LYS LYS TRP TRP GLU MET LYS          
+SEQRES  38 A  615  ARG GLU ILE VAL GLY VAL VAL GLU PRO VAL PRO HIS ASP          
+SEQRES  39 A  615  GLU THR TYR CYS ASP PRO ALA SER LEU PHE HIS VAL SER          
+SEQRES  40 A  615  ASN ASP TYR SER PHE ILE ARG TYR TYR THR ARG THR LEU          
+SEQRES  41 A  615  TYR GLN PHE GLN PHE GLN GLU ALA LEU CYS GLN ALA ALA          
+SEQRES  42 A  615  LYS HIS GLU GLY PRO LEU HIS LYS CYS ASP ILE SER ASN          
+SEQRES  43 A  615  SER THR GLU ALA GLY GLN LYS LEU PHE ASN MET LEU ARG          
+SEQRES  44 A  615  LEU GLY LYS SER GLU PRO TRP THR LEU ALA LEU GLU ASN          
+SEQRES  45 A  615  VAL VAL GLY ALA LYS ASN MET ASN VAL ARG PRO LEU LEU          
+SEQRES  46 A  615  ASN TYR PHE GLU PRO LEU PHE THR TRP LEU LYS ASP GLN          
+SEQRES  47 A  615  ASN LYS ASN SER PHE VAL GLY TRP SER THR ASP TRP SER          
+SEQRES  48 A  615  PRO TYR ALA ASP                                              
+SEQRES   1 B    6  UNK UNK UNK UNK UNK UNK                                      
+SEQRES   1 C   20  UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK          
+SEQRES   2 C   20  UNK UNK UNK UNK UNK UNK UNK                                  
+SEQRES   1 D   18  UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK          
+SEQRES   2 D   18  UNK UNK UNK UNK UNK                                          
+SEQRES   1 E   14  UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK UNK          
+SEQRES   2 E   14  UNK                                                          
+MODRES 1R42 ASN A   90  ASN  GLYCOSYLATION SITE                                 
+MODRES 1R42 ASN A  103  ASN  GLYCOSYLATION SITE                                 
+MODRES 1R42 ASN A  546  ASN  GLYCOSYLATION SITE                                 
+HET    NAG  A 800      14                                                       
+HET    NAG  A 801      14                                                       
+HET    NAG  A 802      14                                                       
+HET     CL  A 803       1                                                       
+HET     ZN  A 804       1                                                       
+HETNAM     NAG 2-ACETAMIDO-2-DEOXY-BETA-D-GLUCOPYRANOSE                         
+HETNAM      CL CHLORIDE ION                                                     
+HETNAM      ZN ZINC ION                                                         
+HETSYN     NAG N-ACETYL-BETA-D-GLUCOSAMINE; 2-ACETAMIDO-2-DEOXY-BETA-           
+HETSYN   2 NAG  D-GLUCOSE; 2-ACETAMIDO-2-DEOXY-D-GLUCOSE; 2-ACETAMIDO-          
+HETSYN   3 NAG  2-DEOXY-GLUCOSE; N-ACETYL-D-GLUCOSAMINE                         
+FORMUL   6  NAG    3(C8 H15 N O6)                                               
+FORMUL   9   CL    CL 1-                                                        
+FORMUL  10   ZN    ZN 2+                                                        
+FORMUL  11  HOH   *302(H2 O)                                                    
+HELIX    1   1 GLU A   22  ASN A   53  1                                  32    
+HELIX    2   2 THR A   55  THR A   78  1                                  24    
+HELIX    3   3 ASN A   90  GLN A  101  1                                  12    
+HELIX    4   4 ASN A  103  LEU A  108  5                                   6    
+HELIX    5   5 SER A  109  GLY A  130  1                                  22    
+HELIX    6   6 GLY A  147  SER A  155  1                                   9    
+HELIX    7   7 ASP A  157  VAL A  172  1                                  16    
+HELIX    8   8 VAL A  172  ASN A  194  1                                  23    
+HELIX    9   9 ASP A  198  GLY A  205  1                                   8    
+HELIX   10  10 ARG A  219  TYR A  252  1                                  34    
+HELIX   11  11 HIS A  265  LEU A  267  5                                   3    
+HELIX   12  12 TRP A  275  ASN A  277  5                                   3    
+HELIX   13  13 LEU A  278  VAL A  283  1                                   6    
+HELIX   14  14 MET A  297  ALA A  301  5                                   5    
+HELIX   15  15 ASP A  303  SER A  317  1                                  15    
+HELIX   16  16 GLY A  326  SER A  331  1                                   6    
+HELIX   17  17 THR A  365  TYR A  385  1                                  21    
+HELIX   18  18 PRO A  389  ARG A  393  5                                   5    
+HELIX   19  19 GLY A  399  THR A  414  1                                  16    
+HELIX   20  20 THR A  414  ILE A  421  1                                   8    
+HELIX   21  21 ASP A  431  VAL A  447  1                                  17    
+HELIX   22  22 GLY A  448  GLY A  466  1                                  19    
+HELIX   23  23 PRO A  469  ASP A  471  5                                   3    
+HELIX   24  24 GLN A  472  ILE A  484  1                                  13    
+HELIX   25  25 CYS A  498  SER A  502  5                                   5    
+HELIX   26  26 LEU A  503  ASN A  508  1                                   6    
+HELIX   27  27 ILE A  513  ALA A  532  1                                  20    
+HELIX   28  28 PRO A  538  CYS A  542  5                                   5    
+HELIX   29  29 SER A  547  ARG A  559  1                                  13    
+HELIX   30  30 PRO A  565  GLY A  575  1                                  11    
+HELIX   31  31 VAL A  581  ASN A  599  1                                  19    
+HELIX   32  32 UNK D  927  UNK D  943  1                                  17    
+HELIX   33  33 UNK E  949  UNK E  951  5                                   3    
+SHEET    1   A 2 LYS A 131  ASN A 134  0                                        
+SHEET    2   A 2 ASN A 137  LEU A 143 -1  O  LEU A 142   N  VAL A 132           
+SHEET    1   B 2 LEU A 262  PRO A 263  0                                        
+SHEET    2   B 2 VAL A 487  VAL A 488  1  O  VAL A 488   N  LEU A 262           
+SHEET    1   C 2 THR A 347  GLY A 352  0                                        
+SHEET    2   C 2 ASP A 355  LEU A 359 -1  O  ARG A 357   N  TRP A 349           
+SHEET    1   D 2 UNK C 909  UNK C 912  0                                        
+SHEET    2   D 2 UNK E 953  UNK E 956 -1  O  UNK E 956   N  UNK C 909           
+SSBOND   1 CYS A  133    CYS A  141                          1555   1555  2.04  
+SSBOND   2 CYS A  344    CYS A  361                          1555   1555  2.03  
+SSBOND   3 CYS A  530    CYS A  542                          1555   1555  2.03  
+LINK         ND2 ASN A  90                 C1  NAG A 800     1555   1555  1.45  
+LINK         ND2 ASN A 103                 C1  NAG A 801     1555   1555  1.45  
+LINK         ND2 ASN A 546                 C1  NAG A 802     1555   1555  1.45  
+LINK         NE2 HIS A 374                ZN    ZN A 804     1555   1555  1.97  
+LINK         NE2 HIS A 378                ZN    ZN A 804     1555   1555  2.26  
+LINK         OE2 GLU A 402                ZN    ZN A 804     1555   1555  2.23  
+LINK         OE1 GLU A 402                ZN    ZN A 804     1555   1555  2.14  
+LINK        ZN    ZN A 804                 O   HOH A 823     1555   1555  2.46  
+CISPEP   1 GLU A  145    PRO A  146          0        -0.21                     
+CRYST1  103.638   89.478  112.399  90.00 109.15  90.00 C 1 2 1       4          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.009649  0.000000  0.003351        0.00000                         
+SCALE2      0.000000  0.011176  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.009418        0.00000                         
+ATOM      1  N   SER A  19      96.155  70.201  45.493  1.00100.66           N  
+ATOM      2  CA  SER A  19      94.696  70.434  45.702  1.00101.02           C  
+ATOM      3  C   SER A  19      93.987  69.087  45.880  1.00100.43           C  
+ATOM      4  O   SER A  19      94.494  68.054  45.439  1.00 99.56           O  
+ATOM      5  CB  SER A  19      94.116  71.194  44.499  1.00102.01           C  
+ATOM      6  OG  SER A  19      92.778  71.609  44.730  1.00102.75           O  
+ATOM      7  N   THR A  20      92.825  69.102  46.535  1.00100.27           N  
+ATOM      8  CA  THR A  20      92.051  67.879  46.776  1.00 99.38           C  
+ATOM      9  C   THR A  20      91.073  67.584  45.641  1.00 98.31           C  
+ATOM     10  O   THR A  20      90.444  68.499  45.100  1.00 98.40           O  
+ATOM     11  CB  THR A  20      91.236  67.973  48.092  1.00 98.99           C  
+ATOM     12  OG1 THR A  20      92.126  68.161  49.199  1.00100.97           O  
+ATOM     13  CG2 THR A  20      90.435  66.697  48.320  1.00 98.68           C  
+ATOM     14  N   ILE A  21      90.946  66.305  45.289  1.00 97.23           N  
+ATOM     15  CA  ILE A  21      90.028  65.874  44.232  1.00 96.91           C  
+ATOM     16  C   ILE A  21      88.577  66.107  44.659  1.00 95.29           C  
+ATOM     17  O   ILE A  21      87.687  65.320  44.350  1.00 95.10           O  
+ATOM     18  CB  ILE A  21      90.209  64.370  43.890  1.00 97.49           C  
+ATOM     19  CG1 ILE A  21      89.957  63.500  45.130  1.00 98.25           C  
+ATOM     20  CG2 ILE A  21      91.599  64.132  43.332  1.00 96.62           C  
+ATOM     21  CD1 ILE A  21      90.970  63.669  46.256  1.00 98.93           C  
+ATOM     22  N   GLU A  22      88.366  67.199  45.383  1.00 94.23           N  
+ATOM     23  CA  GLU A  22      87.061  67.600  45.886  1.00 91.81           C  
+ATOM     24  C   GLU A  22      86.943  69.080  45.591  1.00 89.40           C  
+ATOM     25  O   GLU A  22      85.948  69.541  45.039  1.00 90.17           O  
+ATOM     26  CB  GLU A  22      86.982  67.395  47.400  1.00 94.73           C  
+ATOM     27  CG  GLU A  22      85.759  68.027  48.049  1.00 96.35           C  
+ATOM     28  CD  GLU A  22      84.573  67.093  48.064  1.00 98.28           C  
+ATOM     29  OE1 GLU A  22      84.387  66.375  47.058  1.00100.17           O  
+ATOM     30  OE2 GLU A  22      83.828  67.080  49.071  1.00 97.24           O  
+ATOM     31  N   GLU A  23      87.978  69.821  45.967  1.00 86.05           N  
+ATOM     32  CA  GLU A  23      87.993  71.256  45.746  1.00 83.95           C  
+ATOM     33  C   GLU A  23      88.307  71.545  44.294  1.00 79.92           C  
+ATOM     34  O   GLU A  23      88.001  72.620  43.789  1.00 77.73           O  
+ATOM     35  CB  GLU A  23      89.027  71.939  46.650  1.00 86.41           C  
+ATOM     36  CG  GLU A  23      89.086  73.460  46.481  1.00 88.67           C  
+ATOM     37  CD  GLU A  23      87.761  74.149  46.800  1.00 90.24           C  
+ATOM     38  OE1 GLU A  23      87.382  75.080  46.052  1.00 91.33           O  
+ATOM     39  OE2 GLU A  23      87.104  73.772  47.799  1.00 88.01           O  
+ATOM     40  N   GLN A  24      88.937  70.592  43.621  1.00 77.79           N  
+ATOM     41  CA  GLN A  24      89.236  70.798  42.215  1.00 78.95           C  
+ATOM     42  C   GLN A  24      87.999  70.347  41.425  1.00 76.15           C  
+ATOM     43  O   GLN A  24      87.712  70.867  40.351  1.00 72.82           O  
+ATOM     44  CB  GLN A  24      90.508  70.035  41.801  1.00 81.61           C  
+ATOM     45  CG  GLN A  24      90.470  68.527  41.972  1.00 85.53           C  
+ATOM     46  CD  GLN A  24      91.846  67.891  41.788  1.00 88.76           C  
+ATOM     47  OE1 GLN A  24      92.513  68.098  40.769  1.00 89.50           O  
+ATOM     48  NE2 GLN A  24      92.273  67.109  42.777  1.00 87.62           N  
+ATOM     49  N   ALA A  25      87.257  69.399  41.994  1.00 74.28           N  
+ATOM     50  CA  ALA A  25      86.032  68.910  41.382  1.00 71.62           C  
+ATOM     51  C   ALA A  25      85.074  70.074  41.500  1.00 71.53           C  
+ATOM     52  O   ALA A  25      84.259  70.327  40.607  1.00 71.06           O  
+ATOM     53  CB  ALA A  25      85.484  67.710  42.147  1.00 71.04           C  
+ATOM     54  N   LYS A  26      85.176  70.790  42.613  1.00 68.60           N  
+ATOM     55  CA  LYS A  26      84.317  71.938  42.815  1.00 66.74           C  
+ATOM     56  C   LYS A  26      84.665  73.030  41.822  1.00 63.90           C  
+ATOM     57  O   LYS A  26      83.792  73.798  41.416  1.00 64.98           O  
+ATOM     58  CB  LYS A  26      84.444  72.485  44.240  1.00 68.95           C  
+ATOM     59  CG  LYS A  26      83.837  71.609  45.326  1.00 69.85           C  
+ATOM     60  CD  LYS A  26      83.763  72.376  46.639  1.00 69.77           C  
+ATOM     61  CE  LYS A  26      82.978  71.621  47.688  1.00 71.00           C  
+ATOM     62  NZ  LYS A  26      82.613  72.497  48.830  1.00 70.02           N  
+ATOM     63  N   THR A  27      85.931  73.112  41.424  1.00 61.78           N  
+ATOM     64  CA  THR A  27      86.313  74.154  40.477  1.00 61.06           C  
+ATOM     65  C   THR A  27      85.918  73.707  39.083  1.00 57.64           C  
+ATOM     66  O   THR A  27      85.531  74.527  38.255  1.00 57.40           O  
+ATOM     67  CB  THR A  27      87.838  74.479  40.509  1.00 62.18           C  
+ATOM     68  OG1 THR A  27      88.578  73.376  39.982  1.00 68.06           O  
+ATOM     69  CG2 THR A  27      88.300  74.763  41.935  1.00 61.97           C  
+ATOM     70  N   PHE A  28      86.011  72.406  38.830  1.00 55.68           N  
+ATOM     71  CA  PHE A  28      85.623  71.852  37.541  1.00 55.88           C  
+ATOM     72  C   PHE A  28      84.139  72.151  37.320  1.00 53.72           C  
+ATOM     73  O   PHE A  28      83.747  72.667  36.273  1.00 54.55           O  
+ATOM     74  CB  PHE A  28      85.856  70.344  37.518  1.00 57.42           C  
+ATOM     75  CG  PHE A  28      85.125  69.631  36.402  1.00 62.75           C  
+ATOM     76  CD1 PHE A  28      83.892  69.039  36.626  1.00 61.98           C  
+ATOM     77  CD2 PHE A  28      85.678  69.544  35.134  1.00 63.16           C  
+ATOM     78  CE1 PHE A  28      83.233  68.379  35.615  1.00 63.48           C  
+ATOM     79  CE2 PHE A  28      85.016  68.882  34.114  1.00 64.61           C  
+ATOM     80  CZ  PHE A  28      83.795  68.299  34.356  1.00 63.87           C  
+ATOM     81  N   LEU A  29      83.333  71.847  38.332  1.00 51.40           N  
+ATOM     82  CA  LEU A  29      81.902  72.078  38.289  1.00 52.82           C  
+ATOM     83  C   LEU A  29      81.567  73.551  38.113  1.00 54.08           C  
+ATOM     84  O   LEU A  29      80.663  73.899  37.347  1.00 54.89           O  
+ATOM     85  CB  LEU A  29      81.230  71.543  39.559  1.00 52.25           C  
+ATOM     86  CG  LEU A  29      80.497  70.200  39.504  1.00 54.01           C  
+ATOM     87  CD1 LEU A  29      80.698  69.547  38.146  1.00 54.07           C  
+ATOM     88  CD2 LEU A  29      80.986  69.294  40.624  1.00 54.10           C  
+ATOM     89  N   ASP A  30      82.280  74.423  38.817  1.00 53.96           N  
+ATOM     90  CA  ASP A  30      82.017  75.852  38.687  1.00 57.32           C  
+ATOM     91  C   ASP A  30      82.256  76.299  37.234  1.00 54.77           C  
+ATOM     92  O   ASP A  30      81.478  77.079  36.689  1.00 56.45           O  
+ATOM     93  CB  ASP A  30      82.899  76.664  39.660  1.00 60.62           C  
+ATOM     94  CG  ASP A  30      82.493  78.150  39.736  1.00 65.24           C  
+ATOM     95  OD1 ASP A  30      81.278  78.456  39.785  1.00 68.61           O  
+ATOM     96  OD2 ASP A  30      83.386  79.022  39.761  1.00 68.17           O  
+ATOM     97  N   LYS A  31      83.320  75.803  36.609  1.00 52.19           N  
+ATOM     98  CA  LYS A  31      83.602  76.167  35.223  1.00 56.56           C  
+ATOM     99  C   LYS A  31      82.476  75.659  34.293  1.00 55.65           C  
+ATOM    100  O   LYS A  31      82.022  76.381  33.397  1.00 52.45           O  
+ATOM    101  CB  LYS A  31      84.960  75.605  34.784  1.00 57.95           C  
+ATOM    102  CG  LYS A  31      86.150  76.207  35.536  1.00 63.32           C  
+ATOM    103  CD  LYS A  31      87.485  75.707  34.984  1.00 65.02           C  
+ATOM    104  CE  LYS A  31      88.647  76.120  35.889  1.00 65.61           C  
+ATOM    105  NZ  LYS A  31      89.993  75.848  35.286  1.00 65.43           N  
+ATOM    106  N   PHE A  32      82.035  74.422  34.528  1.00 51.97           N  
+ATOM    107  CA  PHE A  32      80.955  73.802  33.766  1.00 50.59           C  
+ATOM    108  C   PHE A  32      79.654  74.599  33.786  1.00 51.11           C  
+ATOM    109  O   PHE A  32      79.080  74.908  32.742  1.00 51.11           O  
+ATOM    110  CB  PHE A  32      80.681  72.399  34.306  1.00 52.15           C  
+ATOM    111  CG  PHE A  32      79.476  71.745  33.695  1.00 51.39           C  
+ATOM    112  CD1 PHE A  32      78.220  71.892  34.268  1.00 50.24           C  
+ATOM    113  CD2 PHE A  32      79.597  70.996  32.528  1.00 48.31           C  
+ATOM    114  CE1 PHE A  32      77.107  71.299  33.682  1.00 48.86           C  
+ATOM    115  CE2 PHE A  32      78.498  70.413  31.957  1.00 42.53           C  
+ATOM    116  CZ  PHE A  32      77.254  70.564  32.532  1.00 43.56           C  
+ATOM    117  N   ASN A  33      79.185  74.934  34.980  1.00 52.33           N  
+ATOM    118  CA  ASN A  33      77.946  75.675  35.125  1.00 53.63           C  
+ATOM    119  C   ASN A  33      77.909  76.980  34.338  1.00 55.39           C  
+ATOM    120  O   ASN A  33      76.896  77.288  33.700  1.00 54.61           O  
+ATOM    121  CB  ASN A  33      77.669  75.915  36.609  1.00 52.87           C  
+ATOM    122  CG  ASN A  33      77.398  74.621  37.356  1.00 58.76           C  
+ATOM    123  OD1 ASN A  33      77.551  74.544  38.572  1.00 63.89           O  
+ATOM    124  ND2 ASN A  33      76.989  73.591  36.622  1.00 59.29           N  
+ATOM    125  N   HIS A  34      79.001  77.743  34.365  1.00 57.47           N  
+ATOM    126  CA  HIS A  34      79.041  79.002  33.624  1.00 53.96           C  
+ATOM    127  C   HIS A  34      79.120  78.718  32.126  1.00 53.17           C  
+ATOM    128  O   HIS A  34      78.399  79.331  31.347  1.00 55.45           O  
+ATOM    129  CB  HIS A  34      80.213  79.873  34.097  1.00 52.18           C  
+ATOM    130  CG  HIS A  34      80.028  80.424  35.477  1.00 49.33           C  
+ATOM    131  ND1 HIS A  34      79.203  81.499  35.747  1.00 49.97           N  
+ATOM    132  CD2 HIS A  34      80.472  79.980  36.678  1.00 47.95           C  
+ATOM    133  CE1 HIS A  34      79.139  81.686  37.055  1.00 46.78           C  
+ATOM    134  NE2 HIS A  34      79.897  80.776  37.642  1.00 47.14           N  
+ATOM    135  N   GLU A  35      79.973  77.790  31.707  1.00 52.45           N  
+ATOM    136  CA  GLU A  35      80.026  77.480  30.284  1.00 53.91           C  
+ATOM    137  C   GLU A  35      78.703  76.866  29.825  1.00 52.83           C  
+ATOM    138  O   GLU A  35      78.138  77.301  28.824  1.00 52.38           O  
+ATOM    139  CB  GLU A  35      81.181  76.515  29.951  1.00 58.83           C  
+ATOM    140  CG  GLU A  35      82.552  77.189  29.839  1.00 63.59           C  
+ATOM    141  CD  GLU A  35      83.627  76.292  29.242  1.00 67.16           C  
+ATOM    142  OE1 GLU A  35      83.792  75.154  29.731  1.00 70.07           O  
+ATOM    143  OE2 GLU A  35      84.321  76.734  28.293  1.00 71.53           O  
+ATOM    144  N   ALA A  36      78.202  75.874  30.570  1.00 52.05           N  
+ATOM    145  CA  ALA A  36      76.946  75.182  30.229  1.00 50.52           C  
+ATOM    146  C   ALA A  36      75.766  76.116  30.169  1.00 50.06           C  
+ATOM    147  O   ALA A  36      74.976  76.058  29.240  1.00 49.77           O  
+ATOM    148  CB  ALA A  36      76.646  74.050  31.240  1.00 47.95           C  
+ATOM    149  N   GLU A  37      75.635  76.979  31.165  1.00 52.67           N  
+ATOM    150  CA  GLU A  37      74.511  77.903  31.185  1.00 55.96           C  
+ATOM    151  C   GLU A  37      74.469  78.720  29.898  1.00 58.07           C  
+ATOM    152  O   GLU A  37      73.398  78.970  29.344  1.00 60.52           O  
+ATOM    153  CB  GLU A  37      74.624  78.848  32.379  1.00 58.78           C  
+ATOM    154  CG  GLU A  37      73.401  79.707  32.639  1.00 58.88           C  
+ATOM    155  CD  GLU A  37      72.675  79.311  33.915  1.00 65.95           C  
+ATOM    156  OE1 GLU A  37      73.319  78.686  34.800  1.00 66.05           O  
+ATOM    157  OE2 GLU A  37      71.470  79.639  34.038  1.00 66.17           O  
+ATOM    158  N   ASP A  38      75.636  79.139  29.418  1.00 59.83           N  
+ATOM    159  CA  ASP A  38      75.693  79.941  28.198  1.00 60.18           C  
+ATOM    160  C   ASP A  38      75.414  79.150  26.915  1.00 56.28           C  
+ATOM    161  O   ASP A  38      74.668  79.611  26.061  1.00 55.68           O  
+ATOM    162  CB  ASP A  38      77.041  80.648  28.089  1.00 62.33           C  
+ATOM    163  CG  ASP A  38      77.146  81.472  26.836  1.00 65.70           C  
+ATOM    164  OD1 ASP A  38      76.286  82.358  26.641  1.00 68.72           O  
+ATOM    165  OD2 ASP A  38      78.081  81.231  26.043  1.00 67.24           O  
+ATOM    166  N   LEU A  39      75.997  77.966  26.779  1.00 52.55           N  
+ATOM    167  CA  LEU A  39      75.758  77.164  25.579  1.00 54.51           C  
+ATOM    168  C   LEU A  39      74.336  76.621  25.538  1.00 55.29           C  
+ATOM    169  O   LEU A  39      73.764  76.430  24.459  1.00 57.63           O  
+ATOM    170  CB  LEU A  39      76.747  76.000  25.494  1.00 53.66           C  
+ATOM    171  CG  LEU A  39      78.169  76.388  25.102  1.00 58.45           C  
+ATOM    172  CD1 LEU A  39      79.097  75.187  25.215  1.00 59.49           C  
+ATOM    173  CD2 LEU A  39      78.162  76.929  23.668  1.00 59.42           C  
+ATOM    174  N   PHE A  40      73.755  76.365  26.706  1.00 53.82           N  
+ATOM    175  CA  PHE A  40      72.401  75.852  26.738  1.00 51.47           C  
+ATOM    176  C   PHE A  40      71.454  76.981  26.366  1.00 53.27           C  
+ATOM    177  O   PHE A  40      70.415  76.748  25.748  1.00 54.20           O  
+ATOM    178  CB  PHE A  40      72.044  75.315  28.123  1.00 48.97           C  
+ATOM    179  CG  PHE A  40      70.672  74.688  28.193  1.00 44.60           C  
+ATOM    180  CD1 PHE A  40      70.461  73.397  27.728  1.00 49.24           C  
+ATOM    181  CD2 PHE A  40      69.595  75.403  28.704  1.00 45.50           C  
+ATOM    182  CE1 PHE A  40      69.196  72.822  27.769  1.00 49.89           C  
+ATOM    183  CE2 PHE A  40      68.334  74.846  28.752  1.00 47.86           C  
+ATOM    184  CZ  PHE A  40      68.129  73.553  28.285  1.00 48.88           C  
+ATOM    185  N   TYR A  41      71.810  78.203  26.752  1.00 53.80           N  
+ATOM    186  CA  TYR A  41      70.978  79.355  26.424  1.00 57.29           C  
+ATOM    187  C   TYR A  41      70.987  79.636  24.919  1.00 58.87           C  
+ATOM    188  O   TYR A  41      69.950  79.961  24.337  1.00 58.59           O  
+ATOM    189  CB  TYR A  41      71.448  80.611  27.159  1.00 56.46           C  
+ATOM    190  CG  TYR A  41      70.428  81.725  27.109  1.00 57.52           C  
+ATOM    191  CD1 TYR A  41      69.234  81.620  27.798  1.00 57.87           C  
+ATOM    192  CD2 TYR A  41      70.647  82.873  26.353  1.00 61.97           C  
+ATOM    193  CE1 TYR A  41      68.279  82.621  27.742  1.00 61.71           C  
+ATOM    194  CE2 TYR A  41      69.690  83.887  26.291  1.00 61.87           C  
+ATOM    195  CZ  TYR A  41      68.506  83.751  26.989  1.00 63.59           C  
+ATOM    196  OH  TYR A  41      67.530  84.729  26.930  1.00 64.62           O  
+ATOM    197  N   GLN A  42      72.156  79.519  24.293  1.00 59.70           N  
+ATOM    198  CA  GLN A  42      72.269  79.763  22.859  1.00 61.30           C  
+ATOM    199  C   GLN A  42      71.459  78.698  22.125  1.00 63.11           C  
+ATOM    200  O   GLN A  42      70.688  79.004  21.214  1.00 65.49           O  
+ATOM    201  CB  GLN A  42      73.740  79.719  22.422  1.00 61.24           C  
+ATOM    202  CG  GLN A  42      74.611  80.863  23.000  1.00 68.60           C  
+ATOM    203  CD  GLN A  42      76.112  80.752  22.647  1.00 71.71           C  
+ATOM    204  OE1 GLN A  42      76.500  80.768  21.474  1.00 75.43           O  
+ATOM    205  NE2 GLN A  42      76.952  80.651  23.668  1.00 72.34           N  
+ATOM    206  N   SER A  43      71.625  77.449  22.547  1.00 63.26           N  
+ATOM    207  CA  SER A  43      70.917  76.324  21.961  1.00 60.60           C  
+ATOM    208  C   SER A  43      69.412  76.417  22.175  1.00 62.17           C  
+ATOM    209  O   SER A  43      68.641  76.060  21.277  1.00 64.06           O  
+ATOM    210  CB  SER A  43      71.425  75.017  22.551  1.00 62.28           C  
+ATOM    211  OG  SER A  43      70.822  73.917  21.902  1.00 61.78           O  
+ATOM    212  N   SER A  44      68.989  76.882  23.352  1.00 58.42           N  
+ATOM    213  CA  SER A  44      67.563  77.032  23.641  1.00 58.06           C  
+ATOM    214  C   SER A  44      66.925  78.105  22.754  1.00 57.93           C  
+ATOM    215  O   SER A  44      65.864  77.881  22.159  1.00 52.65           O  
+ATOM    216  CB  SER A  44      67.334  77.403  25.112  1.00 60.63           C  
+ATOM    217  OG  SER A  44      67.652  76.327  25.968  1.00 61.97           O  
+ATOM    218  N   LEU A  45      67.568  79.272  22.696  1.00 57.87           N  
+ATOM    219  CA  LEU A  45      67.097  80.395  21.882  1.00 60.76           C  
+ATOM    220  C   LEU A  45      66.955  79.990  20.425  1.00 59.96           C  
+ATOM    221  O   LEU A  45      65.996  80.351  19.764  1.00 58.77           O  
+ATOM    222  CB  LEU A  45      68.066  81.565  21.970  1.00 62.94           C  
+ATOM    223  CG  LEU A  45      67.605  82.752  22.801  1.00 66.79           C  
+ATOM    224  CD1 LEU A  45      68.793  83.658  23.090  1.00 68.77           C  
+ATOM    225  CD2 LEU A  45      66.501  83.496  22.055  1.00 68.80           C  
+ATOM    226  N   ALA A  46      67.925  79.240  19.928  1.00 60.19           N  
+ATOM    227  CA  ALA A  46      67.881  78.781  18.554  1.00 60.51           C  
+ATOM    228  C   ALA A  46      66.662  77.896  18.327  1.00 64.06           C  
+ATOM    229  O   ALA A  46      65.960  78.050  17.327  1.00 66.48           O  
+ATOM    230  CB  ALA A  46      69.140  78.008  18.228  1.00 61.45           C  
+ATOM    231  N   SER A  47      66.416  76.959  19.246  1.00 63.97           N  
+ATOM    232  CA  SER A  47      65.277  76.057  19.113  1.00 61.67           C  
+ATOM    233  C   SER A  47      63.970  76.809  19.221  1.00 61.18           C  
+ATOM    234  O   SER A  47      62.983  76.454  18.587  1.00 60.53           O  
+ATOM    235  CB  SER A  47      65.314  74.962  20.174  1.00 60.54           C  
+ATOM    236  OG  SER A  47      66.322  74.014  19.860  1.00 65.91           O  
+ATOM    237  N   TRP A  48      63.967  77.856  20.026  1.00 61.56           N  
+ATOM    238  CA  TRP A  48      62.765  78.641  20.209  1.00 64.51           C  
+ATOM    239  C   TRP A  48      62.398  79.392  18.931  1.00 65.92           C  
+ATOM    240  O   TRP A  48      61.224  79.565  18.627  1.00 66.51           O  
+ATOM    241  CB  TRP A  48      62.966  79.613  21.371  1.00 66.58           C  
+ATOM    242  CG  TRP A  48      61.874  80.605  21.507  1.00 69.98           C  
+ATOM    243  CD1 TRP A  48      61.803  81.836  20.919  1.00 70.43           C  
+ATOM    244  CD2 TRP A  48      60.663  80.441  22.251  1.00 70.35           C  
+ATOM    245  NE1 TRP A  48      60.618  82.449  21.254  1.00 73.34           N  
+ATOM    246  CE2 TRP A  48      59.900  81.613  22.070  1.00 70.49           C  
+ATOM    247  CE3 TRP A  48      60.149  79.414  23.053  1.00 69.57           C  
+ATOM    248  CZ2 TRP A  48      58.650  81.789  22.659  1.00 71.52           C  
+ATOM    249  CZ3 TRP A  48      58.909  79.586  23.638  1.00 68.56           C  
+ATOM    250  CH2 TRP A  48      58.171  80.766  23.438  1.00 71.23           C  
+ATOM    251  N   ASN A  49      63.409  79.832  18.188  1.00 67.90           N  
+ATOM    252  CA  ASN A  49      63.199  80.560  16.942  1.00 68.81           C  
+ATOM    253  C   ASN A  49      62.525  79.649  15.946  1.00 70.84           C  
+ATOM    254  O   ASN A  49      61.556  80.038  15.303  1.00 73.00           O  
+ATOM    255  CB  ASN A  49      64.529  81.019  16.358  1.00 67.43           C  
+ATOM    256  CG  ASN A  49      65.114  82.186  17.099  1.00 65.03           C  
+ATOM    257  OD1 ASN A  49      66.308  82.461  16.990  1.00 67.03           O  
+ATOM    258  ND2 ASN A  49      64.276  82.898  17.849  1.00 65.94           N  
+ATOM    259  N   TYR A  50      63.044  78.431  15.831  1.00 70.64           N  
+ATOM    260  CA  TYR A  50      62.505  77.442  14.908  1.00 72.08           C  
+ATOM    261  C   TYR A  50      61.087  76.957  15.232  1.00 73.54           C  
+ATOM    262  O   TYR A  50      60.319  76.641  14.317  1.00 75.57           O  
+ATOM    263  CB  TYR A  50      63.443  76.242  14.840  1.00 73.25           C  
+ATOM    264  CG  TYR A  50      62.870  75.061  14.094  1.00 78.28           C  
+ATOM    265  CD1 TYR A  50      63.007  74.947  12.715  1.00 80.80           C  
+ATOM    266  CD2 TYR A  50      62.200  74.053  14.772  1.00 78.39           C  
+ATOM    267  CE1 TYR A  50      62.494  73.856  12.036  1.00 81.32           C  
+ATOM    268  CE2 TYR A  50      61.686  72.965  14.106  1.00 81.26           C  
+ATOM    269  CZ  TYR A  50      61.834  72.868  12.740  1.00 82.64           C  
+ATOM    270  OH  TYR A  50      61.307  71.781  12.087  1.00 84.67           O  
+ATOM    271  N   ASN A  51      60.736  76.883  16.518  1.00 71.08           N  
+ATOM    272  CA  ASN A  51      59.399  76.424  16.902  1.00 70.19           C  
+ATOM    273  C   ASN A  51      58.389  77.557  16.894  1.00 72.34           C  
+ATOM    274  O   ASN A  51      57.191  77.325  17.044  1.00 74.32           O  
+ATOM    275  CB  ASN A  51      59.400  75.771  18.295  1.00 65.80           C  
+ATOM    276  CG  ASN A  51      60.051  74.403  18.299  1.00 62.36           C  
+ATOM    277  OD1 ASN A  51      61.271  74.284  18.206  1.00 65.11           O  
+ATOM    278  ND2 ASN A  51      59.238  73.357  18.395  1.00 59.79           N  
+ATOM    279  N   THR A  52      58.871  78.783  16.731  1.00 73.46           N  
+ATOM    280  CA  THR A  52      57.993  79.947  16.695  1.00 74.93           C  
+ATOM    281  C   THR A  52      57.924  80.532  15.285  1.00 76.24           C  
+ATOM    282  O   THR A  52      56.993  81.264  14.948  1.00 76.71           O  
+ATOM    283  CB  THR A  52      58.489  81.039  17.640  1.00 74.79           C  
+ATOM    284  OG1 THR A  52      59.869  81.310  17.362  1.00 73.63           O  
+ATOM    285  CG2 THR A  52      58.321  80.607  19.090  1.00 76.61           C  
+ATOM    286  N   ASN A  53      58.929  80.210  14.478  1.00 78.03           N  
+ATOM    287  CA  ASN A  53      59.024  80.681  13.105  1.00 77.13           C  
+ATOM    288  C   ASN A  53      59.743  79.627  12.301  1.00 77.86           C  
+ATOM    289  O   ASN A  53      60.925  79.778  12.006  1.00 75.81           O  
+ATOM    290  CB  ASN A  53      59.833  81.974  13.018  1.00 79.63           C  
+ATOM    291  CG  ASN A  53      59.953  82.489  11.585  1.00 83.28           C  
+ATOM    292  OD1 ASN A  53      60.844  83.281  11.262  1.00 84.58           O  
+ATOM    293  ND2 ASN A  53      59.044  82.042  10.720  1.00 82.10           N  
+ATOM    294  N   ILE A  54      59.041  78.555  11.952  1.00 79.76           N  
+ATOM    295  CA  ILE A  54      59.660  77.500  11.176  1.00 82.44           C  
+ATOM    296  C   ILE A  54      60.231  78.102   9.899  1.00 85.61           C  
+ATOM    297  O   ILE A  54      59.491  78.580   9.038  1.00 87.35           O  
+ATOM    298  CB  ILE A  54      58.646  76.395  10.822  1.00 83.60           C  
+ATOM    299  CG1 ILE A  54      58.044  75.815  12.106  1.00 86.06           C  
+ATOM    300  CG2 ILE A  54      59.333  75.278  10.050  1.00 83.48           C  
+ATOM    301  CD1 ILE A  54      57.204  74.550  11.895  1.00 83.99           C  
+ATOM    302  N   THR A  55      61.558  78.095   9.806  1.00 87.96           N  
+ATOM    303  CA  THR A  55      62.292  78.622   8.654  1.00 89.68           C  
+ATOM    304  C   THR A  55      63.375  77.601   8.297  1.00 92.14           C  
+ATOM    305  O   THR A  55      63.638  76.677   9.069  1.00 93.10           O  
+ATOM    306  CB  THR A  55      62.961  79.990   8.991  1.00 89.25           C  
+ATOM    307  OG1 THR A  55      61.980  81.037   8.955  1.00 88.54           O  
+ATOM    308  CG2 THR A  55      64.065  80.310   8.012  1.00 87.76           C  
+ATOM    309  N   GLU A  56      63.989  77.749   7.127  1.00 94.04           N  
+ATOM    310  CA  GLU A  56      65.040  76.825   6.714  1.00 96.12           C  
+ATOM    311  C   GLU A  56      66.372  77.149   7.396  1.00 96.32           C  
+ATOM    312  O   GLU A  56      67.151  76.249   7.723  1.00 95.31           O  
+ATOM    313  CB  GLU A  56      65.223  76.856   5.194  1.00 97.64           C  
+ATOM    314  CG  GLU A  56      66.302  75.903   4.705  1.00 98.58           C  
+ATOM    315  CD  GLU A  56      66.034  74.473   5.130  1.00 99.86           C  
+ATOM    316  OE1 GLU A  56      66.930  73.616   4.947  1.00 99.79           O  
+ATOM    317  OE2 GLU A  56      64.922  74.210   5.643  1.00 99.13           O  
+ATOM    318  N   GLU A  57      66.641  78.435   7.599  1.00 95.33           N  
+ATOM    319  CA  GLU A  57      67.875  78.833   8.255  1.00 95.45           C  
+ATOM    320  C   GLU A  57      67.696  78.760   9.769  1.00 93.63           C  
+ATOM    321  O   GLU A  57      68.673  78.633  10.511  1.00 93.19           O  
+ATOM    322  CB  GLU A  57      68.297  80.247   7.832  1.00 97.97           C  
+ATOM    323  CG  GLU A  57      67.159  81.211   7.562  1.00101.51           C  
+ATOM    324  CD  GLU A  57      66.627  81.106   6.141  1.00104.85           C  
+ATOM    325  OE1 GLU A  57      66.087  80.038   5.778  1.00107.50           O  
+ATOM    326  OE2 GLU A  57      66.755  82.094   5.382  1.00105.18           O  
+ATOM    327  N   ASN A  58      66.446  78.840  10.220  1.00 90.38           N  
+ATOM    328  CA  ASN A  58      66.157  78.755  11.643  1.00 87.27           C  
+ATOM    329  C   ASN A  58      66.293  77.319  12.126  1.00 86.04           C  
+ATOM    330  O   ASN A  58      66.519  77.081  13.313  1.00 85.48           O  
+ATOM    331  CB  ASN A  58      64.762  79.294  11.952  1.00 86.12           C  
+ATOM    332  CG  ASN A  58      64.778  80.773  12.285  1.00 86.39           C  
+ATOM    333  OD1 ASN A  58      63.758  81.354  12.648  1.00 86.71           O  
+ATOM    334  ND2 ASN A  58      65.946  81.391  12.164  1.00 87.58           N  
+ATOM    335  N   VAL A  59      66.157  76.364  11.207  1.00 84.52           N  
+ATOM    336  CA  VAL A  59      66.314  74.956  11.561  1.00 85.10           C  
+ATOM    337  C   VAL A  59      67.818  74.721  11.548  1.00 85.66           C  
+ATOM    338  O   VAL A  59      68.340  73.904  12.298  1.00 86.37           O  
+ATOM    339  CB  VAL A  59      65.667  74.005  10.524  1.00 85.37           C  
+ATOM    340  CG1 VAL A  59      66.584  73.834   9.323  1.00 84.01           C  
+ATOM    341  CG2 VAL A  59      65.393  72.650  11.159  1.00 85.65           C  
+ATOM    342  N   GLN A  60      68.502  75.465  10.684  1.00 86.55           N  
+ATOM    343  CA  GLN A  60      69.948  75.387  10.541  1.00 85.18           C  
+ATOM    344  C   GLN A  60      70.595  75.918  11.813  1.00 83.45           C  
+ATOM    345  O   GLN A  60      71.396  75.236  12.438  1.00 82.47           O  
+ATOM    346  CB  GLN A  60      70.395  76.224   9.333  1.00 88.20           C  
+ATOM    347  CG  GLN A  60      71.910  76.363   9.157  1.00 90.14           C  
+ATOM    348  CD  GLN A  60      72.584  75.081   8.690  1.00 91.55           C  
+ATOM    349  OE1 GLN A  60      73.809  75.032   8.525  1.00 91.33           O  
+ATOM    350  NE2 GLN A  60      71.787  74.037   8.471  1.00 91.31           N  
+ATOM    351  N   ASN A  61      70.242  77.140  12.192  1.00 83.10           N  
+ATOM    352  CA  ASN A  61      70.795  77.745  13.395  1.00 82.86           C  
+ATOM    353  C   ASN A  61      70.599  76.840  14.600  1.00 82.81           C  
+ATOM    354  O   ASN A  61      71.505  76.680  15.424  1.00 81.01           O  
+ATOM    355  CB  ASN A  61      70.130  79.094  13.664  1.00 84.31           C  
+ATOM    356  CG  ASN A  61      70.773  80.228  12.887  1.00 86.50           C  
+ATOM    357  OD1 ASN A  61      70.307  81.365  12.935  1.00 88.53           O  
+ATOM    358  ND2 ASN A  61      71.857  79.926  12.176  1.00 85.86           N  
+ATOM    359  N   MET A  62      69.414  76.245  14.693  1.00 81.78           N  
+ATOM    360  CA  MET A  62      69.092  75.367  15.806  1.00 80.62           C  
+ATOM    361  C   MET A  62      69.897  74.076  15.822  1.00 80.69           C  
+ATOM    362  O   MET A  62      70.520  73.747  16.832  1.00 82.05           O  
+ATOM    363  CB  MET A  62      67.600  75.029  15.808  1.00 78.66           C  
+ATOM    364  CG  MET A  62      67.245  73.878  16.738  1.00 76.58           C  
+ATOM    365  SD  MET A  62      65.498  73.447  16.738  1.00 71.06           S  
+ATOM    366  CE  MET A  62      65.352  72.684  15.098  1.00 74.61           C  
+ATOM    367  N   ASN A  63      69.891  73.341  14.716  1.00 80.33           N  
+ATOM    368  CA  ASN A  63      70.622  72.081  14.679  1.00 80.62           C  
+ATOM    369  C   ASN A  63      72.100  72.290  15.003  1.00 79.18           C  
+ATOM    370  O   ASN A  63      72.720  71.458  15.658  1.00 78.02           O  
+ATOM    371  CB  ASN A  63      70.450  71.385  13.319  1.00 83.16           C  
+ATOM    372  CG  ASN A  63      70.980  72.214  12.159  1.00 89.12           C  
+ATOM    373  OD1 ASN A  63      72.167  72.544  12.108  1.00 92.76           O  
+ATOM    374  ND2 ASN A  63      70.102  72.549  11.213  1.00 90.28           N  
+ATOM    375  N   ASN A  64      72.660  73.409  14.561  1.00 77.49           N  
+ATOM    376  CA  ASN A  64      74.063  73.700  14.829  1.00 76.62           C  
+ATOM    377  C   ASN A  64      74.297  74.119  16.285  1.00 74.47           C  
+ATOM    378  O   ASN A  64      75.279  73.714  16.904  1.00 73.97           O  
+ATOM    379  CB  ASN A  64      74.563  74.798  13.885  1.00 80.17           C  
+ATOM    380  CG  ASN A  64      74.582  74.353  12.430  1.00 82.86           C  
+ATOM    381  OD1 ASN A  64      75.140  73.305  12.102  1.00 83.98           O  
+ATOM    382  ND2 ASN A  64      73.979  75.151  11.551  1.00 81.96           N  
+ATOM    383  N   ALA A  65      73.404  74.939  16.826  1.00 72.07           N  
+ATOM    384  CA  ALA A  65      73.539  75.384  18.208  1.00 69.94           C  
+ATOM    385  C   ALA A  65      73.362  74.166  19.103  1.00 68.49           C  
+ATOM    386  O   ALA A  65      73.959  74.074  20.180  1.00 67.16           O  
+ATOM    387  CB  ALA A  65      72.489  76.437  18.535  1.00 67.66           C  
+ATOM    388  N   GLY A  66      72.549  73.226  18.635  1.00 64.99           N  
+ATOM    389  CA  GLY A  66      72.307  72.022  19.398  1.00 65.29           C  
+ATOM    390  C   GLY A  66      73.494  71.081  19.393  1.00 64.58           C  
+ATOM    391  O   GLY A  66      73.800  70.463  20.408  1.00 67.16           O  
+ATOM    392  N   ASP A  67      74.165  70.974  18.253  1.00 65.25           N  
+ATOM    393  CA  ASP A  67      75.330  70.099  18.103  1.00 66.99           C  
+ATOM    394  C   ASP A  67      76.560  70.626  18.843  1.00 66.34           C  
+ATOM    395  O   ASP A  67      77.482  69.872  19.153  1.00 65.99           O  
+ATOM    396  CB  ASP A  67      75.649  69.925  16.615  1.00 69.38           C  
+ATOM    397  CG  ASP A  67      74.688  68.961  15.919  1.00 72.71           C  
+ATOM    398  OD1 ASP A  67      73.457  69.031  16.174  1.00 68.61           O  
+ATOM    399  OD2 ASP A  67      75.173  68.134  15.111  1.00 75.62           O  
+ATOM    400  N   LYS A  68      76.568  71.929  19.105  1.00 66.46           N  
+ATOM    401  CA  LYS A  68      77.655  72.572  19.833  1.00 66.50           C  
+ATOM    402  C   LYS A  68      77.468  72.213  21.311  1.00 65.17           C  
+ATOM    403  O   LYS A  68      78.439  72.005  22.037  1.00 66.11           O  
+ATOM    404  CB  LYS A  68      77.589  74.095  19.636  1.00 68.02           C  
+ATOM    405  CG  LYS A  68      78.758  74.871  20.218  1.00 69.16           C  
+ATOM    406  CD  LYS A  68      79.245  75.948  19.245  1.00 72.98           C  
+ATOM    407  CE  LYS A  68      79.796  75.324  17.944  1.00 75.81           C  
+ATOM    408  NZ  LYS A  68      80.422  76.303  16.988  1.00 75.23           N  
+ATOM    409  N   TRP A  69      76.209  72.130  21.738  1.00 62.09           N  
+ATOM    410  CA  TRP A  69      75.877  71.776  23.110  1.00 62.63           C  
+ATOM    411  C   TRP A  69      76.201  70.315  23.398  1.00 62.77           C  
+ATOM    412  O   TRP A  69      76.757  69.994  24.448  1.00 61.24           O  
+ATOM    413  CB  TRP A  69      74.395  72.054  23.379  1.00 63.69           C  
+ATOM    414  CG  TRP A  69      73.855  71.419  24.639  1.00 63.92           C  
+ATOM    415  CD1 TRP A  69      73.013  70.344  24.717  1.00 62.10           C  
+ATOM    416  CD2 TRP A  69      74.127  71.813  25.993  1.00 61.22           C  
+ATOM    417  NE1 TRP A  69      72.744  70.048  26.030  1.00 62.30           N  
+ATOM    418  CE2 TRP A  69      73.414  70.933  26.835  1.00 62.78           C  
+ATOM    419  CE3 TRP A  69      74.903  72.823  26.574  1.00 60.61           C  
+ATOM    420  CZ2 TRP A  69      73.453  71.033  28.229  1.00 58.36           C  
+ATOM    421  CZ3 TRP A  69      74.941  72.922  27.960  1.00 58.79           C  
+ATOM    422  CH2 TRP A  69      74.219  72.032  28.769  1.00 60.13           C  
+ATOM    423  N   SER A  70      75.866  69.432  22.460  1.00 62.87           N  
+ATOM    424  CA  SER A  70      76.128  67.998  22.620  1.00 61.50           C  
+ATOM    425  C   SER A  70      77.612  67.688  22.661  1.00 57.88           C  
+ATOM    426  O   SER A  70      78.050  66.822  23.412  1.00 59.93           O  
+ATOM    427  CB  SER A  70      75.486  67.208  21.481  1.00 60.96           C  
+ATOM    428  OG  SER A  70      74.081  67.374  21.507  1.00 64.59           O  
+ATOM    429  N   ALA A  71      78.379  68.396  21.845  1.00 56.88           N  
+ATOM    430  CA  ALA A  71      79.817  68.203  21.796  1.00 58.19           C  
+ATOM    431  C   ALA A  71      80.477  68.735  23.077  1.00 59.44           C  
+ATOM    432  O   ALA A  71      81.514  68.237  23.507  1.00 59.01           O  
+ATOM    433  CB  ALA A  71      80.387  68.909  20.580  1.00 59.54           C  
+ATOM    434  N   PHE A  72      79.880  69.762  23.669  1.00 59.10           N  
+ATOM    435  CA  PHE A  72      80.394  70.338  24.908  1.00 59.32           C  
+ATOM    436  C   PHE A  72      80.130  69.332  26.031  1.00 59.84           C  
+ATOM    437  O   PHE A  72      81.014  69.025  26.839  1.00 59.89           O  
+ATOM    438  CB  PHE A  72      79.675  71.667  25.193  1.00 56.83           C  
+ATOM    439  CG  PHE A  72      79.898  72.204  26.577  1.00 58.68           C  
+ATOM    440  CD1 PHE A  72      81.160  72.606  26.990  1.00 58.92           C  
+ATOM    441  CD2 PHE A  72      78.838  72.327  27.462  1.00 58.94           C  
+ATOM    442  CE1 PHE A  72      81.363  73.126  28.258  1.00 59.30           C  
+ATOM    443  CE2 PHE A  72      79.029  72.847  28.737  1.00 61.33           C  
+ATOM    444  CZ  PHE A  72      80.298  73.248  29.134  1.00 59.68           C  
+ATOM    445  N   LEU A  73      78.912  68.797  26.041  1.00 59.28           N  
+ATOM    446  CA  LEU A  73      78.480  67.840  27.053  1.00 60.23           C  
+ATOM    447  C   LEU A  73      79.315  66.576  27.051  1.00 59.35           C  
+ATOM    448  O   LEU A  73      79.494  65.943  28.088  1.00 62.14           O  
+ATOM    449  CB  LEU A  73      77.016  67.476  26.827  1.00 59.54           C  
+ATOM    450  CG  LEU A  73      76.066  67.506  28.018  1.00 57.82           C  
+ATOM    451  CD1 LEU A  73      76.145  68.850  28.721  1.00 61.20           C  
+ATOM    452  CD2 LEU A  73      74.651  67.260  27.517  1.00 54.80           C  
+ATOM    453  N   LYS A  74      79.830  66.219  25.885  1.00 59.78           N  
+ATOM    454  CA  LYS A  74      80.633  65.020  25.744  1.00 59.80           C  
+ATOM    455  C   LYS A  74      82.073  65.261  26.185  1.00 60.17           C  
+ATOM    456  O   LYS A  74      82.693  64.396  26.808  1.00 57.83           O  
+ATOM    457  CB  LYS A  74      80.601  64.545  24.287  1.00 63.29           C  
+ATOM    458  CG  LYS A  74      81.167  63.155  24.081  1.00 65.54           C  
+ATOM    459  CD  LYS A  74      81.290  62.806  22.610  1.00 70.87           C  
+ATOM    460  CE  LYS A  74      81.702  61.351  22.444  1.00 74.27           C  
+ATOM    461  NZ  LYS A  74      82.874  61.015  23.313  1.00 77.42           N  
+ATOM    462  N   GLU A  75      82.620  66.425  25.854  1.00 58.97           N  
+ATOM    463  CA  GLU A  75      83.984  66.700  26.269  1.00 62.86           C  
+ATOM    464  C   GLU A  75      83.992  66.847  27.792  1.00 63.45           C  
+ATOM    465  O   GLU A  75      84.918  66.393  28.469  1.00 63.19           O  
+ATOM    466  CB  GLU A  75      84.524  67.988  25.630  1.00 66.32           C  
+ATOM    467  CG  GLU A  75      85.935  68.321  26.130  1.00 75.62           C  
+ATOM    468  CD  GLU A  75      86.518  69.610  25.562  1.00 81.12           C  
+ATOM    469  OE1 GLU A  75      87.688  69.925  25.898  1.00 82.96           O  
+ATOM    470  OE2 GLU A  75      85.820  70.307  24.792  1.00 85.09           O  
+ATOM    471  N   GLN A  76      82.947  67.478  28.319  1.00 59.57           N  
+ATOM    472  CA  GLN A  76      82.830  67.704  29.748  1.00 59.05           C  
+ATOM    473  C   GLN A  76      82.595  66.417  30.524  1.00 61.62           C  
+ATOM    474  O   GLN A  76      83.033  66.281  31.668  1.00 62.43           O  
+ATOM    475  CB  GLN A  76      81.702  68.692  30.017  1.00 54.12           C  
+ATOM    476  CG  GLN A  76      81.999  70.082  29.495  1.00 51.15           C  
+ATOM    477  CD  GLN A  76      83.176  70.706  30.211  1.00 53.23           C  
+ATOM    478  OE1 GLN A  76      83.233  70.701  31.441  1.00 47.54           O  
+ATOM    479  NE2 GLN A  76      84.123  71.249  29.448  1.00 50.32           N  
+ATOM    480  N   SER A  77      81.894  65.477  29.906  1.00 62.45           N  
+ATOM    481  CA  SER A  77      81.629  64.200  30.544  1.00 64.34           C  
+ATOM    482  C   SER A  77      82.915  63.381  30.603  1.00 65.35           C  
+ATOM    483  O   SER A  77      83.283  62.853  31.643  1.00 63.24           O  
+ATOM    484  CB  SER A  77      80.577  63.427  29.757  1.00 65.93           C  
+ATOM    485  OG  SER A  77      80.340  62.171  30.359  1.00 71.70           O  
+ATOM    486  N   THR A  78      83.602  63.288  29.474  1.00 69.15           N  
+ATOM    487  CA  THR A  78      84.835  62.528  29.399  1.00 73.71           C  
+ATOM    488  C   THR A  78      86.016  63.351  29.903  1.00 75.34           C  
+ATOM    489  O   THR A  78      87.156  63.162  29.470  1.00 77.89           O  
+ATOM    490  CB  THR A  78      85.095  62.077  27.955  1.00 76.71           C  
+ATOM    491  OG1 THR A  78      85.285  63.228  27.120  1.00 80.29           O  
+ATOM    492  CG2 THR A  78      83.898  61.274  27.434  1.00 77.79           C  
+ATOM    493  N   LEU A  79      85.729  64.262  30.827  1.00 74.35           N  
+ATOM    494  CA  LEU A  79      86.738  65.131  31.412  1.00 72.47           C  
+ATOM    495  C   LEU A  79      86.459  65.178  32.903  1.00 73.96           C  
+ATOM    496  O   LEU A  79      87.278  65.643  33.690  1.00 73.17           O  
+ATOM    497  CB  LEU A  79      86.620  66.535  30.827  1.00 71.25           C  
+ATOM    498  CG  LEU A  79      87.798  67.501  30.963  1.00 69.68           C  
+ATOM    499  CD1 LEU A  79      88.996  66.964  30.198  1.00 66.00           C  
+ATOM    500  CD2 LEU A  79      87.397  68.860  30.418  1.00 69.28           C  
+ATOM    501  N   ALA A  80      85.277  64.698  33.276  1.00 75.29           N  
+ATOM    502  CA  ALA A  80      84.858  64.660  34.666  1.00 77.32           C  
+ATOM    503  C   ALA A  80      85.213  63.305  35.263  1.00 78.68           C  
+ATOM    504  O   ALA A  80      85.250  63.148  36.483  1.00 77.72           O  
+ATOM    505  CB  ALA A  80      83.362  64.898  34.766  1.00 76.89           C  
+ATOM    506  N   GLN A  81      85.465  62.327  34.398  1.00 81.12           N  
+ATOM    507  CA  GLN A  81      85.824  60.984  34.846  1.00 84.91           C  
+ATOM    508  C   GLN A  81      87.005  61.110  35.804  1.00 88.26           C  
+ATOM    509  O   GLN A  81      87.079  60.434  36.832  1.00 89.33           O  
+ATOM    510  CB  GLN A  81      86.243  60.121  33.657  1.00 84.36           C  
+ATOM    511  CG  GLN A  81      85.234  60.028  32.518  1.00 84.15           C  
+ATOM    512  CD  GLN A  81      83.960  59.327  32.920  1.00 83.16           C  
+ATOM    513  OE1 GLN A  81      83.953  58.513  33.844  1.00 83.26           O  
+ATOM    514  NE2 GLN A  81      82.873  59.625  32.215  1.00 82.42           N  
+ATOM    515  N   MET A  82      87.923  61.997  35.440  1.00 91.07           N  
+ATOM    516  CA  MET A  82      89.130  62.279  36.205  1.00 94.16           C  
+ATOM    517  C   MET A  82      88.936  62.280  37.723  1.00 94.16           C  
+ATOM    518  O   MET A  82      89.823  61.846  38.458  1.00 94.47           O  
+ATOM    519  CB  MET A  82      89.691  63.635  35.763  1.00 97.45           C  
+ATOM    520  CG  MET A  82      91.079  63.973  36.288  1.00103.21           C  
+ATOM    521  SD  MET A  82      91.635  65.626  35.750  1.00108.38           S  
+ATOM    522  CE  MET A  82      91.590  66.533  37.314  1.00107.73           C  
+ATOM    523  N   TYR A  83      87.780  62.751  38.188  1.00 94.22           N  
+ATOM    524  CA  TYR A  83      87.509  62.840  39.625  1.00 95.90           C  
+ATOM    525  C   TYR A  83      86.819  61.633  40.244  1.00 98.09           C  
+ATOM    526  O   TYR A  83      85.599  61.491  40.166  1.00 98.23           O  
+ATOM    527  CB  TYR A  83      86.695  64.102  39.922  1.00 92.32           C  
+ATOM    528  CG  TYR A  83      87.282  65.323  39.260  1.00 91.51           C  
+ATOM    529  CD1 TYR A  83      86.922  65.676  37.962  1.00 91.24           C  
+ATOM    530  CD2 TYR A  83      88.261  66.072  39.893  1.00 89.95           C  
+ATOM    531  CE1 TYR A  83      87.526  66.738  37.316  1.00 88.60           C  
+ATOM    532  CE2 TYR A  83      88.870  67.131  39.255  1.00 89.69           C  
+ATOM    533  CZ  TYR A  83      88.500  67.458  37.969  1.00 88.95           C  
+ATOM    534  OH  TYR A  83      89.118  68.505  37.338  1.00 87.04           O  
+ATOM    535  N   PRO A  84      87.602  60.760  40.898  1.00 99.93           N  
+ATOM    536  CA  PRO A  84      87.139  59.538  41.563  1.00100.87           C  
+ATOM    537  C   PRO A  84      85.861  59.769  42.358  1.00101.55           C  
+ATOM    538  O   PRO A  84      85.860  60.485  43.360  1.00101.55           O  
+ATOM    539  CB  PRO A  84      88.313  59.170  42.465  1.00101.12           C  
+ATOM    540  CG  PRO A  84      89.492  59.641  41.675  1.00101.65           C  
+ATOM    541  CD  PRO A  84      89.030  60.996  41.176  1.00101.18           C  
+ATOM    542  N   LEU A  85      84.774  59.163  41.899  1.00101.94           N  
+ATOM    543  CA  LEU A  85      83.486  59.298  42.559  1.00103.12           C  
+ATOM    544  C   LEU A  85      83.557  58.920  44.045  1.00102.98           C  
+ATOM    545  O   LEU A  85      82.918  59.560  44.883  1.00101.64           O  
+ATOM    546  CB  LEU A  85      82.439  58.438  41.834  1.00104.42           C  
+ATOM    547  CG  LEU A  85      82.649  56.917  41.741  1.00106.38           C  
+ATOM    548  CD1 LEU A  85      81.552  56.314  40.871  1.00105.71           C  
+ATOM    549  CD2 LEU A  85      84.016  56.596  41.150  1.00106.18           C  
+ATOM    550  N   GLN A  86      84.344  57.897  44.372  1.00102.75           N  
+ATOM    551  CA  GLN A  86      84.468  57.459  45.761  1.00102.94           C  
+ATOM    552  C   GLN A  86      85.268  58.455  46.600  1.00101.55           C  
+ATOM    553  O   GLN A  86      84.974  58.667  47.778  1.00101.40           O  
+ATOM    554  CB  GLN A  86      85.121  56.072  45.832  1.00104.41           C  
+ATOM    555  CG  GLN A  86      85.029  55.430  47.217  1.00108.36           C  
+ATOM    556  CD  GLN A  86      85.542  53.992  47.261  1.00110.94           C  
+ATOM    557  OE1 GLN A  86      86.735  53.737  47.083  1.00112.09           O  
+ATOM    558  NE2 GLN A  86      84.635  53.047  47.500  1.00111.60           N  
+ATOM    559  N   GLU A  87      86.277  59.066  45.989  1.00 99.65           N  
+ATOM    560  CA  GLU A  87      87.107  60.044  46.682  1.00 98.09           C  
+ATOM    561  C   GLU A  87      86.302  61.306  46.965  1.00 96.78           C  
+ATOM    562  O   GLU A  87      86.839  62.284  47.479  1.00 96.53           O  
+ATOM    563  CB  GLU A  87      88.316  60.414  45.821  1.00 99.81           C  
+ATOM    564  CG  GLU A  87      89.673  59.947  46.337  1.00101.77           C  
+ATOM    565  CD  GLU A  87      89.799  58.437  46.397  1.00103.68           C  
+ATOM    566  OE1 GLU A  87      89.435  57.847  47.439  1.00102.92           O  
+ATOM    567  OE2 GLU A  87      90.255  57.841  45.395  1.00104.13           O  
+ATOM    568  N   ILE A  88      85.015  61.280  46.627  1.00 96.60           N  
+ATOM    569  CA  ILE A  88      84.141  62.436  46.820  1.00 95.69           C  
+ATOM    570  C   ILE A  88      83.312  62.354  48.100  1.00 95.45           C  
+ATOM    571  O   ILE A  88      82.871  61.275  48.498  1.00 96.20           O  
+ATOM    572  CB  ILE A  88      83.181  62.610  45.618  1.00 95.00           C  
+ATOM    573  CG1 ILE A  88      83.980  62.627  44.309  1.00 94.78           C  
+ATOM    574  CG2 ILE A  88      82.386  63.905  45.770  1.00 93.19           C  
+ATOM    575  CD1 ILE A  88      84.981  63.770  44.196  1.00 92.24           C  
+ATOM    576  N   GLN A  89      83.091  63.507  48.726  1.00 94.15           N  
+ATOM    577  CA  GLN A  89      82.337  63.581  49.970  1.00 94.43           C  
+ATOM    578  C   GLN A  89      81.042  64.385  49.880  1.00 93.71           C  
+ATOM    579  O   GLN A  89      79.967  63.878  50.208  1.00 93.72           O  
+ATOM    580  CB  GLN A  89      83.225  64.180  51.060  1.00 97.05           C  
+ATOM    581  CG  GLN A  89      82.462  64.768  52.232  1.00 99.34           C  
+ATOM    582  CD  GLN A  89      83.289  65.774  53.013  1.00101.26           C  
+ATOM    583  OE1 GLN A  89      84.286  65.422  53.649  1.00100.01           O  
+ATOM    584  NE2 GLN A  89      82.884  67.040  52.956  1.00101.87           N  
+ATOM    585  N   ASN A  90      81.158  65.643  49.457  1.00 92.79           N  
+ATOM    586  CA  ASN A  90      80.016  66.553  49.322  1.00 90.90           C  
+ATOM    587  C   ASN A  90      78.946  65.979  48.381  1.00 90.26           C  
+ATOM    588  O   ASN A  90      78.998  66.198  47.173  1.00 91.08           O  
+ATOM    589  CB  ASN A  90      80.509  67.899  48.786  1.00 89.39           C  
+ATOM    590  CG  ASN A  90      79.440  68.970  48.821  1.00 90.70           C  
+ATOM    591  OD1 ASN A  90      78.297  68.724  48.434  1.00 92.11           O  
+ATOM    592  ND2 ASN A  90      79.822  70.163  49.277  1.00 89.55           N  
+ATOM    593  N   LEU A  91      77.977  65.257  48.940  1.00 88.12           N  
+ATOM    594  CA  LEU A  91      76.910  64.631  48.153  1.00 85.40           C  
+ATOM    595  C   LEU A  91      76.329  65.516  47.047  1.00 84.35           C  
+ATOM    596  O   LEU A  91      75.912  65.022  45.998  1.00 84.64           O  
+ATOM    597  CB  LEU A  91      75.776  64.156  49.072  1.00 83.90           C  
+ATOM    598  CG  LEU A  91      76.119  63.066  50.091  1.00 84.40           C  
+ATOM    599  CD1 LEU A  91      77.111  63.614  51.104  1.00 86.11           C  
+ATOM    600  CD2 LEU A  91      74.857  62.596  50.795  1.00 83.84           C  
+ATOM    601  N   THR A  92      76.297  66.821  47.278  1.00 81.99           N  
+ATOM    602  CA  THR A  92      75.766  67.731  46.281  1.00 80.55           C  
+ATOM    603  C   THR A  92      76.680  67.783  45.061  1.00 80.91           C  
+ATOM    604  O   THR A  92      76.205  67.939  43.927  1.00 81.61           O  
+ATOM    605  CB  THR A  92      75.608  69.140  46.851  1.00 80.63           C  
+ATOM    606  OG1 THR A  92      74.728  69.087  47.979  1.00 84.14           O  
+ATOM    607  CG2 THR A  92      75.030  70.084  45.802  1.00 79.94           C  
+ATOM    608  N   VAL A  93      77.988  67.656  45.286  1.00 76.81           N  
+ATOM    609  CA  VAL A  93      78.922  67.683  44.175  1.00 74.09           C  
+ATOM    610  C   VAL A  93      78.964  66.313  43.535  1.00 71.84           C  
+ATOM    611  O   VAL A  93      79.305  66.189  42.362  1.00 71.16           O  
+ATOM    612  CB  VAL A  93      80.353  68.070  44.603  1.00 74.81           C  
+ATOM    613  CG1 VAL A  93      80.319  69.344  45.427  1.00 75.69           C  
+ATOM    614  CG2 VAL A  93      80.998  66.938  45.352  1.00 76.40           C  
+ATOM    615  N   LYS A  94      78.608  65.283  44.298  1.00 69.93           N  
+ATOM    616  CA  LYS A  94      78.607  63.927  43.751  1.00 70.92           C  
+ATOM    617  C   LYS A  94      77.476  63.827  42.721  1.00 68.93           C  
+ATOM    618  O   LYS A  94      77.664  63.286  41.634  1.00 67.89           O  
+ATOM    619  CB  LYS A  94      78.407  62.870  44.855  1.00 70.89           C  
+ATOM    620  CG  LYS A  94      78.868  61.473  44.416  1.00 73.63           C  
+ATOM    621  CD  LYS A  94      78.466  60.351  45.379  1.00 78.15           C  
+ATOM    622  CE  LYS A  94      76.985  59.968  45.224  1.00 80.34           C  
+ATOM    623  NZ  LYS A  94      76.590  58.775  46.046  1.00 77.92           N  
+ATOM    624  N   LEU A  95      76.307  64.358  43.075  1.00 67.34           N  
+ATOM    625  CA  LEU A  95      75.151  64.358  42.178  1.00 65.87           C  
+ATOM    626  C   LEU A  95      75.542  64.924  40.824  1.00 63.56           C  
+ATOM    627  O   LEU A  95      75.390  64.263  39.799  1.00 65.40           O  
+ATOM    628  CB  LEU A  95      74.014  65.208  42.756  1.00 62.56           C  
+ATOM    629  CG  LEU A  95      73.308  64.657  43.990  1.00 62.33           C  
+ATOM    630  CD1 LEU A  95      72.277  65.681  44.480  1.00 59.82           C  
+ATOM    631  CD2 LEU A  95      72.659  63.314  43.648  1.00 55.94           C  
+ATOM    632  N   GLN A  96      76.040  66.157  40.828  1.00 62.44           N  
+ATOM    633  CA  GLN A  96      76.454  66.829  39.599  1.00 60.35           C  
+ATOM    634  C   GLN A  96      77.487  66.016  38.838  1.00 60.37           C  
+ATOM    635  O   GLN A  96      77.352  65.770  37.639  1.00 57.33           O  
+ATOM    636  CB  GLN A  96      77.039  68.193  39.930  1.00 58.70           C  
+ATOM    637  CG  GLN A  96      76.008  69.232  40.228  1.00 59.52           C  
+ATOM    638  CD  GLN A  96      76.600  70.430  40.925  1.00 59.21           C  
+ATOM    639  OE1 GLN A  96      76.848  70.395  42.126  1.00 62.83           O  
+ATOM    640  NE2 GLN A  96      76.842  71.494  40.176  1.00 57.13           N  
+ATOM    641  N   LEU A  97      78.524  65.609  39.554  1.00 60.69           N  
+ATOM    642  CA  LEU A  97      79.602  64.830  38.980  1.00 62.07           C  
+ATOM    643  C   LEU A  97      79.019  63.535  38.437  1.00 63.49           C  
+ATOM    644  O   LEU A  97      79.398  63.059  37.371  1.00 62.66           O  
+ATOM    645  CB  LEU A  97      80.635  64.548  40.066  1.00 64.03           C  
+ATOM    646  CG  LEU A  97      82.030  64.059  39.693  1.00 67.28           C  
+ATOM    647  CD1 LEU A  97      82.701  65.051  38.740  1.00 69.09           C  
+ATOM    648  CD2 LEU A  97      82.838  63.906  40.978  1.00 66.72           C  
+ATOM    649  N   GLN A  98      78.072  62.979  39.179  1.00 66.77           N  
+ATOM    650  CA  GLN A  98      77.419  61.737  38.794  1.00 69.42           C  
+ATOM    651  C   GLN A  98      76.743  61.905  37.433  1.00 69.42           C  
+ATOM    652  O   GLN A  98      77.017  61.156  36.488  1.00 68.75           O  
+ATOM    653  CB  GLN A  98      76.382  61.356  39.856  1.00 70.34           C  
+ATOM    654  CG  GLN A  98      75.971  59.894  39.866  1.00 76.34           C  
+ATOM    655  CD  GLN A  98      75.104  59.555  41.070  1.00 79.88           C  
+ATOM    656  OE1 GLN A  98      73.934  59.944  41.145  1.00 81.11           O  
+ATOM    657  NE2 GLN A  98      75.681  58.837  42.027  1.00 80.81           N  
+ATOM    658  N   ALA A  99      75.864  62.896  37.338  1.00 67.40           N  
+ATOM    659  CA  ALA A  99      75.155  63.157  36.099  1.00 68.76           C  
+ATOM    660  C   ALA A  99      76.117  63.268  34.915  1.00 71.66           C  
+ATOM    661  O   ALA A  99      75.907  62.644  33.870  1.00 72.73           O  
+ATOM    662  CB  ALA A  99      74.343  64.426  36.234  1.00 65.63           C  
+ATOM    663  N   LEU A 100      77.181  64.046  35.094  1.00 72.26           N  
+ATOM    664  CA  LEU A 100      78.174  64.267  34.052  1.00 73.07           C  
+ATOM    665  C   LEU A 100      78.997  63.075  33.544  1.00 76.69           C  
+ATOM    666  O   LEU A 100      79.096  62.867  32.331  1.00 76.47           O  
+ATOM    667  CB  LEU A 100      79.135  65.381  34.484  1.00 69.34           C  
+ATOM    668  CG  LEU A 100      78.694  66.809  34.171  1.00 65.59           C  
+ATOM    669  CD1 LEU A 100      79.789  67.812  34.524  1.00 60.84           C  
+ATOM    670  CD2 LEU A 100      78.380  66.885  32.690  1.00 62.54           C  
+ATOM    671  N   GLN A 101      79.595  62.297  34.444  1.00 79.82           N  
+ATOM    672  CA  GLN A 101      80.428  61.180  34.003  1.00 81.93           C  
+ATOM    673  C   GLN A 101      79.694  59.897  33.654  1.00 84.08           C  
+ATOM    674  O   GLN A 101      80.159  58.793  33.946  1.00 85.98           O  
+ATOM    675  CB  GLN A 101      81.533  60.893  35.025  1.00 80.73           C  
+ATOM    676  CG  GLN A 101      81.093  60.789  36.461  1.00 82.32           C  
+ATOM    677  CD  GLN A 101      82.263  60.508  37.389  1.00 82.78           C  
+ATOM    678  OE1 GLN A 101      82.902  59.458  37.298  1.00 84.07           O  
+ATOM    679  NE2 GLN A 101      82.557  61.452  38.279  1.00 79.96           N  
+ATOM    680  N   GLN A 102      78.557  60.063  32.995  1.00 85.31           N  
+ATOM    681  CA  GLN A 102      77.719  58.956  32.562  1.00 86.29           C  
+ATOM    682  C   GLN A 102      78.037  58.748  31.079  1.00 86.68           C  
+ATOM    683  O   GLN A 102      77.651  59.569  30.244  1.00 86.96           O  
+ATOM    684  CB  GLN A 102      76.259  59.359  32.749  1.00 87.37           C  
+ATOM    685  CG  GLN A 102      75.238  58.269  32.591  1.00 90.79           C  
+ATOM    686  CD  GLN A 102      73.826  58.832  32.612  1.00 93.78           C  
+ATOM    687  OE1 GLN A 102      73.459  59.584  33.519  1.00 94.22           O  
+ATOM    688  NE2 GLN A 102      73.027  58.473  31.610  1.00 93.12           N  
+ATOM    689  N   ASN A 103      78.743  57.665  30.751  1.00 86.05           N  
+ATOM    690  CA  ASN A 103      79.114  57.402  29.360  1.00 86.29           C  
+ATOM    691  C   ASN A 103      77.944  57.058  28.447  1.00 86.53           C  
+ATOM    692  O   ASN A 103      77.755  57.686  27.405  1.00 87.60           O  
+ATOM    693  CB  ASN A 103      80.153  56.283  29.274  1.00 86.71           C  
+ATOM    694  CG  ASN A 103      81.480  56.670  29.891  1.00 87.05           C  
+ATOM    695  OD1 ASN A 103      81.897  57.827  29.816  1.00 85.80           O  
+ATOM    696  ND2 ASN A 103      82.159  55.695  30.485  1.00 87.90           N  
+ATOM    697  N   GLY A 104      77.168  56.051  28.830  1.00 85.63           N  
+ATOM    698  CA  GLY A 104      76.034  55.658  28.018  1.00 82.81           C  
+ATOM    699  C   GLY A 104      76.451  54.886  26.781  1.00 81.70           C  
+ATOM    700  O   GLY A 104      77.173  53.897  26.874  1.00 81.65           O  
+ATOM    701  N   SER A 105      75.998  55.349  25.620  1.00 80.78           N  
+ATOM    702  CA  SER A 105      76.302  54.701  24.351  1.00 80.70           C  
+ATOM    703  C   SER A 105      77.760  54.838  23.938  1.00 79.24           C  
+ATOM    704  O   SER A 105      78.303  53.954  23.258  1.00 76.75           O  
+ATOM    705  CB  SER A 105      75.403  55.269  23.253  1.00 81.72           C  
+ATOM    706  OG  SER A 105      74.037  55.058  23.576  1.00 88.00           O  
+ATOM    707  N   SER A 106      78.388  55.944  24.344  1.00 77.86           N  
+ATOM    708  CA  SER A 106      79.793  56.199  24.016  1.00 75.95           C  
+ATOM    709  C   SER A 106      80.683  55.099  24.590  1.00 73.84           C  
+ATOM    710  O   SER A 106      81.875  55.044  24.302  1.00 75.28           O  
+ATOM    711  CB  SER A 106      80.242  57.557  24.572  1.00 77.50           C  
+ATOM    712  OG  SER A 106      80.443  57.497  25.979  1.00 78.57           O  
+ATOM    713  N   VAL A 107      80.096  54.226  25.405  1.00 72.41           N  
+ATOM    714  CA  VAL A 107      80.832  53.127  26.010  1.00 70.10           C  
+ATOM    715  C   VAL A 107      80.904  51.985  25.008  1.00 70.17           C  
+ATOM    716  O   VAL A 107      81.497  50.945  25.274  1.00 69.93           O  
+ATOM    717  CB  VAL A 107      80.140  52.631  27.294  1.00 69.70           C  
+ATOM    718  CG1 VAL A 107      79.086  51.592  26.950  1.00 68.25           C  
+ATOM    719  CG2 VAL A 107      81.163  52.075  28.252  1.00 67.59           C  
+ATOM    720  N   LEU A 108      80.296  52.195  23.847  1.00 70.82           N  
+ATOM    721  CA  LEU A 108      80.284  51.200  22.782  1.00 72.73           C  
+ATOM    722  C   LEU A 108      81.338  51.515  21.728  1.00 72.95           C  
+ATOM    723  O   LEU A 108      81.748  52.662  21.567  1.00 72.13           O  
+ATOM    724  CB  LEU A 108      78.907  51.152  22.101  1.00 73.55           C  
+ATOM    725  CG  LEU A 108      77.720  50.554  22.865  1.00 73.34           C  
+ATOM    726  CD1 LEU A 108      76.425  50.901  22.135  1.00 72.21           C  
+ATOM    727  CD2 LEU A 108      77.894  49.039  22.999  1.00 70.38           C  
+ATOM    728  N   SER A 109      81.763  50.484  21.006  1.00 72.80           N  
+ATOM    729  CA  SER A 109      82.748  50.645  19.953  1.00 74.11           C  
+ATOM    730  C   SER A 109      82.055  51.328  18.779  1.00 76.30           C  
+ATOM    731  O   SER A 109      80.935  50.973  18.429  1.00 78.27           O  
+ATOM    732  CB  SER A 109      83.261  49.284  19.519  1.00 71.87           C  
+ATOM    733  OG  SER A 109      82.231  48.549  18.899  1.00 69.77           O  
+ATOM    734  N   GLU A 110      82.728  52.297  18.169  1.00 77.63           N  
+ATOM    735  CA  GLU A 110      82.172  53.048  17.048  1.00 79.07           C  
+ATOM    736  C   GLU A 110      81.231  52.274  16.120  1.00 77.50           C  
+ATOM    737  O   GLU A 110      80.158  52.770  15.783  1.00 76.20           O  
+ATOM    738  CB  GLU A 110      83.303  53.676  16.229  1.00 82.04           C  
+ATOM    739  CG  GLU A 110      82.828  54.537  15.060  1.00 89.37           C  
+ATOM    740  CD  GLU A 110      81.819  55.611  15.470  1.00 92.84           C  
+ATOM    741  OE1 GLU A 110      80.670  55.260  15.829  1.00 94.08           O  
+ATOM    742  OE2 GLU A 110      82.176  56.810  15.434  1.00 94.82           O  
+ATOM    743  N   ASP A 111      81.619  51.069  15.707  1.00 75.30           N  
+ATOM    744  CA  ASP A 111      80.770  50.277  14.818  1.00 73.62           C  
+ATOM    745  C   ASP A 111      79.455  49.859  15.474  1.00 72.52           C  
+ATOM    746  O   ASP A 111      78.456  49.648  14.789  1.00 70.71           O  
+ATOM    747  CB  ASP A 111      81.507  49.026  14.323  1.00 76.22           C  
+ATOM    748  CG  ASP A 111      82.637  49.354  13.348  1.00 79.86           C  
+ATOM    749  OD1 ASP A 111      82.485  50.305  12.545  1.00 79.21           O  
+ATOM    750  OD2 ASP A 111      83.671  48.649  13.373  1.00 80.87           O  
+ATOM    751  N   LYS A 112      79.465  49.733  16.798  1.00 69.70           N  
+ATOM    752  CA  LYS A 112      78.271  49.355  17.542  1.00 67.28           C  
+ATOM    753  C   LYS A 112      77.348  50.573  17.684  1.00 64.91           C  
+ATOM    754  O   LYS A 112      76.159  50.505  17.382  1.00 59.06           O  
+ATOM    755  CB  LYS A 112      78.652  48.828  18.931  1.00 67.06           C  
+ATOM    756  CG  LYS A 112      79.386  47.472  18.942  1.00 67.82           C  
+ATOM    757  CD  LYS A 112      78.482  46.326  18.522  1.00 66.20           C  
+ATOM    758  CE  LYS A 112      79.161  44.969  18.709  1.00 68.16           C  
+ATOM    759  NZ  LYS A 112      79.490  44.663  20.129  1.00 61.37           N  
+ATOM    760  N   SER A 113      77.918  51.681  18.145  1.00 62.69           N  
+ATOM    761  CA  SER A 113      77.179  52.919  18.330  1.00 61.31           C  
+ATOM    762  C   SER A 113      76.535  53.338  17.021  1.00 59.74           C  
+ATOM    763  O   SER A 113      75.415  53.843  16.996  1.00 60.06           O  
+ATOM    764  CB  SER A 113      78.122  54.024  18.803  1.00 59.82           C  
+ATOM    765  OG  SER A 113      78.666  53.704  20.063  1.00 66.04           O  
+ATOM    766  N   LYS A 114      77.262  53.129  15.937  1.00 58.88           N  
+ATOM    767  CA  LYS A 114      76.780  53.483  14.620  1.00 60.41           C  
+ATOM    768  C   LYS A 114      75.565  52.613  14.299  1.00 58.30           C  
+ATOM    769  O   LYS A 114      74.527  53.110  13.847  1.00 58.52           O  
+ATOM    770  CB  LYS A 114      77.895  53.266  13.582  1.00 63.11           C  
+ATOM    771  CG  LYS A 114      77.747  54.072  12.281  1.00 67.88           C  
+ATOM    772  CD  LYS A 114      76.562  53.593  11.447  1.00 73.84           C  
+ATOM    773  CE  LYS A 114      76.383  54.428  10.186  1.00 76.98           C  
+ATOM    774  NZ  LYS A 114      75.981  55.826  10.498  1.00 76.33           N  
+ATOM    775  N   ARG A 115      75.685  51.316  14.545  1.00 56.55           N  
+ATOM    776  CA  ARG A 115      74.581  50.403  14.250  1.00 56.91           C  
+ATOM    777  C   ARG A 115      73.374  50.701  15.139  1.00 55.18           C  
+ATOM    778  O   ARG A 115      72.245  50.753  14.653  1.00 54.01           O  
+ATOM    779  CB  ARG A 115      75.036  48.950  14.414  1.00 57.34           C  
+ATOM    780  CG  ARG A 115      73.969  47.912  14.153  1.00 56.61           C  
+ATOM    781  CD  ARG A 115      73.419  48.003  12.743  1.00 62.62           C  
+ATOM    782  NE  ARG A 115      72.361  47.016  12.532  1.00 64.22           N  
+ATOM    783  CZ  ARG A 115      71.500  47.034  11.522  1.00 64.74           C  
+ATOM    784  NH1 ARG A 115      70.576  46.087  11.430  1.00 66.05           N  
+ATOM    785  NH2 ARG A 115      71.555  47.995  10.609  1.00 66.49           N  
+ATOM    786  N   LEU A 116      73.611  50.925  16.429  1.00 54.28           N  
+ATOM    787  CA  LEU A 116      72.517  51.224  17.342  1.00 54.49           C  
+ATOM    788  C   LEU A 116      71.779  52.475  16.879  1.00 55.82           C  
+ATOM    789  O   LEU A 116      70.548  52.496  16.875  1.00 59.76           O  
+ATOM    790  CB  LEU A 116      73.022  51.428  18.776  1.00 51.14           C  
+ATOM    791  CG  LEU A 116      71.982  51.965  19.777  1.00 53.12           C  
+ATOM    792  CD1 LEU A 116      70.786  51.023  19.816  1.00 53.21           C  
+ATOM    793  CD2 LEU A 116      72.588  52.107  21.179  1.00 47.25           C  
+ATOM    794  N   ASN A 117      72.515  53.513  16.483  1.00 53.56           N  
+ATOM    795  CA  ASN A 117      71.871  54.743  16.034  1.00 53.15           C  
+ATOM    796  C   ASN A 117      71.046  54.520  14.768  1.00 49.72           C  
+ATOM    797  O   ASN A 117      69.964  55.082  14.614  1.00 48.28           O  
+ATOM    798  CB  ASN A 117      72.910  55.855  15.819  1.00 55.23           C  
+ATOM    799  CG  ASN A 117      73.374  56.472  17.130  1.00 60.81           C  
+ATOM    800  OD1 ASN A 117      72.657  56.422  18.143  1.00 63.42           O  
+ATOM    801  ND2 ASN A 117      74.567  57.065  17.123  1.00 60.10           N  
+ATOM    802  N   THR A 118      71.567  53.698  13.870  1.00 49.21           N  
+ATOM    803  CA  THR A 118      70.867  53.365  12.646  1.00 51.63           C  
+ATOM    804  C   THR A 118      69.569  52.658  13.041  1.00 51.25           C  
+ATOM    805  O   THR A 118      68.491  53.029  12.593  1.00 53.22           O  
+ATOM    806  CB  THR A 118      71.732  52.443  11.757  1.00 54.31           C  
+ATOM    807  OG1 THR A 118      72.881  53.165  11.303  1.00 57.83           O  
+ATOM    808  CG2 THR A 118      70.955  51.963  10.560  1.00 54.78           C  
+ATOM    809  N   ILE A 119      69.664  51.662  13.911  1.00 48.76           N  
+ATOM    810  CA  ILE A 119      68.468  50.955  14.345  1.00 47.22           C  
+ATOM    811  C   ILE A 119      67.450  51.875  14.998  1.00 46.84           C  
+ATOM    812  O   ILE A 119      66.256  51.755  14.758  1.00 48.59           O  
+ATOM    813  CB  ILE A 119      68.798  49.812  15.320  1.00 44.09           C  
+ATOM    814  CG1 ILE A 119      69.518  48.694  14.569  1.00 43.60           C  
+ATOM    815  CG2 ILE A 119      67.528  49.241  15.903  1.00 43.23           C  
+ATOM    816  CD1 ILE A 119      69.941  47.559  15.468  1.00 49.95           C  
+ATOM    817  N   LEU A 120      67.901  52.796  15.833  1.00 48.35           N  
+ATOM    818  CA  LEU A 120      66.948  53.704  16.463  1.00 50.24           C  
+ATOM    819  C   LEU A 120      66.272  54.572  15.385  1.00 50.80           C  
+ATOM    820  O   LEU A 120      65.044  54.702  15.362  1.00 49.35           O  
+ATOM    821  CB  LEU A 120      67.648  54.583  17.511  1.00 47.47           C  
+ATOM    822  CG  LEU A 120      68.163  53.846  18.761  1.00 52.58           C  
+ATOM    823  CD1 LEU A 120      69.080  54.755  19.605  1.00 48.80           C  
+ATOM    824  CD2 LEU A 120      66.970  53.376  19.590  1.00 49.48           C  
+ATOM    825  N   ASN A 121      67.062  55.141  14.476  1.00 50.93           N  
+ATOM    826  CA  ASN A 121      66.481  55.991  13.439  1.00 51.01           C  
+ATOM    827  C   ASN A 121      65.528  55.233  12.542  1.00 49.39           C  
+ATOM    828  O   ASN A 121      64.476  55.750  12.161  1.00 50.26           O  
+ATOM    829  CB  ASN A 121      67.580  56.664  12.614  1.00 50.01           C  
+ATOM    830  CG  ASN A 121      68.338  57.707  13.424  1.00 58.41           C  
+ATOM    831  OD1 ASN A 121      67.734  58.490  14.170  1.00 57.76           O  
+ATOM    832  ND2 ASN A 121      69.662  57.727  13.284  1.00 60.24           N  
+ATOM    833  N   THR A 122      65.883  53.997  12.225  1.00 48.30           N  
+ATOM    834  CA  THR A 122      65.047  53.173  11.376  1.00 47.20           C  
+ATOM    835  C   THR A 122      63.721  52.848  12.059  1.00 50.34           C  
+ATOM    836  O   THR A 122      62.668  53.048  11.463  1.00 52.08           O  
+ATOM    837  CB  THR A 122      65.770  51.866  10.996  1.00 46.23           C  
+ATOM    838  OG1 THR A 122      67.089  52.178  10.535  1.00 44.13           O  
+ATOM    839  CG2 THR A 122      65.018  51.135   9.875  1.00 43.39           C  
+ATOM    840  N   MET A 123      63.760  52.366  13.307  1.00 48.98           N  
+ATOM    841  CA  MET A 123      62.524  52.019  14.005  1.00 47.15           C  
+ATOM    842  C   MET A 123      61.659  53.259  14.096  1.00 46.96           C  
+ATOM    843  O   MET A 123      60.433  53.217  13.944  1.00 46.14           O  
+ATOM    844  CB  MET A 123      62.793  51.502  15.437  1.00 46.47           C  
+ATOM    845  CG  MET A 123      63.479  50.138  15.547  1.00 46.52           C  
+ATOM    846  SD  MET A 123      63.332  49.382  17.211  1.00 48.13           S  
+ATOM    847  CE  MET A 123      64.448  50.456  18.191  1.00 43.47           C  
+ATOM    848  N   SER A 124      62.312  54.379  14.357  1.00 45.10           N  
+ATOM    849  CA  SER A 124      61.589  55.624  14.490  1.00 45.57           C  
+ATOM    850  C   SER A 124      60.860  56.046  13.217  1.00 43.30           C  
+ATOM    851  O   SER A 124      59.719  56.507  13.263  1.00 42.41           O  
+ATOM    852  CB  SER A 124      62.540  56.736  14.900  1.00 42.83           C  
+ATOM    853  OG  SER A 124      61.793  57.887  15.187  1.00 45.69           O  
+ATOM    854  N   THR A 125      61.531  55.904  12.087  1.00 44.99           N  
+ATOM    855  CA  THR A 125      60.933  56.316  10.839  1.00 49.14           C  
+ATOM    856  C   THR A 125      59.851  55.359  10.384  1.00 49.29           C  
+ATOM    857  O   THR A 125      58.810  55.821   9.939  1.00 49.80           O  
+ATOM    858  CB  THR A 125      61.984  56.488   9.721  1.00 48.30           C  
+ATOM    859  OG1 THR A 125      62.567  55.221   9.425  1.00 60.68           O  
+ATOM    860  CG2 THR A 125      63.074  57.442  10.154  1.00 47.17           C  
+ATOM    861  N   ILE A 126      60.051  54.041  10.499  1.00 47.56           N  
+ATOM    862  CA  ILE A 126      58.982  53.159  10.047  1.00 46.49           C  
+ATOM    863  C   ILE A 126      57.745  53.405  10.906  1.00 45.92           C  
+ATOM    864  O   ILE A 126      56.631  53.217  10.438  1.00 45.77           O  
+ATOM    865  CB  ILE A 126      59.344  51.645  10.101  1.00 51.70           C  
+ATOM    866  CG1 ILE A 126      59.015  51.084  11.462  1.00 50.90           C  
+ATOM    867  CG2 ILE A 126      60.797  51.403   9.765  1.00 50.94           C  
+ATOM    868  CD1 ILE A 126      57.683  50.380  11.474  1.00 58.81           C  
+ATOM    869  N   TYR A 127      57.927  53.848  12.153  1.00 40.08           N  
+ATOM    870  CA  TYR A 127      56.781  54.134  13.021  1.00 38.45           C  
+ATOM    871  C   TYR A 127      56.031  55.392  12.589  1.00 40.30           C  
+ATOM    872  O   TYR A 127      54.796  55.443  12.595  1.00 41.50           O  
+ATOM    873  CB  TYR A 127      57.235  54.342  14.488  1.00 37.76           C  
+ATOM    874  CG  TYR A 127      56.097  54.626  15.461  1.00 34.98           C  
+ATOM    875  CD1 TYR A 127      55.652  55.924  15.717  1.00 36.37           C  
+ATOM    876  CD2 TYR A 127      55.431  53.583  16.076  1.00 36.29           C  
+ATOM    877  CE1 TYR A 127      54.579  56.146  16.552  1.00 31.00           C  
+ATOM    878  CE2 TYR A 127      54.366  53.801  16.897  1.00 31.26           C  
+ATOM    879  CZ  TYR A 127      53.943  55.055  17.137  1.00 33.23           C  
+ATOM    880  OH  TYR A 127      52.877  55.178  18.003  1.00 35.94           O  
+ATOM    881  N   SER A 128      56.772  56.426  12.222  1.00 40.35           N  
+ATOM    882  CA  SER A 128      56.105  57.671  11.861  1.00 44.39           C  
+ATOM    883  C   SER A 128      55.733  57.731  10.396  1.00 42.49           C  
+ATOM    884  O   SER A 128      54.978  58.593  10.004  1.00 43.42           O  
+ATOM    885  CB  SER A 128      56.991  58.865  12.189  1.00 42.39           C  
+ATOM    886  OG  SER A 128      58.140  58.831  11.374  1.00 52.66           O  
+ATOM    887  N   THR A 129      56.217  56.784   9.609  1.00 42.60           N  
+ATOM    888  CA  THR A 129      55.948  56.814   8.190  1.00 47.13           C  
+ATOM    889  C   THR A 129      55.283  55.561   7.621  1.00 47.30           C  
+ATOM    890  O   THR A 129      54.889  55.530   6.460  1.00 48.95           O  
+ATOM    891  CB  THR A 129      57.261  57.137   7.442  1.00 48.29           C  
+ATOM    892  OG1 THR A 129      56.946  57.652   6.151  1.00 63.79           O  
+ATOM    893  CG2 THR A 129      58.134  55.906   7.304  1.00 41.73           C  
+ATOM    894  N   GLY A 130      55.135  54.537   8.449  1.00 46.75           N  
+ATOM    895  CA  GLY A 130      54.501  53.321   7.988  1.00 45.85           C  
+ATOM    896  C   GLY A 130      53.027  53.545   7.720  1.00 47.69           C  
+ATOM    897  O   GLY A 130      52.381  54.400   8.338  1.00 45.48           O  
+ATOM    898  N   LYS A 131      52.473  52.780   6.793  1.00 47.64           N  
+ATOM    899  CA  LYS A 131      51.064  52.933   6.486  1.00 50.98           C  
+ATOM    900  C   LYS A 131      50.390  51.629   6.113  1.00 49.80           C  
+ATOM    901  O   LYS A 131      51.036  50.662   5.722  1.00 50.68           O  
+ATOM    902  CB  LYS A 131      50.877  53.969   5.365  1.00 51.67           C  
+ATOM    903  CG  LYS A 131      51.687  53.705   4.124  1.00 61.30           C  
+ATOM    904  CD  LYS A 131      51.525  54.873   3.156  1.00 66.53           C  
+ATOM    905  CE  LYS A 131      51.687  56.207   3.892  1.00 68.37           C  
+ATOM    906  NZ  LYS A 131      51.442  57.407   3.029  1.00 69.30           N  
+ATOM    907  N   VAL A 132      49.078  51.588   6.253  1.00 50.20           N  
+ATOM    908  CA  VAL A 132      48.368  50.375   5.888  1.00 53.55           C  
+ATOM    909  C   VAL A 132      47.398  50.789   4.795  1.00 54.86           C  
+ATOM    910  O   VAL A 132      46.951  51.936   4.760  1.00 55.43           O  
+ATOM    911  CB  VAL A 132      47.601  49.770   7.093  1.00 51.16           C  
+ATOM    912  CG1 VAL A 132      48.560  49.474   8.216  1.00 49.54           C  
+ATOM    913  CG2 VAL A 132      46.544  50.712   7.564  1.00 49.77           C  
+ATOM    914  N   CYS A 133      47.078  49.877   3.891  1.00 55.50           N  
+ATOM    915  CA  CYS A 133      46.162  50.239   2.822  1.00 56.53           C  
+ATOM    916  C   CYS A 133      44.901  49.385   2.861  1.00 55.57           C  
+ATOM    917  O   CYS A 133      44.922  48.240   3.314  1.00 56.66           O  
+ATOM    918  CB  CYS A 133      46.850  50.103   1.462  1.00 55.34           C  
+ATOM    919  SG  CYS A 133      48.441  50.985   1.264  1.00 65.94           S  
+ATOM    920  N   ASN A 134      43.801  49.969   2.403  1.00 54.31           N  
+ATOM    921  CA  ASN A 134      42.521  49.298   2.349  1.00 57.20           C  
+ATOM    922  C   ASN A 134      42.594  48.046   1.466  1.00 59.43           C  
+ATOM    923  O   ASN A 134      43.139  48.085   0.362  1.00 60.82           O  
+ATOM    924  CB  ASN A 134      41.481  50.247   1.783  1.00 57.36           C  
+ATOM    925  CG  ASN A 134      40.112  49.625   1.724  1.00 60.31           C  
+ATOM    926  OD1 ASN A 134      39.974  48.442   1.437  1.00 56.89           O  
+ATOM    927  ND2 ASN A 134      39.085  50.424   1.983  1.00 65.29           N  
+ATOM    928  N   PRO A 135      42.042  46.916   1.942  1.00 60.03           N  
+ATOM    929  CA  PRO A 135      42.080  45.687   1.146  1.00 62.56           C  
+ATOM    930  C   PRO A 135      41.287  45.824  -0.159  1.00 64.29           C  
+ATOM    931  O   PRO A 135      41.653  45.244  -1.176  1.00 63.40           O  
+ATOM    932  CB  PRO A 135      41.468  44.641   2.082  1.00 64.43           C  
+ATOM    933  CG  PRO A 135      41.719  45.212   3.467  1.00 65.12           C  
+ATOM    934  CD  PRO A 135      41.421  46.672   3.255  1.00 61.42           C  
+ATOM    935  N   ASP A 136      40.206  46.599  -0.122  1.00 65.66           N  
+ATOM    936  CA  ASP A 136      39.373  46.794  -1.297  1.00 66.13           C  
+ATOM    937  C   ASP A 136      39.838  47.973  -2.155  1.00 65.17           C  
+ATOM    938  O   ASP A 136      39.188  48.329  -3.144  1.00 67.32           O  
+ATOM    939  CB  ASP A 136      37.901  46.974  -0.892  1.00 69.62           C  
+ATOM    940  CG  ASP A 136      37.477  48.438  -0.812  1.00 78.34           C  
+ATOM    941  OD1 ASP A 136      37.540  49.027   0.294  1.00 81.73           O  
+ATOM    942  OD2 ASP A 136      37.077  49.006  -1.861  1.00 82.61           O  
+ATOM    943  N   ASN A 137      40.963  48.577  -1.776  1.00 60.44           N  
+ATOM    944  CA  ASN A 137      41.524  49.695  -2.532  1.00 54.21           C  
+ATOM    945  C   ASN A 137      42.949  49.967  -2.085  1.00 51.34           C  
+ATOM    946  O   ASN A 137      43.185  50.758  -1.182  1.00 48.64           O  
+ATOM    947  CB  ASN A 137      40.675  50.954  -2.357  1.00 51.81           C  
+ATOM    948  CG  ASN A 137      41.207  52.126  -3.160  1.00 51.54           C  
+ATOM    949  OD1 ASN A 137      40.627  53.211  -3.149  1.00 53.27           O  
+ATOM    950  ND2 ASN A 137      42.317  51.916  -3.858  1.00 50.08           N  
+ATOM    951  N   PRO A 138      43.919  49.301  -2.730  1.00 50.59           N  
+ATOM    952  CA  PRO A 138      45.359  49.390  -2.481  1.00 49.58           C  
+ATOM    953  C   PRO A 138      45.917  50.808  -2.549  1.00 51.18           C  
+ATOM    954  O   PRO A 138      47.037  51.049  -2.115  1.00 50.92           O  
+ATOM    955  CB  PRO A 138      45.948  48.501  -3.569  1.00 49.37           C  
+ATOM    956  CG  PRO A 138      44.881  47.453  -3.767  1.00 46.67           C  
+ATOM    957  CD  PRO A 138      43.631  48.302  -3.775  1.00 49.05           C  
+ATOM    958  N   GLN A 139      45.139  51.739  -3.095  1.00 49.29           N  
+ATOM    959  CA  GLN A 139      45.588  53.122  -3.225  1.00 49.72           C  
+ATOM    960  C   GLN A 139      45.112  54.014  -2.064  1.00 50.19           C  
+ATOM    961  O   GLN A 139      45.552  55.151  -1.918  1.00 46.16           O  
+ATOM    962  CB  GLN A 139      45.131  53.702  -4.577  1.00 49.39           C  
+ATOM    963  CG  GLN A 139      45.943  53.205  -5.781  1.00 47.81           C  
+ATOM    964  CD  GLN A 139      45.794  51.714  -6.029  1.00 48.35           C  
+ATOM    965  OE1 GLN A 139      46.781  50.973  -6.067  1.00 51.48           O  
+ATOM    966  NE2 GLN A 139      44.553  51.263  -6.187  1.00 48.01           N  
+ATOM    967  N   GLU A 140      44.211  53.493  -1.246  1.00 49.85           N  
+ATOM    968  CA  GLU A 140      43.736  54.243  -0.098  1.00 54.96           C  
+ATOM    969  C   GLU A 140      44.618  53.740   1.038  1.00 55.47           C  
+ATOM    970  O   GLU A 140      44.456  52.618   1.505  1.00 57.42           O  
+ATOM    971  CB  GLU A 140      42.270  53.918   0.192  1.00 56.94           C  
+ATOM    972  CG  GLU A 140      41.594  54.936   1.088  1.00 63.65           C  
+ATOM    973  CD  GLU A 140      40.349  54.394   1.762  1.00 68.96           C  
+ATOM    974  OE1 GLU A 140      39.490  53.803   1.071  1.00 71.10           O  
+ATOM    975  OE2 GLU A 140      40.225  54.571   2.994  1.00 75.40           O  
+ATOM    976  N   CYS A 141      45.579  54.547   1.454  1.00 55.78           N  
+ATOM    977  CA  CYS A 141      46.478  54.133   2.519  1.00 58.91           C  
+ATOM    978  C   CYS A 141      46.462  55.160   3.650  1.00 58.76           C  
+ATOM    979  O   CYS A 141      46.368  56.365   3.411  1.00 61.75           O  
+ATOM    980  CB  CYS A 141      47.890  53.964   1.960  1.00 59.51           C  
+ATOM    981  SG  CYS A 141      48.007  52.838   0.521  1.00 62.56           S  
+ATOM    982  N   LEU A 142      46.540  54.674   4.881  1.00 56.14           N  
+ATOM    983  CA  LEU A 142      46.503  55.534   6.059  1.00 53.31           C  
+ATOM    984  C   LEU A 142      47.755  55.417   6.927  1.00 51.99           C  
+ATOM    985  O   LEU A 142      48.331  54.339   7.062  1.00 52.02           O  
+ATOM    986  CB  LEU A 142      45.297  55.174   6.924  1.00 57.03           C  
+ATOM    987  CG  LEU A 142      43.889  55.142   6.319  1.00 59.17           C  
+ATOM    988  CD1 LEU A 142      42.958  54.446   7.300  1.00 55.95           C  
+ATOM    989  CD2 LEU A 142      43.391  56.561   6.031  1.00 58.25           C  
+ATOM    990  N   LEU A 143      48.162  56.541   7.506  1.00 48.95           N  
+ATOM    991  CA  LEU A 143      49.295  56.593   8.412  1.00 48.13           C  
+ATOM    992  C   LEU A 143      48.657  56.384   9.777  1.00 45.99           C  
+ATOM    993  O   LEU A 143      47.433  56.454   9.908  1.00 40.81           O  
+ATOM    994  CB  LEU A 143      49.966  57.985   8.404  1.00 47.10           C  
+ATOM    995  CG  LEU A 143      50.868  58.424   7.239  1.00 51.40           C  
+ATOM    996  CD1 LEU A 143      50.154  58.187   5.924  1.00 57.98           C  
+ATOM    997  CD2 LEU A 143      51.207  59.905   7.365  1.00 51.36           C  
+ATOM    998  N   LEU A 144      49.476  56.131  10.793  1.00 46.17           N  
+ATOM    999  CA  LEU A 144      48.952  55.970  12.149  1.00 45.50           C  
+ATOM   1000  C   LEU A 144      48.264  57.285  12.518  1.00 40.89           C  
+ATOM   1001  O   LEU A 144      47.152  57.301  13.040  1.00 44.40           O  
+ATOM   1002  CB  LEU A 144      50.096  55.719  13.140  1.00 43.15           C  
+ATOM   1003  CG  LEU A 144      49.602  55.714  14.578  1.00 46.53           C  
+ATOM   1004  CD1 LEU A 144      48.563  54.587  14.711  1.00 44.11           C  
+ATOM   1005  CD2 LEU A 144      50.766  55.521  15.560  1.00 45.33           C  
+ATOM   1006  N   GLU A 145      48.950  58.387  12.247  1.00 40.22           N  
+ATOM   1007  CA  GLU A 145      48.428  59.710  12.566  1.00 45.82           C  
+ATOM   1008  C   GLU A 145      48.334  60.625  11.347  1.00 46.65           C  
+ATOM   1009  O   GLU A 145      49.345  60.955  10.735  1.00 48.94           O  
+ATOM   1010  CB  GLU A 145      49.323  60.389  13.601  1.00 43.82           C  
+ATOM   1011  CG  GLU A 145      48.967  61.856  13.874  1.00 46.73           C  
+ATOM   1012  CD  GLU A 145      47.614  62.057  14.557  1.00 49.80           C  
+ATOM   1013  OE1 GLU A 145      47.046  61.099  15.124  1.00 51.55           O  
+ATOM   1014  OE2 GLU A 145      47.115  63.203  14.548  1.00 57.46           O  
+ATOM   1015  N   PRO A 146      47.119  61.034  10.977  1.00 49.70           N  
+ATOM   1016  CA  PRO A 146      45.873  60.670  11.646  1.00 51.88           C  
+ATOM   1017  C   PRO A 146      45.413  59.501  10.801  1.00 53.11           C  
+ATOM   1018  O   PRO A 146      46.190  58.980  10.009  1.00 60.08           O  
+ATOM   1019  CB  PRO A 146      45.018  61.906  11.422  1.00 51.21           C  
+ATOM   1020  CG  PRO A 146      45.347  62.229   9.969  1.00 47.66           C  
+ATOM   1021  CD  PRO A 146      46.855  61.975   9.865  1.00 52.49           C  
+ATOM   1022  N   GLY A 147      44.183  59.058  10.931  1.00 51.56           N  
+ATOM   1023  CA  GLY A 147      43.800  57.974  10.044  1.00 48.02           C  
+ATOM   1024  C   GLY A 147      43.481  56.742  10.829  1.00 47.73           C  
+ATOM   1025  O   GLY A 147      42.323  56.462  11.112  1.00 48.02           O  
+ATOM   1026  N   LEU A 148      44.521  56.001  11.178  1.00 45.46           N  
+ATOM   1027  CA  LEU A 148      44.349  54.808  11.970  1.00 43.23           C  
+ATOM   1028  C   LEU A 148      43.917  55.280  13.365  1.00 42.90           C  
+ATOM   1029  O   LEU A 148      43.041  54.680  13.995  1.00 44.98           O  
+ATOM   1030  CB  LEU A 148      45.669  54.045  12.010  1.00 41.48           C  
+ATOM   1031  CG  LEU A 148      45.701  52.754  11.196  1.00 44.84           C  
+ATOM   1032  CD1 LEU A 148      44.750  52.804  10.023  1.00 43.39           C  
+ATOM   1033  CD2 LEU A 148      47.116  52.509  10.744  1.00 48.53           C  
+ATOM   1034  N   ASN A 149      44.517  56.367  13.836  1.00 41.64           N  
+ATOM   1035  CA  ASN A 149      44.164  56.914  15.139  1.00 43.15           C  
+ATOM   1036  C   ASN A 149      42.729  57.403  15.103  1.00 45.76           C  
+ATOM   1037  O   ASN A 149      41.961  57.184  16.051  1.00 45.90           O  
+ATOM   1038  CB  ASN A 149      45.060  58.110  15.496  1.00 43.87           C  
+ATOM   1039  CG  ASN A 149      46.413  57.702  16.082  1.00 46.60           C  
+ATOM   1040  OD1 ASN A 149      47.328  58.519  16.133  1.00 42.68           O  
+ATOM   1041  ND2 ASN A 149      46.539  56.446  16.534  1.00 40.19           N  
+ATOM   1042  N   GLU A 150      42.359  58.077  14.013  1.00 45.75           N  
+ATOM   1043  CA  GLU A 150      41.004  58.623  13.911  1.00 45.88           C  
+ATOM   1044  C   GLU A 150      39.992  57.508  13.997  1.00 46.49           C  
+ATOM   1045  O   GLU A 150      38.947  57.647  14.641  1.00 46.67           O  
+ATOM   1046  CB  GLU A 150      40.824  59.413  12.612  1.00 49.52           C  
+ATOM   1047  CG  GLU A 150      39.487  60.157  12.518  1.00 56.91           C  
+ATOM   1048  CD  GLU A 150      38.318  59.240  12.153  1.00 60.78           C  
+ATOM   1049  OE1 GLU A 150      37.155  59.559  12.507  1.00 61.93           O  
+ATOM   1050  OE2 GLU A 150      38.564  58.205  11.492  1.00 61.58           O  
+ATOM   1051  N   ILE A 151      40.316  56.392  13.354  1.00 46.61           N  
+ATOM   1052  CA  ILE A 151      39.449  55.222  13.363  1.00 45.61           C  
+ATOM   1053  C   ILE A 151      39.367  54.592  14.741  1.00 45.90           C  
+ATOM   1054  O   ILE A 151      38.280  54.354  15.255  1.00 45.76           O  
+ATOM   1055  CB  ILE A 151      39.978  54.116  12.431  1.00 48.45           C  
+ATOM   1056  CG1 ILE A 151      39.795  54.509  10.965  1.00 46.05           C  
+ATOM   1057  CG2 ILE A 151      39.276  52.800  12.746  1.00 44.08           C  
+ATOM   1058  CD1 ILE A 151      40.455  53.525  10.025  1.00 43.84           C  
+ATOM   1059  N   MET A 152      40.524  54.298  15.333  1.00 46.46           N  
+ATOM   1060  CA  MET A 152      40.549  53.641  16.635  1.00 43.94           C  
+ATOM   1061  C   MET A 152      39.879  54.447  17.732  1.00 43.28           C  
+ATOM   1062  O   MET A 152      39.441  53.893  18.751  1.00 41.67           O  
+ATOM   1063  CB  MET A 152      41.992  53.283  17.022  1.00 46.92           C  
+ATOM   1064  CG  MET A 152      42.666  52.293  16.051  1.00 45.27           C  
+ATOM   1065  SD  MET A 152      41.630  50.809  15.760  1.00 47.16           S  
+ATOM   1066  CE  MET A 152      41.820  49.985  17.417  1.00 33.26           C  
+ATOM   1067  N   ALA A 153      39.750  55.750  17.510  1.00 42.12           N  
+ATOM   1068  CA  ALA A 153      39.122  56.606  18.501  1.00 43.24           C  
+ATOM   1069  C   ALA A 153      37.641  56.851  18.247  1.00 48.17           C  
+ATOM   1070  O   ALA A 153      36.877  57.086  19.199  1.00 47.00           O  
+ATOM   1071  CB  ALA A 153      39.848  57.943  18.565  1.00 40.64           C  
+ATOM   1072  N   ASN A 154      37.217  56.770  16.984  1.00 46.85           N  
+ATOM   1073  CA  ASN A 154      35.824  57.091  16.669  1.00 50.97           C  
+ATOM   1074  C   ASN A 154      34.909  56.023  16.070  1.00 51.30           C  
+ATOM   1075  O   ASN A 154      33.689  56.130  16.186  1.00 51.95           O  
+ATOM   1076  CB  ASN A 154      35.793  58.331  15.765  1.00 50.93           C  
+ATOM   1077  CG  ASN A 154      36.523  59.524  16.384  1.00 55.23           C  
+ATOM   1078  OD1 ASN A 154      37.568  59.957  15.893  1.00 58.09           O  
+ATOM   1079  ND2 ASN A 154      35.981  60.044  17.474  1.00 56.25           N  
+ATOM   1080  N   SER A 155      35.485  54.995  15.457  1.00 49.70           N  
+ATOM   1081  CA  SER A 155      34.696  53.955  14.827  1.00 49.68           C  
+ATOM   1082  C   SER A 155      33.960  53.047  15.794  1.00 51.93           C  
+ATOM   1083  O   SER A 155      34.461  52.757  16.882  1.00 51.95           O  
+ATOM   1084  CB  SER A 155      35.588  53.112  13.912  1.00 49.14           C  
+ATOM   1085  OG  SER A 155      34.903  51.957  13.462  1.00 46.51           O  
+ATOM   1086  N   LEU A 156      32.765  52.599  15.385  1.00 52.43           N  
+ATOM   1087  CA  LEU A 156      31.952  51.693  16.200  1.00 50.67           C  
+ATOM   1088  C   LEU A 156      31.741  50.389  15.460  1.00 50.97           C  
+ATOM   1089  O   LEU A 156      30.897  49.579  15.843  1.00 52.49           O  
+ATOM   1090  CB  LEU A 156      30.586  52.306  16.530  1.00 50.55           C  
+ATOM   1091  CG  LEU A 156      30.505  53.272  17.715  1.00 52.54           C  
+ATOM   1092  CD1 LEU A 156      31.596  54.303  17.602  1.00 57.37           C  
+ATOM   1093  CD2 LEU A 156      29.149  53.969  17.726  1.00 58.98           C  
+ATOM   1094  N   ASP A 157      32.506  50.189  14.394  1.00 51.91           N  
+ATOM   1095  CA  ASP A 157      32.399  48.974  13.598  1.00 51.79           C  
+ATOM   1096  C   ASP A 157      33.478  47.962  13.986  1.00 51.03           C  
+ATOM   1097  O   ASP A 157      34.657  48.182  13.756  1.00 52.92           O  
+ATOM   1098  CB  ASP A 157      32.534  49.302  12.116  1.00 54.76           C  
+ATOM   1099  CG  ASP A 157      32.530  48.057  11.249  1.00 61.26           C  
+ATOM   1100  OD1 ASP A 157      31.545  47.844  10.521  1.00 69.21           O  
+ATOM   1101  OD2 ASP A 157      33.504  47.277  11.304  1.00 64.53           O  
+ATOM   1102  N   TYR A 158      33.059  46.847  14.556  1.00 48.99           N  
+ATOM   1103  CA  TYR A 158      33.975  45.811  14.984  1.00 51.52           C  
+ATOM   1104  C   TYR A 158      35.003  45.436  13.911  1.00 53.70           C  
+ATOM   1105  O   TYR A 158      36.206  45.365  14.187  1.00 54.40           O  
+ATOM   1106  CB  TYR A 158      33.177  44.568  15.400  1.00 48.22           C  
+ATOM   1107  CG  TYR A 158      33.998  43.467  16.031  1.00 48.10           C  
+ATOM   1108  CD1 TYR A 158      34.096  43.350  17.412  1.00 48.60           C  
+ATOM   1109  CD2 TYR A 158      34.672  42.535  15.249  1.00 46.54           C  
+ATOM   1110  CE1 TYR A 158      34.839  42.331  17.997  1.00 46.55           C  
+ATOM   1111  CE2 TYR A 158      35.421  41.521  15.828  1.00 42.71           C  
+ATOM   1112  CZ  TYR A 158      35.495  41.425  17.199  1.00 45.44           C  
+ATOM   1113  OH  TYR A 158      36.229  40.412  17.778  1.00 50.38           O  
+ATOM   1114  N   ASN A 159      34.544  45.205  12.687  1.00 52.29           N  
+ATOM   1115  CA  ASN A 159      35.469  44.804  11.635  1.00 51.36           C  
+ATOM   1116  C   ASN A 159      36.453  45.867  11.186  1.00 46.61           C  
+ATOM   1117  O   ASN A 159      37.616  45.566  10.944  1.00 45.96           O  
+ATOM   1118  CB  ASN A 159      34.702  44.270  10.425  1.00 51.22           C  
+ATOM   1119  CG  ASN A 159      33.805  43.106  10.784  1.00 55.05           C  
+ATOM   1120  OD1 ASN A 159      34.214  42.182  11.500  1.00 54.52           O  
+ATOM   1121  ND2 ASN A 159      32.575  43.135  10.278  1.00 53.89           N  
+ATOM   1122  N   GLU A 160      35.998  47.106  11.062  1.00 44.95           N  
+ATOM   1123  CA  GLU A 160      36.892  48.179  10.642  1.00 46.80           C  
+ATOM   1124  C   GLU A 160      37.999  48.384  11.710  1.00 45.39           C  
+ATOM   1125  O   GLU A 160      39.182  48.530  11.385  1.00 45.27           O  
+ATOM   1126  CB  GLU A 160      36.091  49.470  10.446  1.00 46.17           C  
+ATOM   1127  CG  GLU A 160      36.914  50.600   9.880  1.00 50.19           C  
+ATOM   1128  CD  GLU A 160      36.196  51.931   9.938  1.00 55.80           C  
+ATOM   1129  OE1 GLU A 160      36.646  52.874   9.247  1.00 59.01           O  
+ATOM   1130  OE2 GLU A 160      35.188  52.045  10.675  1.00 59.21           O  
+ATOM   1131  N   ARG A 161      37.605  48.393  12.982  1.00 45.38           N  
+ATOM   1132  CA  ARG A 161      38.568  48.558  14.066  1.00 47.50           C  
+ATOM   1133  C   ARG A 161      39.539  47.374  14.072  1.00 46.48           C  
+ATOM   1134  O   ARG A 161      40.728  47.540  14.334  1.00 44.85           O  
+ATOM   1135  CB  ARG A 161      37.861  48.642  15.428  1.00 43.17           C  
+ATOM   1136  CG  ARG A 161      36.962  49.839  15.614  1.00 46.64           C  
+ATOM   1137  CD  ARG A 161      36.358  49.833  17.017  1.00 45.67           C  
+ATOM   1138  NE  ARG A 161      37.419  50.040  17.988  1.00 43.83           N  
+ATOM   1139  CZ  ARG A 161      37.821  51.233  18.397  1.00 41.83           C  
+ATOM   1140  NH1 ARG A 161      37.228  52.334  17.943  1.00 39.73           N  
+ATOM   1141  NH2 ARG A 161      38.867  51.326  19.197  1.00 39.96           N  
+ATOM   1142  N   LEU A 162      39.031  46.182  13.782  1.00 45.08           N  
+ATOM   1143  CA  LEU A 162      39.886  45.006  13.777  1.00 46.38           C  
+ATOM   1144  C   LEU A 162      40.855  45.133  12.621  1.00 47.59           C  
+ATOM   1145  O   LEU A 162      42.050  44.840  12.750  1.00 49.48           O  
+ATOM   1146  CB  LEU A 162      39.060  43.724  13.622  1.00 47.74           C  
+ATOM   1147  CG  LEU A 162      39.902  42.462  13.419  1.00 52.10           C  
+ATOM   1148  CD1 LEU A 162      40.755  42.262  14.656  1.00 51.13           C  
+ATOM   1149  CD2 LEU A 162      39.013  41.234  13.182  1.00 50.62           C  
+ATOM   1150  N   TRP A 163      40.342  45.561  11.475  1.00 46.39           N  
+ATOM   1151  CA  TRP A 163      41.203  45.726  10.321  1.00 44.60           C  
+ATOM   1152  C   TRP A 163      42.374  46.662  10.626  1.00 42.26           C  
+ATOM   1153  O   TRP A 163      43.516  46.366  10.304  1.00 43.44           O  
+ATOM   1154  CB  TRP A 163      40.430  46.301   9.138  1.00 44.79           C  
+ATOM   1155  CG  TRP A 163      41.399  46.758   8.090  1.00 43.39           C  
+ATOM   1156  CD1 TRP A 163      42.199  45.965   7.312  1.00 43.76           C  
+ATOM   1157  CD2 TRP A 163      41.776  48.108   7.808  1.00 42.53           C  
+ATOM   1158  NE1 TRP A 163      43.056  46.742   6.571  1.00 46.24           N  
+ATOM   1159  CE2 TRP A 163      42.813  48.063   6.856  1.00 44.33           C  
+ATOM   1160  CE3 TRP A 163      41.340  49.352   8.273  1.00 44.69           C  
+ATOM   1161  CZ2 TRP A 163      43.425  49.221   6.354  1.00 46.89           C  
+ATOM   1162  CZ3 TRP A 163      41.949  50.503   7.774  1.00 50.35           C  
+ATOM   1163  CH2 TRP A 163      42.979  50.427   6.824  1.00 46.03           C  
+ATOM   1164  N   ALA A 164      42.076  47.813  11.219  1.00 43.19           N  
+ATOM   1165  CA  ALA A 164      43.112  48.793  11.553  1.00 41.14           C  
+ATOM   1166  C   ALA A 164      44.110  48.278  12.629  1.00 40.66           C  
+ATOM   1167  O   ALA A 164      45.330  48.439  12.492  1.00 43.60           O  
+ATOM   1168  CB  ALA A 164      42.443  50.117  12.005  1.00 34.14           C  
+ATOM   1169  N   TRP A 165      43.594  47.666  13.687  1.00 41.38           N  
+ATOM   1170  CA  TRP A 165      44.431  47.125  14.776  1.00 42.42           C  
+ATOM   1171  C   TRP A 165      45.448  46.108  14.257  1.00 40.94           C  
+ATOM   1172  O   TRP A 165      46.645  46.282  14.454  1.00 42.04           O  
+ATOM   1173  CB  TRP A 165      43.541  46.461  15.836  1.00 38.76           C  
+ATOM   1174  CG  TRP A 165      44.232  46.029  17.094  1.00 40.46           C  
+ATOM   1175  CD1 TRP A 165      44.401  46.767  18.239  1.00 42.42           C  
+ATOM   1176  CD2 TRP A 165      44.835  44.750  17.350  1.00 39.98           C  
+ATOM   1177  NE1 TRP A 165      45.072  46.020  19.189  1.00 41.98           N  
+ATOM   1178  CE2 TRP A 165      45.350  44.783  18.667  1.00 40.30           C  
+ATOM   1179  CE3 TRP A 165      44.989  43.582  16.594  1.00 41.21           C  
+ATOM   1180  CZ2 TRP A 165      46.009  43.700  19.238  1.00 42.24           C  
+ATOM   1181  CZ3 TRP A 165      45.648  42.500  17.163  1.00 43.25           C  
+ATOM   1182  CH2 TRP A 165      46.151  42.568  18.472  1.00 41.47           C  
+ATOM   1183  N   GLU A 166      44.960  45.058  13.593  1.00 43.18           N  
+ATOM   1184  CA  GLU A 166      45.790  43.980  13.027  1.00 41.02           C  
+ATOM   1185  C   GLU A 166      46.730  44.422  11.912  1.00 42.69           C  
+ATOM   1186  O   GLU A 166      47.885  43.960  11.834  1.00 40.80           O  
+ATOM   1187  CB  GLU A 166      44.879  42.858  12.493  1.00 48.28           C  
+ATOM   1188  CG  GLU A 166      45.585  41.758  11.689  1.00 47.82           C  
+ATOM   1189  CD  GLU A 166      46.605  40.961  12.520  1.00 51.63           C  
+ATOM   1190  OE1 GLU A 166      46.531  40.990  13.761  1.00 51.75           O  
+ATOM   1191  OE2 GLU A 166      47.473  40.291  11.933  1.00 49.59           O  
+ATOM   1192  N   SER A 167      46.240  45.296  11.032  1.00 39.17           N  
+ATOM   1193  CA  SER A 167      47.066  45.792   9.922  1.00 43.57           C  
+ATOM   1194  C   SER A 167      48.268  46.606  10.436  1.00 44.55           C  
+ATOM   1195  O   SER A 167      49.383  46.487   9.915  1.00 45.67           O  
+ATOM   1196  CB  SER A 167      46.227  46.670   8.976  1.00 45.98           C  
+ATOM   1197  OG  SER A 167      45.161  45.929   8.414  1.00 54.83           O  
+ATOM   1198  N   TRP A 168      48.031  47.448  11.440  1.00 41.00           N  
+ATOM   1199  CA  TRP A 168      49.106  48.254  12.011  1.00 41.59           C  
+ATOM   1200  C   TRP A 168      50.162  47.288  12.514  1.00 37.14           C  
+ATOM   1201  O   TRP A 168      51.320  47.412  12.188  1.00 38.57           O  
+ATOM   1202  CB  TRP A 168      48.588  49.101  13.190  1.00 41.19           C  
+ATOM   1203  CG  TRP A 168      49.642  49.985  13.786  1.00 43.26           C  
+ATOM   1204  CD1 TRP A 168      50.037  50.032  15.097  1.00 43.27           C  
+ATOM   1205  CD2 TRP A 168      50.453  50.937  13.091  1.00 42.65           C  
+ATOM   1206  NE1 TRP A 168      51.047  50.955  15.255  1.00 42.03           N  
+ATOM   1207  CE2 TRP A 168      51.320  51.524  14.039  1.00 45.32           C  
+ATOM   1208  CE3 TRP A 168      50.531  51.350  11.760  1.00 42.15           C  
+ATOM   1209  CZ2 TRP A 168      52.252  52.504  13.693  1.00 43.42           C  
+ATOM   1210  CZ3 TRP A 168      51.459  52.326  11.414  1.00 41.19           C  
+ATOM   1211  CH2 TRP A 168      52.305  52.890  12.378  1.00 45.58           C  
+ATOM   1212  N   ARG A 169      49.750  46.293  13.291  1.00 39.14           N  
+ATOM   1213  CA  ARG A 169      50.720  45.340  13.821  1.00 39.66           C  
+ATOM   1214  C   ARG A 169      51.285  44.404  12.774  1.00 39.78           C  
+ATOM   1215  O   ARG A 169      52.429  43.996  12.845  1.00 39.24           O  
+ATOM   1216  CB  ARG A 169      50.082  44.556  14.973  1.00 40.33           C  
+ATOM   1217  CG  ARG A 169      49.820  45.451  16.184  1.00 38.98           C  
+ATOM   1218  CD  ARG A 169      48.823  44.861  17.143  1.00 38.74           C  
+ATOM   1219  NE  ARG A 169      48.739  45.678  18.352  1.00 41.41           N  
+ATOM   1220  CZ  ARG A 169      48.106  46.844  18.422  1.00 40.74           C  
+ATOM   1221  NH1 ARG A 169      48.087  47.534  19.560  1.00 34.90           N  
+ATOM   1222  NH2 ARG A 169      47.469  47.312  17.360  1.00 36.83           N  
+ATOM   1223  N   SER A 170      50.487  44.070  11.774  1.00 47.88           N  
+ATOM   1224  CA  SER A 170      50.977  43.165  10.758  1.00 49.75           C  
+ATOM   1225  C   SER A 170      51.920  43.817   9.769  1.00 49.84           C  
+ATOM   1226  O   SER A 170      52.935  43.232   9.423  1.00 50.53           O  
+ATOM   1227  CB  SER A 170      49.818  42.516  10.019  1.00 52.41           C  
+ATOM   1228  OG  SER A 170      50.309  41.356   9.388  1.00 63.67           O  
+ATOM   1229  N   GLU A 171      51.610  45.027   9.314  1.00 51.82           N  
+ATOM   1230  CA  GLU A 171      52.497  45.684   8.359  1.00 53.53           C  
+ATOM   1231  C   GLU A 171      53.696  46.410   8.958  1.00 52.48           C  
+ATOM   1232  O   GLU A 171      54.801  46.286   8.449  1.00 55.00           O  
+ATOM   1233  CB  GLU A 171      51.733  46.676   7.487  1.00 62.67           C  
+ATOM   1234  CG  GLU A 171      51.307  46.116   6.158  1.00 71.80           C  
+ATOM   1235  CD  GLU A 171      50.239  45.077   6.310  1.00 76.92           C  
+ATOM   1236  OE1 GLU A 171      49.120  45.453   6.720  1.00 81.42           O  
+ATOM   1237  OE2 GLU A 171      50.516  43.890   6.033  1.00 80.59           O  
+ATOM   1238  N   VAL A 172      53.513  47.185  10.017  1.00 48.52           N  
+ATOM   1239  CA  VAL A 172      54.675  47.874  10.539  1.00 49.14           C  
+ATOM   1240  C   VAL A 172      55.287  47.155  11.719  1.00 45.48           C  
+ATOM   1241  O   VAL A 172      56.498  47.041  11.807  1.00 49.15           O  
+ATOM   1242  CB  VAL A 172      54.354  49.362  10.907  1.00 52.33           C  
+ATOM   1243  CG1 VAL A 172      53.603  50.023   9.769  1.00 54.23           C  
+ATOM   1244  CG2 VAL A 172      53.538  49.432  12.165  1.00 59.04           C  
+ATOM   1245  N   GLY A 173      54.463  46.651  12.624  1.00 46.08           N  
+ATOM   1246  CA  GLY A 173      55.012  45.957  13.779  1.00 45.13           C  
+ATOM   1247  C   GLY A 173      56.027  44.904  13.393  1.00 45.13           C  
+ATOM   1248  O   GLY A 173      57.110  44.809  13.974  1.00 47.80           O  
+ATOM   1249  N   LYS A 174      55.688  44.103  12.390  1.00 45.82           N  
+ATOM   1250  CA  LYS A 174      56.595  43.057  11.940  1.00 45.72           C  
+ATOM   1251  C   LYS A 174      57.905  43.590  11.388  1.00 44.65           C  
+ATOM   1252  O   LYS A 174      58.913  42.907  11.435  1.00 45.00           O  
+ATOM   1253  CB  LYS A 174      55.916  42.176  10.889  1.00 47.18           C  
+ATOM   1254  CG  LYS A 174      54.796  41.319  11.448  1.00 46.49           C  
+ATOM   1255  CD  LYS A 174      54.339  40.368  10.381  1.00 47.83           C  
+ATOM   1256  CE  LYS A 174      53.157  39.553  10.830  1.00 50.32           C  
+ATOM   1257  NZ  LYS A 174      52.868  38.490   9.822  1.00 57.21           N  
+ATOM   1258  N   GLN A 175      57.896  44.801  10.841  1.00 44.99           N  
+ATOM   1259  CA  GLN A 175      59.132  45.369  10.321  1.00 42.52           C  
+ATOM   1260  C   GLN A 175      60.029  45.665  11.510  1.00 41.26           C  
+ATOM   1261  O   GLN A 175      61.245  45.626  11.418  1.00 41.57           O  
+ATOM   1262  CB  GLN A 175      58.862  46.674   9.589  1.00 43.68           C  
+ATOM   1263  CG  GLN A 175      58.026  46.533   8.332  1.00 44.74           C  
+ATOM   1264  CD  GLN A 175      57.987  47.821   7.565  1.00 45.51           C  
+ATOM   1265  OE1 GLN A 175      59.037  48.390   7.244  1.00 50.56           O  
+ATOM   1266  NE2 GLN A 175      56.786  48.308   7.272  1.00 44.92           N  
+ATOM   1267  N   LEU A 176      59.397  45.965  12.630  1.00 43.48           N  
+ATOM   1268  CA  LEU A 176      60.100  46.306  13.839  1.00 46.07           C  
+ATOM   1269  C   LEU A 176      60.691  45.116  14.578  1.00 47.47           C  
+ATOM   1270  O   LEU A 176      61.661  45.269  15.306  1.00 46.87           O  
+ATOM   1271  CB  LEU A 176      59.148  47.044  14.767  1.00 46.25           C  
+ATOM   1272  CG  LEU A 176      59.164  48.572  14.800  1.00 51.99           C  
+ATOM   1273  CD1 LEU A 176      59.959  49.131  13.665  1.00 49.23           C  
+ATOM   1274  CD2 LEU A 176      57.742  49.072  14.778  1.00 48.87           C  
+ATOM   1275  N   ARG A 177      60.105  43.937  14.400  1.00 48.05           N  
+ATOM   1276  CA  ARG A 177      60.570  42.763  15.127  1.00 49.20           C  
+ATOM   1277  C   ARG A 177      62.074  42.538  15.036  1.00 50.27           C  
+ATOM   1278  O   ARG A 177      62.758  42.472  16.058  1.00 48.80           O  
+ATOM   1279  CB  ARG A 177      59.797  41.517  14.675  1.00 49.21           C  
+ATOM   1280  CG  ARG A 177      60.177  40.243  15.413  1.00 50.17           C  
+ATOM   1281  CD  ARG A 177      59.940  40.333  16.918  1.00 51.21           C  
+ATOM   1282  NE  ARG A 177      60.655  39.266  17.627  1.00 49.26           N  
+ATOM   1283  CZ  ARG A 177      60.067  38.324  18.362  1.00 49.89           C  
+ATOM   1284  NH1 ARG A 177      60.798  37.395  18.975  1.00 48.75           N  
+ATOM   1285  NH2 ARG A 177      58.749  38.316  18.495  1.00 40.95           N  
+ATOM   1286  N   PRO A 178      62.615  42.439  13.811  1.00 50.34           N  
+ATOM   1287  CA  PRO A 178      64.046  42.226  13.584  1.00 49.93           C  
+ATOM   1288  C   PRO A 178      64.894  43.305  14.258  1.00 50.49           C  
+ATOM   1289  O   PRO A 178      65.881  43.013  14.931  1.00 47.70           O  
+ATOM   1290  CB  PRO A 178      64.169  42.312  12.066  1.00 48.29           C  
+ATOM   1291  CG  PRO A 178      62.847  41.944  11.595  1.00 47.50           C  
+ATOM   1292  CD  PRO A 178      61.920  42.619  12.532  1.00 46.19           C  
+ATOM   1293  N   LEU A 179      64.508  44.556  14.034  1.00 48.29           N  
+ATOM   1294  CA  LEU A 179      65.226  45.686  14.591  1.00 48.69           C  
+ATOM   1295  C   LEU A 179      65.206  45.697  16.116  1.00 46.59           C  
+ATOM   1296  O   LEU A 179      66.226  45.952  16.756  1.00 45.44           O  
+ATOM   1297  CB  LEU A 179      64.629  46.997  14.057  1.00 47.07           C  
+ATOM   1298  CG  LEU A 179      64.696  47.083  12.527  1.00 47.67           C  
+ATOM   1299  CD1 LEU A 179      63.813  48.207  11.986  1.00 42.75           C  
+ATOM   1300  CD2 LEU A 179      66.135  47.276  12.125  1.00 45.13           C  
+ATOM   1301  N   TYR A 180      64.049  45.429  16.697  1.00 45.46           N  
+ATOM   1302  CA  TYR A 180      63.924  45.442  18.149  1.00 47.65           C  
+ATOM   1303  C   TYR A 180      64.829  44.431  18.849  1.00 46.70           C  
+ATOM   1304  O   TYR A 180      65.391  44.735  19.889  1.00 43.21           O  
+ATOM   1305  CB  TYR A 180      62.472  45.199  18.576  1.00 45.88           C  
+ATOM   1306  CG  TYR A 180      62.184  45.783  19.938  1.00 42.70           C  
+ATOM   1307  CD1 TYR A 180      62.187  47.155  20.126  1.00 40.60           C  
+ATOM   1308  CD2 TYR A 180      61.987  44.969  21.043  1.00 42.08           C  
+ATOM   1309  CE1 TYR A 180      62.002  47.709  21.377  1.00 42.13           C  
+ATOM   1310  CE2 TYR A 180      61.810  45.510  22.313  1.00 41.56           C  
+ATOM   1311  CZ  TYR A 180      61.816  46.879  22.475  1.00 45.54           C  
+ATOM   1312  OH  TYR A 180      61.652  47.427  23.731  1.00 43.27           O  
+ATOM   1313  N   GLU A 181      64.968  43.237  18.278  1.00 48.99           N  
+ATOM   1314  CA  GLU A 181      65.812  42.198  18.875  1.00 50.96           C  
+ATOM   1315  C   GLU A 181      67.261  42.653  18.897  1.00 51.19           C  
+ATOM   1316  O   GLU A 181      67.936  42.568  19.922  1.00 51.56           O  
+ATOM   1317  CB  GLU A 181      65.691  40.876  18.098  1.00 50.22           C  
+ATOM   1318  CG  GLU A 181      64.314  40.235  18.206  1.00 49.31           C  
+ATOM   1319  CD  GLU A 181      64.146  39.021  17.309  1.00 52.43           C  
+ATOM   1320  OE1 GLU A 181      65.099  38.679  16.578  1.00 52.95           O  
+ATOM   1321  OE2 GLU A 181      63.053  38.408  17.334  1.00 52.31           O  
+ATOM   1322  N   GLU A 182      67.744  43.143  17.765  1.00 49.95           N  
+ATOM   1323  CA  GLU A 182      69.112  43.620  17.715  1.00 52.23           C  
+ATOM   1324  C   GLU A 182      69.250  44.762  18.732  1.00 50.24           C  
+ATOM   1325  O   GLU A 182      70.236  44.839  19.455  1.00 53.90           O  
+ATOM   1326  CB  GLU A 182      69.447  44.091  16.302  1.00 54.63           C  
+ATOM   1327  CG  GLU A 182      70.932  44.241  16.042  1.00 60.95           C  
+ATOM   1328  CD  GLU A 182      71.223  44.630  14.609  1.00 66.62           C  
+ATOM   1329  OE1 GLU A 182      72.383  44.996  14.318  1.00 68.79           O  
+ATOM   1330  OE2 GLU A 182      70.292  44.563  13.775  1.00 69.82           O  
+ATOM   1331  N   TYR A 183      68.238  45.623  18.808  1.00 48.18           N  
+ATOM   1332  CA  TYR A 183      68.228  46.743  19.746  1.00 46.19           C  
+ATOM   1333  C   TYR A 183      68.389  46.382  21.228  1.00 47.08           C  
+ATOM   1334  O   TYR A 183      69.136  47.039  21.928  1.00 47.19           O  
+ATOM   1335  CB  TYR A 183      66.959  47.566  19.534  1.00 42.72           C  
+ATOM   1336  CG  TYR A 183      66.448  48.355  20.730  1.00 39.06           C  
+ATOM   1337  CD1 TYR A 183      65.630  47.747  21.701  1.00 35.14           C  
+ATOM   1338  CD2 TYR A 183      66.708  49.713  20.854  1.00 36.02           C  
+ATOM   1339  CE1 TYR A 183      65.095  48.469  22.740  1.00 33.74           C  
+ATOM   1340  CE2 TYR A 183      66.159  50.462  21.913  1.00 35.18           C  
+ATOM   1341  CZ  TYR A 183      65.361  49.842  22.845  1.00 36.10           C  
+ATOM   1342  OH  TYR A 183      64.807  50.577  23.891  1.00 36.22           O  
+ATOM   1343  N   VAL A 184      67.696  45.360  21.722  1.00 47.63           N  
+ATOM   1344  CA  VAL A 184      67.861  45.016  23.128  1.00 50.68           C  
+ATOM   1345  C   VAL A 184      69.285  44.524  23.383  1.00 50.01           C  
+ATOM   1346  O   VAL A 184      69.879  44.856  24.413  1.00 51.49           O  
+ATOM   1347  CB  VAL A 184      66.840  43.924  23.613  1.00 52.85           C  
+ATOM   1348  CG1 VAL A 184      65.418  44.417  23.456  1.00 53.77           C  
+ATOM   1349  CG2 VAL A 184      67.027  42.686  22.865  1.00 49.45           C  
+ATOM   1350  N   VAL A 185      69.825  43.741  22.445  1.00 51.26           N  
+ATOM   1351  CA  VAL A 185      71.194  43.216  22.546  1.00 51.53           C  
+ATOM   1352  C   VAL A 185      72.160  44.375  22.748  1.00 51.24           C  
+ATOM   1353  O   VAL A 185      72.876  44.449  23.747  1.00 51.43           O  
+ATOM   1354  CB  VAL A 185      71.621  42.449  21.253  1.00 51.05           C  
+ATOM   1355  CG1 VAL A 185      73.092  42.144  21.290  1.00 47.16           C  
+ATOM   1356  CG2 VAL A 185      70.860  41.135  21.132  1.00 51.22           C  
+ATOM   1357  N   LEU A 186      72.150  45.294  21.794  1.00 49.24           N  
+ATOM   1358  CA  LEU A 186      73.015  46.456  21.842  1.00 48.85           C  
+ATOM   1359  C   LEU A 186      72.807  47.309  23.075  1.00 46.69           C  
+ATOM   1360  O   LEU A 186      73.759  47.852  23.624  1.00 49.59           O  
+ATOM   1361  CB  LEU A 186      72.801  47.317  20.590  1.00 51.63           C  
+ATOM   1362  CG  LEU A 186      73.811  47.193  19.450  1.00 53.91           C  
+ATOM   1363  CD1 LEU A 186      74.645  45.933  19.599  1.00 55.35           C  
+ATOM   1364  CD2 LEU A 186      73.060  47.201  18.134  1.00 55.66           C  
+ATOM   1365  N   LYS A 187      71.563  47.436  23.505  1.00 46.79           N  
+ATOM   1366  CA  LYS A 187      71.231  48.253  24.668  1.00 46.69           C  
+ATOM   1367  C   LYS A 187      71.675  47.600  25.979  1.00 48.89           C  
+ATOM   1368  O   LYS A 187      72.143  48.283  26.900  1.00 42.27           O  
+ATOM   1369  CB  LYS A 187      69.723  48.511  24.698  1.00 49.23           C  
+ATOM   1370  CG  LYS A 187      69.315  49.987  24.813  1.00 53.66           C  
+ATOM   1371  CD  LYS A 187      69.958  50.841  23.750  1.00 49.14           C  
+ATOM   1372  CE  LYS A 187      69.111  52.081  23.379  1.00 53.28           C  
+ATOM   1373  NZ  LYS A 187      69.237  53.303  24.236  1.00 45.11           N  
+ATOM   1374  N   ASN A 188      71.509  46.282  26.070  1.00 48.85           N  
+ATOM   1375  CA  ASN A 188      71.917  45.574  27.273  1.00 52.86           C  
+ATOM   1376  C   ASN A 188      73.428  45.635  27.364  1.00 55.23           C  
+ATOM   1377  O   ASN A 188      73.999  45.648  28.456  1.00 57.31           O  
+ATOM   1378  CB  ASN A 188      71.470  44.114  27.251  1.00 47.26           C  
+ATOM   1379  CG  ASN A 188      70.122  43.913  27.904  1.00 51.39           C  
+ATOM   1380  OD1 ASN A 188      69.720  44.687  28.788  1.00 46.38           O  
+ATOM   1381  ND2 ASN A 188      69.423  42.852  27.503  1.00 50.97           N  
+ATOM   1382  N   GLU A 189      74.071  45.687  26.206  1.00 56.30           N  
+ATOM   1383  CA  GLU A 189      75.522  45.758  26.155  1.00 58.89           C  
+ATOM   1384  C   GLU A 189      75.958  47.121  26.678  1.00 58.57           C  
+ATOM   1385  O   GLU A 189      76.869  47.218  27.478  1.00 58.60           O  
+ATOM   1386  CB  GLU A 189      75.987  45.564  24.717  1.00 63.65           C  
+ATOM   1387  CG  GLU A 189      77.434  45.189  24.577  1.00 69.67           C  
+ATOM   1388  CD  GLU A 189      77.728  44.605  23.216  1.00 75.35           C  
+ATOM   1389  OE1 GLU A 189      76.939  43.735  22.771  1.00 74.94           O  
+ATOM   1390  OE2 GLU A 189      78.746  45.004  22.601  1.00 78.22           O  
+ATOM   1391  N   MET A 190      75.298  48.181  26.224  1.00 58.29           N  
+ATOM   1392  CA  MET A 190      75.639  49.510  26.689  1.00 56.08           C  
+ATOM   1393  C   MET A 190      75.494  49.500  28.196  1.00 55.02           C  
+ATOM   1394  O   MET A 190      76.423  49.861  28.920  1.00 57.97           O  
+ATOM   1395  CB  MET A 190      74.705  50.564  26.064  1.00 58.79           C  
+ATOM   1396  CG  MET A 190      74.754  51.960  26.705  1.00 54.15           C  
+ATOM   1397  SD  MET A 190      73.334  52.305  27.803  1.00 67.15           S  
+ATOM   1398  CE  MET A 190      74.050  52.282  29.393  1.00 59.79           C  
+ATOM   1399  N   ALA A 191      74.335  49.054  28.662  1.00 51.03           N  
+ATOM   1400  CA  ALA A 191      74.033  49.014  30.085  1.00 51.89           C  
+ATOM   1401  C   ALA A 191      75.044  48.228  30.956  1.00 54.43           C  
+ATOM   1402  O   ALA A 191      75.486  48.718  31.997  1.00 52.65           O  
+ATOM   1403  CB  ALA A 191      72.632  48.470  30.283  1.00 47.04           C  
+ATOM   1404  N   ARG A 192      75.402  47.018  30.539  1.00 56.23           N  
+ATOM   1405  CA  ARG A 192      76.350  46.205  31.298  1.00 58.28           C  
+ATOM   1406  C   ARG A 192      77.698  46.916  31.418  1.00 58.56           C  
+ATOM   1407  O   ARG A 192      78.259  47.025  32.511  1.00 58.94           O  
+ATOM   1408  CB  ARG A 192      76.548  44.839  30.631  1.00 56.21           C  
+ATOM   1409  CG  ARG A 192      75.368  43.888  30.766  1.00 55.16           C  
+ATOM   1410  CD  ARG A 192      75.800  42.463  30.474  1.00 52.73           C  
+ATOM   1411  NE  ARG A 192      76.299  42.297  29.110  1.00 55.56           N  
+ATOM   1412  CZ  ARG A 192      75.518  42.116  28.045  1.00 57.36           C  
+ATOM   1413  NH1 ARG A 192      76.052  41.975  26.841  1.00 57.55           N  
+ATOM   1414  NH2 ARG A 192      74.200  42.069  28.185  1.00 56.33           N  
+ATOM   1415  N   ALA A 193      78.198  47.416  30.293  1.00 57.75           N  
+ATOM   1416  CA  ALA A 193      79.475  48.109  30.264  1.00 57.66           C  
+ATOM   1417  C   ALA A 193      79.443  49.378  31.091  1.00 60.45           C  
+ATOM   1418  O   ALA A 193      80.488  49.939  31.408  1.00 63.35           O  
+ATOM   1419  CB  ALA A 193      79.850  48.428  28.850  1.00 56.66           C  
+ATOM   1420  N   ASN A 194      78.239  49.829  31.428  1.00 62.12           N  
+ATOM   1421  CA  ASN A 194      78.037  51.034  32.234  1.00 60.49           C  
+ATOM   1422  C   ASN A 194      77.802  50.632  33.683  1.00 59.42           C  
+ATOM   1423  O   ASN A 194      77.399  51.451  34.513  1.00 58.58           O  
+ATOM   1424  CB  ASN A 194      76.832  51.819  31.715  1.00 63.68           C  
+ATOM   1425  CG  ASN A 194      77.203  52.797  30.625  1.00 65.73           C  
+ATOM   1426  OD1 ASN A 194      77.762  53.861  30.898  1.00 69.53           O  
+ATOM   1427  ND2 ASN A 194      76.908  52.442  29.380  1.00 64.47           N  
+ATOM   1428  N   HIS A 195      78.030  49.352  33.958  1.00 59.05           N  
+ATOM   1429  CA  HIS A 195      77.898  48.787  35.292  1.00 60.18           C  
+ATOM   1430  C   HIS A 195      76.474  48.579  35.812  1.00 59.91           C  
+ATOM   1431  O   HIS A 195      76.185  48.765  37.002  1.00 62.07           O  
+ATOM   1432  CB  HIS A 195      78.748  49.621  36.274  1.00 61.18           C  
+ATOM   1433  CG  HIS A 195      80.152  49.831  35.794  1.00 63.80           C  
+ATOM   1434  ND1 HIS A 195      80.657  51.080  35.491  1.00 63.65           N  
+ATOM   1435  CD2 HIS A 195      81.098  48.939  35.408  1.00 63.46           C  
+ATOM   1436  CE1 HIS A 195      81.845  50.947  34.926  1.00 64.42           C  
+ATOM   1437  NE2 HIS A 195      82.134  49.658  34.862  1.00 65.27           N  
+ATOM   1438  N   TYR A 196      75.587  48.185  34.905  1.00 56.74           N  
+ATOM   1439  CA  TYR A 196      74.205  47.884  35.247  1.00 53.70           C  
+ATOM   1440  C   TYR A 196      73.971  46.459  34.756  1.00 52.60           C  
+ATOM   1441  O   TYR A 196      74.689  45.970  33.872  1.00 51.52           O  
+ATOM   1442  CB  TYR A 196      73.236  48.834  34.523  1.00 55.65           C  
+ATOM   1443  CG  TYR A 196      73.232  50.257  35.035  1.00 50.55           C  
+ATOM   1444  CD1 TYR A 196      72.451  50.619  36.124  1.00 47.08           C  
+ATOM   1445  CD2 TYR A 196      74.020  51.233  34.432  1.00 45.73           C  
+ATOM   1446  CE1 TYR A 196      72.449  51.914  36.606  1.00 49.20           C  
+ATOM   1447  CE2 TYR A 196      74.029  52.530  34.908  1.00 49.02           C  
+ATOM   1448  CZ  TYR A 196      73.242  52.866  35.994  1.00 51.64           C  
+ATOM   1449  OH  TYR A 196      73.254  54.155  36.466  1.00 52.63           O  
+ATOM   1450  N   GLU A 197      72.966  45.796  35.316  1.00 55.15           N  
+ATOM   1451  CA  GLU A 197      72.622  44.422  34.920  1.00 56.28           C  
+ATOM   1452  C   GLU A 197      72.093  44.338  33.488  1.00 56.25           C  
+ATOM   1453  O   GLU A 197      72.490  43.468  32.706  1.00 56.79           O  
+ATOM   1454  CB  GLU A 197      71.549  43.872  35.854  1.00 57.24           C  
+ATOM   1455  CG  GLU A 197      71.939  43.847  37.308  1.00 59.62           C  
+ATOM   1456  CD  GLU A 197      70.737  43.878  38.214  1.00 64.50           C  
+ATOM   1457  OE1 GLU A 197      69.757  43.134  37.945  1.00 63.51           O  
+ATOM   1458  OE2 GLU A 197      70.774  44.656  39.195  1.00 63.79           O  
+ATOM   1459  N   ASP A 198      71.170  45.239  33.167  1.00 56.16           N  
+ATOM   1460  CA  ASP A 198      70.545  45.287  31.850  1.00 56.53           C  
+ATOM   1461  C   ASP A 198      69.943  46.672  31.603  1.00 54.91           C  
+ATOM   1462  O   ASP A 198      69.847  47.499  32.517  1.00 51.77           O  
+ATOM   1463  CB  ASP A 198      69.450  44.222  31.756  1.00 57.09           C  
+ATOM   1464  CG  ASP A 198      68.508  44.257  32.940  1.00 62.79           C  
+ATOM   1465  OD1 ASP A 198      68.521  43.290  33.737  1.00 62.81           O  
+ATOM   1466  OD2 ASP A 198      67.757  45.256  33.086  1.00 64.77           O  
+ATOM   1467  N   TYR A 199      69.513  46.909  30.370  1.00 53.75           N  
+ATOM   1468  CA  TYR A 199      68.954  48.205  29.999  1.00 50.58           C  
+ATOM   1469  C   TYR A 199      67.806  48.665  30.907  1.00 48.84           C  
+ATOM   1470  O   TYR A 199      67.692  49.852  31.226  1.00 45.89           O  
+ATOM   1471  CB  TYR A 199      68.520  48.171  28.535  1.00 48.33           C  
+ATOM   1472  CG  TYR A 199      68.170  49.532  27.983  1.00 51.39           C  
+ATOM   1473  CD1 TYR A 199      68.986  50.624  28.223  1.00 51.51           C  
+ATOM   1474  CD2 TYR A 199      67.047  49.711  27.187  1.00 52.25           C  
+ATOM   1475  CE1 TYR A 199      68.702  51.851  27.687  1.00 52.92           C  
+ATOM   1476  CE2 TYR A 199      66.751  50.928  26.642  1.00 50.91           C  
+ATOM   1477  CZ  TYR A 199      67.581  51.994  26.891  1.00 55.39           C  
+ATOM   1478  OH  TYR A 199      67.315  53.196  26.312  1.00 53.79           O  
+ATOM   1479  N   GLY A 200      66.974  47.727  31.346  1.00 46.40           N  
+ATOM   1480  CA  GLY A 200      65.878  48.089  32.219  1.00 43.61           C  
+ATOM   1481  C   GLY A 200      66.351  48.509  33.601  1.00 46.53           C  
+ATOM   1482  O   GLY A 200      65.751  49.372  34.244  1.00 42.66           O  
+ATOM   1483  N   ASP A 201      67.414  47.868  34.079  1.00 47.76           N  
+ATOM   1484  CA  ASP A 201      67.990  48.194  35.381  1.00 46.70           C  
+ATOM   1485  C   ASP A 201      68.525  49.636  35.249  1.00 44.03           C  
+ATOM   1486  O   ASP A 201      68.412  50.456  36.153  1.00 39.61           O  
+ATOM   1487  CB  ASP A 201      69.121  47.182  35.687  1.00 50.00           C  
+ATOM   1488  CG  ASP A 201      69.871  47.486  36.979  1.00 51.37           C  
+ATOM   1489  OD1 ASP A 201      69.234  47.745  38.025  1.00 54.90           O  
+ATOM   1490  OD2 ASP A 201      71.118  47.455  36.945  1.00 61.26           O  
+ATOM   1491  N   TYR A 202      69.104  49.918  34.090  1.00 46.21           N  
+ATOM   1492  CA  TYR A 202      69.631  51.235  33.756  1.00 49.61           C  
+ATOM   1493  C   TYR A 202      68.545  52.319  33.921  1.00 48.73           C  
+ATOM   1494  O   TYR A 202      68.793  53.362  34.529  1.00 50.43           O  
+ATOM   1495  CB  TYR A 202      70.134  51.197  32.309  1.00 53.12           C  
+ATOM   1496  CG  TYR A 202      70.719  52.490  31.780  1.00 56.64           C  
+ATOM   1497  CD1 TYR A 202      72.003  52.897  32.141  1.00 60.66           C  
+ATOM   1498  CD2 TYR A 202      70.006  53.279  30.878  1.00 55.72           C  
+ATOM   1499  CE1 TYR A 202      72.568  54.050  31.611  1.00 62.17           C  
+ATOM   1500  CE2 TYR A 202      70.549  54.430  30.344  1.00 58.76           C  
+ATOM   1501  CZ  TYR A 202      71.835  54.812  30.707  1.00 65.33           C  
+ATOM   1502  OH  TYR A 202      72.405  55.929  30.132  1.00 68.51           O  
+ATOM   1503  N   TRP A 203      67.342  52.067  33.395  1.00 44.93           N  
+ATOM   1504  CA  TRP A 203      66.236  53.036  33.497  1.00 43.50           C  
+ATOM   1505  C   TRP A 203      65.764  53.283  34.926  1.00 41.99           C  
+ATOM   1506  O   TRP A 203      65.425  54.416  35.302  1.00 40.97           O  
+ATOM   1507  CB  TRP A 203      65.009  52.573  32.671  1.00 42.70           C  
+ATOM   1508  CG  TRP A 203      65.087  52.834  31.191  1.00 46.05           C  
+ATOM   1509  CD1 TRP A 203      65.935  53.691  30.549  1.00 47.20           C  
+ATOM   1510  CD2 TRP A 203      64.271  52.243  30.171  1.00 43.74           C  
+ATOM   1511  NE1 TRP A 203      65.703  53.663  29.198  1.00 44.41           N  
+ATOM   1512  CE2 TRP A 203      64.687  52.781  28.940  1.00 44.09           C  
+ATOM   1513  CE3 TRP A 203      63.229  51.308  30.181  1.00 47.12           C  
+ATOM   1514  CZ2 TRP A 203      64.097  52.416  27.725  1.00 45.38           C  
+ATOM   1515  CZ3 TRP A 203      62.645  50.942  28.976  1.00 43.17           C  
+ATOM   1516  CH2 TRP A 203      63.084  51.496  27.765  1.00 44.11           C  
+ATOM   1517  N   ARG A 204      65.674  52.209  35.704  1.00 41.94           N  
+ATOM   1518  CA  ARG A 204      65.233  52.319  37.082  1.00 43.68           C  
+ATOM   1519  C   ARG A 204      66.275  53.150  37.844  1.00 44.56           C  
+ATOM   1520  O   ARG A 204      66.039  53.615  38.956  1.00 45.28           O  
+ATOM   1521  CB  ARG A 204      65.055  50.920  37.688  1.00 45.75           C  
+ATOM   1522  CG  ARG A 204      63.981  50.081  36.993  1.00 43.67           C  
+ATOM   1523  CD  ARG A 204      63.688  48.766  37.736  1.00 48.12           C  
+ATOM   1524  NE  ARG A 204      64.795  47.800  37.711  1.00 41.66           N  
+ATOM   1525  CZ  ARG A 204      64.968  46.878  36.766  1.00 48.35           C  
+ATOM   1526  NH1 ARG A 204      64.112  46.793  35.757  1.00 53.00           N  
+ATOM   1527  NH2 ARG A 204      65.977  46.014  36.840  1.00 48.25           N  
+ATOM   1528  N   GLY A 205      67.421  53.350  37.207  1.00 47.17           N  
+ATOM   1529  CA  GLY A 205      68.474  54.161  37.780  1.00 47.42           C  
+ATOM   1530  C   GLY A 205      67.999  55.563  38.120  1.00 50.83           C  
+ATOM   1531  O   GLY A 205      68.657  56.250  38.926  1.00 48.17           O  
+ATOM   1532  N   ASP A 206      66.864  55.992  37.544  1.00 48.28           N  
+ATOM   1533  CA  ASP A 206      66.327  57.348  37.814  1.00 47.90           C  
+ATOM   1534  C   ASP A 206      65.756  57.521  39.209  1.00 48.03           C  
+ATOM   1535  O   ASP A 206      65.651  58.647  39.690  1.00 47.01           O  
+ATOM   1536  CB  ASP A 206      65.222  57.732  36.816  1.00 47.77           C  
+ATOM   1537  CG  ASP A 206      64.732  59.177  36.992  1.00 48.16           C  
+ATOM   1538  OD1 ASP A 206      63.699  59.403  37.666  1.00 44.01           O  
+ATOM   1539  OD2 ASP A 206      65.393  60.101  36.456  1.00 49.42           O  
+ATOM   1540  N   TYR A 207      65.363  56.415  39.845  1.00 47.43           N  
+ATOM   1541  CA  TYR A 207      64.794  56.477  41.187  1.00 48.36           C  
+ATOM   1542  C   TYR A 207      65.814  56.156  42.303  1.00 49.31           C  
+ATOM   1543  O   TYR A 207      65.550  56.362  43.494  1.00 43.32           O  
+ATOM   1544  CB  TYR A 207      63.617  55.516  41.298  1.00 48.85           C  
+ATOM   1545  CG  TYR A 207      62.520  55.806  40.305  1.00 48.55           C  
+ATOM   1546  CD1 TYR A 207      62.563  55.282  39.015  1.00 50.67           C  
+ATOM   1547  CD2 TYR A 207      61.468  56.640  40.645  1.00 47.26           C  
+ATOM   1548  CE1 TYR A 207      61.581  55.595  38.089  1.00 53.57           C  
+ATOM   1549  CE2 TYR A 207      60.482  56.958  39.736  1.00 51.32           C  
+ATOM   1550  CZ  TYR A 207      60.543  56.436  38.459  1.00 51.85           C  
+ATOM   1551  OH  TYR A 207      59.558  56.772  37.559  1.00 55.41           O  
+ATOM   1552  N   GLU A 208      66.979  55.671  41.906  1.00 48.39           N  
+ATOM   1553  CA  GLU A 208      68.010  55.318  42.860  1.00 54.12           C  
+ATOM   1554  C   GLU A 208      68.647  56.486  43.602  1.00 57.28           C  
+ATOM   1555  O   GLU A 208      69.049  57.482  43.003  1.00 59.35           O  
+ATOM   1556  CB  GLU A 208      69.108  54.516  42.170  1.00 50.96           C  
+ATOM   1557  CG  GLU A 208      70.345  54.377  43.011  1.00 55.45           C  
+ATOM   1558  CD  GLU A 208      71.339  53.393  42.444  1.00 59.42           C  
+ATOM   1559  OE1 GLU A 208      71.609  53.434  41.216  1.00 61.40           O  
+ATOM   1560  OE2 GLU A 208      71.869  52.580  43.234  1.00 65.33           O  
+ATOM   1561  N   VAL A 209      68.720  56.364  44.919  1.00 58.16           N  
+ATOM   1562  CA  VAL A 209      69.361  57.384  45.717  1.00 63.63           C  
+ATOM   1563  C   VAL A 209      70.208  56.668  46.773  1.00 65.87           C  
+ATOM   1564  O   VAL A 209      69.741  55.729  47.427  1.00 64.62           O  
+ATOM   1565  CB  VAL A 209      68.328  58.333  46.355  1.00 64.32           C  
+ATOM   1566  CG1 VAL A 209      66.938  57.805  46.119  1.00 63.53           C  
+ATOM   1567  CG2 VAL A 209      68.627  58.529  47.840  1.00 60.57           C  
+ATOM   1568  N   ASN A 210      71.465  57.096  46.903  1.00 66.94           N  
+ATOM   1569  CA  ASN A 210      72.402  56.486  47.843  1.00 68.14           C  
+ATOM   1570  C   ASN A 210      73.171  57.457  48.727  1.00 69.92           C  
+ATOM   1571  O   ASN A 210      73.107  58.682  48.553  1.00 69.15           O  
+ATOM   1572  CB  ASN A 210      73.401  55.632  47.078  1.00 67.77           C  
+ATOM   1573  CG  ASN A 210      72.738  54.467  46.383  1.00 73.38           C  
+ATOM   1574  OD1 ASN A 210      73.377  53.710  45.656  1.00 74.04           O  
+ATOM   1575  ND2 ASN A 210      71.437  54.314  46.609  1.00 74.11           N  
+ATOM   1576  N   GLY A 211      73.902  56.887  49.684  1.00 69.66           N  
+ATOM   1577  CA  GLY A 211      74.703  57.687  50.597  1.00 68.95           C  
+ATOM   1578  C   GLY A 211      73.921  58.705  51.400  1.00 68.33           C  
+ATOM   1579  O   GLY A 211      74.446  59.754  51.769  1.00 70.66           O  
+ATOM   1580  N   VAL A 212      72.658  58.407  51.665  1.00 68.63           N  
+ATOM   1581  CA  VAL A 212      71.815  59.302  52.442  1.00 69.01           C  
+ATOM   1582  C   VAL A 212      70.975  58.436  53.365  1.00 71.26           C  
+ATOM   1583  O   VAL A 212      69.948  57.906  52.961  1.00 72.61           O  
+ATOM   1584  CB  VAL A 212      70.881  60.128  51.542  1.00 67.03           C  
+ATOM   1585  CG1 VAL A 212      70.019  61.046  52.395  1.00 66.46           C  
+ATOM   1586  CG2 VAL A 212      71.698  60.933  50.546  1.00 66.74           C  
+ATOM   1587  N   ASP A 213      71.424  58.295  54.607  1.00 73.31           N  
+ATOM   1588  CA  ASP A 213      70.728  57.474  55.592  1.00 73.51           C  
+ATOM   1589  C   ASP A 213      69.257  57.849  55.784  1.00 69.55           C  
+ATOM   1590  O   ASP A 213      68.930  58.988  56.109  1.00 68.91           O  
+ATOM   1591  CB  ASP A 213      71.463  57.557  56.936  1.00 78.93           C  
+ATOM   1592  CG  ASP A 213      72.898  57.048  56.851  1.00 85.65           C  
+ATOM   1593  OD1 ASP A 213      73.092  55.823  56.678  1.00 85.93           O  
+ATOM   1594  OD2 ASP A 213      73.834  57.877  56.952  1.00 90.65           O  
+ATOM   1595  N   GLY A 214      68.371  56.880  55.580  1.00 67.33           N  
+ATOM   1596  CA  GLY A 214      66.955  57.138  55.764  1.00 66.22           C  
+ATOM   1597  C   GLY A 214      66.159  57.520  54.523  1.00 65.06           C  
+ATOM   1598  O   GLY A 214      64.938  57.646  54.587  1.00 65.12           O  
+ATOM   1599  N   TYR A 215      66.831  57.711  53.396  1.00 60.50           N  
+ATOM   1600  CA  TYR A 215      66.129  58.078  52.178  1.00 59.95           C  
+ATOM   1601  C   TYR A 215      66.667  57.296  50.998  1.00 58.77           C  
+ATOM   1602  O   TYR A 215      66.308  57.567  49.854  1.00 62.75           O  
+ATOM   1603  CB  TYR A 215      66.271  59.576  51.918  1.00 54.21           C  
+ATOM   1604  CG  TYR A 215      65.613  60.432  52.967  1.00 55.74           C  
+ATOM   1605  CD1 TYR A 215      64.236  60.625  52.977  1.00 52.18           C  
+ATOM   1606  CD2 TYR A 215      66.376  61.070  53.954  1.00 61.87           C  
+ATOM   1607  CE1 TYR A 215      63.634  61.432  53.932  1.00 57.30           C  
+ATOM   1608  CE2 TYR A 215      65.779  61.886  54.923  1.00 55.81           C  
+ATOM   1609  CZ  TYR A 215      64.417  62.062  54.901  1.00 58.90           C  
+ATOM   1610  OH  TYR A 215      63.839  62.894  55.823  1.00 61.04           O  
+ATOM   1611  N   ASP A 216      67.536  56.329  51.271  1.00 55.66           N  
+ATOM   1612  CA  ASP A 216      68.096  55.518  50.203  1.00 56.18           C  
+ATOM   1613  C   ASP A 216      67.006  54.715  49.485  1.00 53.19           C  
+ATOM   1614  O   ASP A 216      65.932  54.469  50.030  1.00 53.82           O  
+ATOM   1615  CB  ASP A 216      69.188  54.593  50.740  1.00 55.40           C  
+ATOM   1616  CG  ASP A 216      70.532  55.296  50.859  1.00 61.25           C  
+ATOM   1617  OD1 ASP A 216      71.548  54.627  51.150  1.00 66.34           O  
+ATOM   1618  OD2 ASP A 216      70.579  56.523  50.657  1.00 62.95           O  
+ATOM   1619  N   TYR A 217      67.287  54.311  48.258  1.00 49.24           N  
+ATOM   1620  CA  TYR A 217      66.300  53.595  47.485  1.00 47.58           C  
+ATOM   1621  C   TYR A 217      66.999  52.815  46.404  1.00 43.49           C  
+ATOM   1622  O   TYR A 217      67.775  53.356  45.627  1.00 47.10           O  
+ATOM   1623  CB  TYR A 217      65.311  54.597  46.863  1.00 50.05           C  
+ATOM   1624  CG  TYR A 217      64.059  53.955  46.303  1.00 47.08           C  
+ATOM   1625  CD1 TYR A 217      62.936  53.772  47.088  1.00 47.16           C  
+ATOM   1626  CD2 TYR A 217      64.027  53.490  45.001  1.00 47.37           C  
+ATOM   1627  CE1 TYR A 217      61.812  53.139  46.589  1.00 49.55           C  
+ATOM   1628  CE2 TYR A 217      62.913  52.852  44.497  1.00 50.36           C  
+ATOM   1629  CZ  TYR A 217      61.810  52.676  45.290  1.00 49.17           C  
+ATOM   1630  OH  TYR A 217      60.718  52.006  44.774  1.00 49.16           O  
+ATOM   1631  N   SER A 218      66.702  51.532  46.349  1.00 45.62           N  
+ATOM   1632  CA  SER A 218      67.313  50.630  45.381  1.00 49.02           C  
+ATOM   1633  C   SER A 218      66.597  50.612  44.019  1.00 46.94           C  
+ATOM   1634  O   SER A 218      65.428  50.978  43.918  1.00 47.75           O  
+ATOM   1635  CB  SER A 218      67.325  49.211  45.971  1.00 45.81           C  
+ATOM   1636  OG  SER A 218      67.780  48.266  45.013  1.00 57.50           O  
+ATOM   1637  N   ARG A 219      67.303  50.157  42.988  1.00 47.42           N  
+ATOM   1638  CA  ARG A 219      66.730  50.075  41.654  1.00 52.48           C  
+ATOM   1639  C   ARG A 219      65.710  48.936  41.592  1.00 56.32           C  
+ATOM   1640  O   ARG A 219      64.646  49.085  40.976  1.00 57.68           O  
+ATOM   1641  CB  ARG A 219      67.828  49.856  40.604  1.00 47.25           C  
+ATOM   1642  CG  ARG A 219      68.835  50.970  40.547  1.00 47.15           C  
+ATOM   1643  CD  ARG A 219      69.564  51.007  39.224  1.00 49.48           C  
+ATOM   1644  NE  ARG A 219      70.576  49.964  39.073  1.00 54.68           N  
+ATOM   1645  CZ  ARG A 219      71.842  50.074  39.478  1.00 54.05           C  
+ATOM   1646  NH1 ARG A 219      72.280  51.184  40.071  1.00 48.45           N  
+ATOM   1647  NH2 ARG A 219      72.681  49.073  39.267  1.00 49.62           N  
+ATOM   1648  N   GLY A 220      66.035  47.809  42.233  1.00 55.85           N  
+ATOM   1649  CA  GLY A 220      65.134  46.660  42.264  1.00 50.97           C  
+ATOM   1650  C   GLY A 220      63.941  46.946  43.151  1.00 49.91           C  
+ATOM   1651  O   GLY A 220      62.867  46.355  43.008  1.00 50.99           O  
+ATOM   1652  N   GLN A 221      64.132  47.872  44.078  1.00 48.05           N  
+ATOM   1653  CA  GLN A 221      63.083  48.269  45.003  1.00 47.21           C  
+ATOM   1654  C   GLN A 221      61.920  48.955  44.265  1.00 48.49           C  
+ATOM   1655  O   GLN A 221      60.803  49.004  44.777  1.00 45.54           O  
+ATOM   1656  CB  GLN A 221      63.677  49.214  46.049  1.00 49.38           C  
+ATOM   1657  CG  GLN A 221      62.765  49.589  47.188  1.00 55.96           C  
+ATOM   1658  CD  GLN A 221      63.499  50.349  48.283  1.00 67.46           C  
+ATOM   1659  OE1 GLN A 221      64.680  50.089  48.565  1.00 70.40           O  
+ATOM   1660  NE2 GLN A 221      62.800  51.281  48.922  1.00 71.25           N  
+ATOM   1661  N   LEU A 222      62.192  49.508  43.077  1.00 50.06           N  
+ATOM   1662  CA  LEU A 222      61.155  50.159  42.271  1.00 44.41           C  
+ATOM   1663  C   LEU A 222      60.177  49.079  41.816  1.00 42.77           C  
+ATOM   1664  O   LEU A 222      58.967  49.226  41.913  1.00 42.08           O  
+ATOM   1665  CB  LEU A 222      61.757  50.825  41.024  1.00 46.44           C  
+ATOM   1666  CG  LEU A 222      60.731  51.477  40.073  1.00 44.61           C  
+ATOM   1667  CD1 LEU A 222      60.075  52.686  40.752  1.00 47.35           C  
+ATOM   1668  CD2 LEU A 222      61.413  51.916  38.797  1.00 51.72           C  
+ATOM   1669  N   ILE A 223      60.716  47.987  41.307  1.00 45.34           N  
+ATOM   1670  CA  ILE A 223      59.879  46.900  40.839  1.00 49.01           C  
+ATOM   1671  C   ILE A 223      58.922  46.395  41.899  1.00 51.39           C  
+ATOM   1672  O   ILE A 223      57.779  46.083  41.582  1.00 57.98           O  
+ATOM   1673  CB  ILE A 223      60.703  45.686  40.373  1.00 48.83           C  
+ATOM   1674  CG1 ILE A 223      61.731  46.106  39.333  1.00 45.97           C  
+ATOM   1675  CG2 ILE A 223      59.759  44.629  39.812  1.00 47.43           C  
+ATOM   1676  CD1 ILE A 223      62.533  44.952  38.757  1.00 46.96           C  
+ATOM   1677  N   GLU A 224      59.355  46.301  43.154  1.00 52.10           N  
+ATOM   1678  CA  GLU A 224      58.439  45.787  44.172  1.00 53.43           C  
+ATOM   1679  C   GLU A 224      57.455  46.818  44.714  1.00 50.70           C  
+ATOM   1680  O   GLU A 224      56.345  46.466  45.115  1.00 47.99           O  
+ATOM   1681  CB  GLU A 224      59.199  45.067  45.318  1.00 58.19           C  
+ATOM   1682  CG  GLU A 224      60.139  45.894  46.178  1.00 65.71           C  
+ATOM   1683  CD  GLU A 224      61.065  45.021  47.042  1.00 70.40           C  
+ATOM   1684  OE1 GLU A 224      61.891  44.282  46.464  1.00 71.48           O  
+ATOM   1685  OE2 GLU A 224      60.974  45.072  48.294  1.00 71.24           O  
+ATOM   1686  N   ASP A 225      57.825  48.092  44.718  1.00 49.34           N  
+ATOM   1687  CA  ASP A 225      56.874  49.089  45.194  1.00 47.61           C  
+ATOM   1688  C   ASP A 225      55.784  49.288  44.144  1.00 46.96           C  
+ATOM   1689  O   ASP A 225      54.644  49.615  44.473  1.00 43.62           O  
+ATOM   1690  CB  ASP A 225      57.578  50.406  45.488  1.00 51.78           C  
+ATOM   1691  CG  ASP A 225      58.555  50.277  46.632  1.00 57.96           C  
+ATOM   1692  OD1 ASP A 225      58.215  49.582  47.617  1.00 60.88           O  
+ATOM   1693  OD2 ASP A 225      59.646  50.863  46.558  1.00 60.99           O  
+ATOM   1694  N   VAL A 226      56.147  49.083  42.879  1.00 45.20           N  
+ATOM   1695  CA  VAL A 226      55.193  49.207  41.782  1.00 47.37           C  
+ATOM   1696  C   VAL A 226      54.204  48.039  41.926  1.00 43.31           C  
+ATOM   1697  O   VAL A 226      52.993  48.229  42.033  1.00 45.69           O  
+ATOM   1698  CB  VAL A 226      55.934  49.169  40.377  1.00 44.11           C  
+ATOM   1699  CG1 VAL A 226      54.950  48.901  39.259  1.00 44.92           C  
+ATOM   1700  CG2 VAL A 226      56.620  50.515  40.109  1.00 45.69           C  
+ATOM   1701  N   GLU A 227      54.727  46.827  41.971  1.00 48.17           N  
+ATOM   1702  CA  GLU A 227      53.872  45.649  42.107  1.00 48.96           C  
+ATOM   1703  C   GLU A 227      53.031  45.637  43.370  1.00 48.83           C  
+ATOM   1704  O   GLU A 227      51.893  45.189  43.343  1.00 50.72           O  
+ATOM   1705  CB  GLU A 227      54.727  44.399  42.029  1.00 50.84           C  
+ATOM   1706  CG  GLU A 227      55.570  44.425  40.780  1.00 53.80           C  
+ATOM   1707  CD  GLU A 227      56.320  43.150  40.540  1.00 59.10           C  
+ATOM   1708  OE1 GLU A 227      56.853  42.588  41.525  1.00 61.80           O  
+ATOM   1709  OE2 GLU A 227      56.395  42.730  39.357  1.00 55.85           O  
+ATOM   1710  N   HIS A 228      53.572  46.148  44.472  1.00 48.24           N  
+ATOM   1711  CA  HIS A 228      52.826  46.169  45.731  1.00 50.58           C  
+ATOM   1712  C   HIS A 228      51.708  47.187  45.648  1.00 49.55           C  
+ATOM   1713  O   HIS A 228      50.583  46.942  46.091  1.00 53.67           O  
+ATOM   1714  CB  HIS A 228      53.760  46.491  46.922  1.00 50.99           C  
+ATOM   1715  CG  HIS A 228      53.037  46.821  48.193  1.00 56.14           C  
+ATOM   1716  ND1 HIS A 228      52.414  48.036  48.407  1.00 62.44           N  
+ATOM   1717  CD2 HIS A 228      52.817  46.088  49.313  1.00 61.37           C  
+ATOM   1718  CE1 HIS A 228      51.842  48.036  49.600  1.00 61.27           C  
+ATOM   1719  NE2 HIS A 228      52.071  46.865  50.170  1.00 61.15           N  
+ATOM   1720  N   THR A 229      52.010  48.342  45.087  1.00 47.14           N  
+ATOM   1721  CA  THR A 229      50.988  49.368  44.953  1.00 46.95           C  
+ATOM   1722  C   THR A 229      49.938  48.949  43.889  1.00 43.41           C  
+ATOM   1723  O   THR A 229      48.755  49.258  44.001  1.00 42.40           O  
+ATOM   1724  CB  THR A 229      51.640  50.714  44.569  1.00 48.14           C  
+ATOM   1725  OG1 THR A 229      50.621  51.703  44.446  1.00 61.31           O  
+ATOM   1726  CG2 THR A 229      52.403  50.598  43.244  1.00 35.15           C  
+ATOM   1727  N   PHE A 230      50.371  48.223  42.868  1.00 44.54           N  
+ATOM   1728  CA  PHE A 230      49.456  47.784  41.829  1.00 47.61           C  
+ATOM   1729  C   PHE A 230      48.382  46.833  42.380  1.00 49.90           C  
+ATOM   1730  O   PHE A 230      47.209  46.916  41.993  1.00 47.47           O  
+ATOM   1731  CB  PHE A 230      50.230  47.116  40.696  1.00 48.01           C  
+ATOM   1732  CG  PHE A 230      49.368  46.741  39.545  1.00 50.55           C  
+ATOM   1733  CD1 PHE A 230      48.670  47.720  38.854  1.00 48.24           C  
+ATOM   1734  CD2 PHE A 230      49.180  45.404  39.203  1.00 51.35           C  
+ATOM   1735  CE1 PHE A 230      47.793  47.384  37.845  1.00 48.09           C  
+ATOM   1736  CE2 PHE A 230      48.298  45.058  38.193  1.00 50.58           C  
+ATOM   1737  CZ  PHE A 230      47.604  46.048  37.514  1.00 50.90           C  
+ATOM   1738  N   GLU A 231      48.781  45.949  43.298  1.00 52.41           N  
+ATOM   1739  CA  GLU A 231      47.851  45.004  43.932  1.00 52.36           C  
+ATOM   1740  C   GLU A 231      46.677  45.724  44.560  1.00 49.53           C  
+ATOM   1741  O   GLU A 231      45.536  45.291  44.435  1.00 50.81           O  
+ATOM   1742  CB  GLU A 231      48.552  44.189  45.018  1.00 55.50           C  
+ATOM   1743  CG  GLU A 231      49.387  43.035  44.501  1.00 65.99           C  
+ATOM   1744  CD  GLU A 231      48.548  41.956  43.830  1.00 70.56           C  
+ATOM   1745  OE1 GLU A 231      47.473  41.617  44.379  1.00 73.90           O  
+ATOM   1746  OE2 GLU A 231      48.972  41.441  42.767  1.00 73.54           O  
+ATOM   1747  N   GLU A 232      46.958  46.823  45.245  1.00 47.42           N  
+ATOM   1748  CA  GLU A 232      45.901  47.605  45.879  1.00 49.60           C  
+ATOM   1749  C   GLU A 232      44.978  48.298  44.884  1.00 47.92           C  
+ATOM   1750  O   GLU A 232      43.883  48.712  45.239  1.00 50.81           O  
+ATOM   1751  CB  GLU A 232      46.508  48.675  46.787  1.00 54.22           C  
+ATOM   1752  CG  GLU A 232      46.870  48.196  48.179  1.00 64.26           C  
+ATOM   1753  CD  GLU A 232      47.601  49.256  48.977  1.00 67.17           C  
+ATOM   1754  OE1 GLU A 232      48.800  49.490  48.687  1.00 72.80           O  
+ATOM   1755  OE2 GLU A 232      46.974  49.856  49.879  1.00 66.71           O  
+ATOM   1756  N   ILE A 233      45.427  48.447  43.645  1.00 47.41           N  
+ATOM   1757  CA  ILE A 233      44.624  49.124  42.635  1.00 50.68           C  
+ATOM   1758  C   ILE A 233      43.703  48.136  41.906  1.00 48.41           C  
+ATOM   1759  O   ILE A 233      42.663  48.510  41.377  1.00 48.06           O  
+ATOM   1760  CB  ILE A 233      45.556  49.857  41.620  1.00 52.01           C  
+ATOM   1761  CG1 ILE A 233      45.037  51.252  41.339  1.00 53.39           C  
+ATOM   1762  CG2 ILE A 233      45.584  49.122  40.308  1.00 55.14           C  
+ATOM   1763  CD1 ILE A 233      43.869  51.257  40.393  1.00 54.56           C  
+ATOM   1764  N   LYS A 234      44.082  46.867  41.914  1.00 50.67           N  
+ATOM   1765  CA  LYS A 234      43.310  45.830  41.239  1.00 53.80           C  
+ATOM   1766  C   LYS A 234      41.796  45.781  41.461  1.00 52.37           C  
+ATOM   1767  O   LYS A 234      41.052  45.639  40.502  1.00 54.07           O  
+ATOM   1768  CB  LYS A 234      43.900  44.449  41.537  1.00 51.34           C  
+ATOM   1769  CG  LYS A 234      45.193  44.137  40.808  1.00 55.23           C  
+ATOM   1770  CD  LYS A 234      45.629  42.676  41.070  1.00 57.52           C  
+ATOM   1771  CE  LYS A 234      46.964  42.360  40.419  1.00 60.70           C  
+ATOM   1772  NZ  LYS A 234      47.432  40.964  40.666  1.00 64.37           N  
+ATOM   1773  N   PRO A 235      41.318  45.879  42.717  1.00 52.27           N  
+ATOM   1774  CA  PRO A 235      39.866  45.828  42.904  1.00 50.42           C  
+ATOM   1775  C   PRO A 235      39.150  46.952  42.164  1.00 50.15           C  
+ATOM   1776  O   PRO A 235      38.129  46.733  41.514  1.00 51.90           O  
+ATOM   1777  CB  PRO A 235      39.703  45.926  44.425  1.00 52.00           C  
+ATOM   1778  CG  PRO A 235      40.951  45.274  44.932  1.00 50.26           C  
+ATOM   1779  CD  PRO A 235      42.010  45.861  44.019  1.00 55.55           C  
+ATOM   1780  N   LEU A 236      39.681  48.161  42.267  1.00 48.59           N  
+ATOM   1781  CA  LEU A 236      39.071  49.281  41.578  1.00 47.72           C  
+ATOM   1782  C   LEU A 236      39.075  49.010  40.068  1.00 45.59           C  
+ATOM   1783  O   LEU A 236      38.069  49.202  39.398  1.00 44.65           O  
+ATOM   1784  CB  LEU A 236      39.838  50.573  41.872  1.00 47.96           C  
+ATOM   1785  CG  LEU A 236      39.381  51.753  41.020  1.00 47.32           C  
+ATOM   1786  CD1 LEU A 236      37.905  52.037  41.280  1.00 47.06           C  
+ATOM   1787  CD2 LEU A 236      40.221  52.962  41.342  1.00 48.64           C  
+ATOM   1788  N   TYR A 237      40.202  48.556  39.541  1.00 44.58           N  
+ATOM   1789  CA  TYR A 237      40.305  48.280  38.112  1.00 46.85           C  
+ATOM   1790  C   TYR A 237      39.345  47.195  37.633  1.00 49.03           C  
+ATOM   1791  O   TYR A 237      38.639  47.393  36.646  1.00 49.90           O  
+ATOM   1792  CB  TYR A 237      41.732  47.882  37.751  1.00 46.93           C  
+ATOM   1793  CG  TYR A 237      41.910  47.596  36.276  1.00 44.95           C  
+ATOM   1794  CD1 TYR A 237      41.742  48.600  35.334  1.00 41.54           C  
+ATOM   1795  CD2 TYR A 237      42.195  46.315  35.825  1.00 39.75           C  
+ATOM   1796  CE1 TYR A 237      41.850  48.335  33.983  1.00 39.62           C  
+ATOM   1797  CE2 TYR A 237      42.300  46.041  34.480  1.00 42.76           C  
+ATOM   1798  CZ  TYR A 237      42.129  47.058  33.559  1.00 43.52           C  
+ATOM   1799  OH  TYR A 237      42.270  46.800  32.208  1.00 39.87           O  
+ATOM   1800  N   GLU A 238      39.324  46.052  38.321  1.00 48.83           N  
+ATOM   1801  CA  GLU A 238      38.426  44.944  37.970  1.00 50.10           C  
+ATOM   1802  C   GLU A 238      36.968  45.398  37.858  1.00 49.81           C  
+ATOM   1803  O   GLU A 238      36.245  44.940  36.979  1.00 52.07           O  
+ATOM   1804  CB  GLU A 238      38.490  43.824  39.018  1.00 47.15           C  
+ATOM   1805  CG  GLU A 238      39.798  43.100  39.089  1.00 58.34           C  
+ATOM   1806  CD  GLU A 238      39.756  41.908  40.044  1.00 65.67           C  
+ATOM   1807  OE1 GLU A 238      40.806  41.228  40.196  1.00 67.95           O  
+ATOM   1808  OE2 GLU A 238      38.678  41.658  40.637  1.00 62.80           O  
+ATOM   1809  N   HIS A 239      36.542  46.273  38.767  1.00 46.17           N  
+ATOM   1810  CA  HIS A 239      35.180  46.783  38.770  1.00 46.40           C  
+ATOM   1811  C   HIS A 239      34.954  47.776  37.644  1.00 47.86           C  
+ATOM   1812  O   HIS A 239      33.847  47.895  37.098  1.00 48.84           O  
+ATOM   1813  CB  HIS A 239      34.869  47.444  40.114  1.00 48.69           C  
+ATOM   1814  CG  HIS A 239      34.464  46.468  41.173  1.00 51.53           C  
+ATOM   1815  ND1 HIS A 239      33.203  45.916  41.229  1.00 53.42           N  
+ATOM   1816  CD2 HIS A 239      35.173  45.888  42.168  1.00 50.72           C  
+ATOM   1817  CE1 HIS A 239      33.153  45.036  42.212  1.00 51.07           C  
+ATOM   1818  NE2 HIS A 239      34.335  44.999  42.796  1.00 54.57           N  
+ATOM   1819  N   LEU A 240      36.010  48.494  37.304  1.00 43.13           N  
+ATOM   1820  CA  LEU A 240      35.939  49.448  36.233  1.00 42.93           C  
+ATOM   1821  C   LEU A 240      35.848  48.581  34.976  1.00 39.85           C  
+ATOM   1822  O   LEU A 240      35.066  48.842  34.078  1.00 39.89           O  
+ATOM   1823  CB  LEU A 240      37.214  50.299  36.241  1.00 42.82           C  
+ATOM   1824  CG  LEU A 240      37.229  51.560  35.373  1.00 43.56           C  
+ATOM   1825  CD1 LEU A 240      37.913  51.293  34.087  1.00 46.06           C  
+ATOM   1826  CD2 LEU A 240      35.819  52.048  35.164  1.00 40.50           C  
+ATOM   1827  N   HIS A 241      36.649  47.527  34.955  1.00 39.76           N  
+ATOM   1828  CA  HIS A 241      36.716  46.589  33.851  1.00 40.34           C  
+ATOM   1829  C   HIS A 241      35.382  45.877  33.601  1.00 43.11           C  
+ATOM   1830  O   HIS A 241      34.949  45.762  32.458  1.00 44.51           O  
+ATOM   1831  CB  HIS A 241      37.827  45.578  34.144  1.00 39.18           C  
+ATOM   1832  CG  HIS A 241      37.996  44.526  33.093  1.00 42.51           C  
+ATOM   1833  ND1 HIS A 241      37.044  43.559  32.841  1.00 42.16           N  
+ATOM   1834  CD2 HIS A 241      39.027  44.265  32.256  1.00 44.74           C  
+ATOM   1835  CE1 HIS A 241      37.484  42.748  31.896  1.00 40.83           C  
+ATOM   1836  NE2 HIS A 241      38.686  43.153  31.526  1.00 45.21           N  
+ATOM   1837  N   ALA A 242      34.745  45.403  34.674  1.00 45.07           N  
+ATOM   1838  CA  ALA A 242      33.464  44.700  34.594  1.00 46.13           C  
+ATOM   1839  C   ALA A 242      32.369  45.645  34.143  1.00 46.12           C  
+ATOM   1840  O   ALA A 242      31.453  45.262  33.424  1.00 50.38           O  
+ATOM   1841  CB  ALA A 242      33.099  44.103  35.955  1.00 44.72           C  
+ATOM   1842  N   TYR A 243      32.458  46.892  34.566  1.00 47.59           N  
+ATOM   1843  CA  TYR A 243      31.448  47.850  34.176  1.00 45.30           C  
+ATOM   1844  C   TYR A 243      31.595  48.256  32.707  1.00 47.30           C  
+ATOM   1845  O   TYR A 243      30.600  48.334  31.980  1.00 47.74           O  
+ATOM   1846  CB  TYR A 243      31.512  49.088  35.075  1.00 39.17           C  
+ATOM   1847  CG  TYR A 243      30.652  50.236  34.596  1.00 36.29           C  
+ATOM   1848  CD1 TYR A 243      29.291  50.271  34.861  1.00 37.69           C  
+ATOM   1849  CD2 TYR A 243      31.207  51.284  33.872  1.00 34.23           C  
+ATOM   1850  CE1 TYR A 243      28.494  51.332  34.415  1.00 44.45           C  
+ATOM   1851  CE2 TYR A 243      30.430  52.340  33.425  1.00 43.89           C  
+ATOM   1852  CZ  TYR A 243      29.074  52.358  33.697  1.00 44.06           C  
+ATOM   1853  OH  TYR A 243      28.300  53.394  33.225  1.00 49.40           O  
+ATOM   1854  N   VAL A 244      32.812  48.515  32.241  1.00 45.54           N  
+ATOM   1855  CA  VAL A 244      32.895  48.921  30.850  1.00 46.64           C  
+ATOM   1856  C   VAL A 244      32.704  47.691  29.965  1.00 47.60           C  
+ATOM   1857  O   VAL A 244      32.139  47.794  28.886  1.00 44.97           O  
+ATOM   1858  CB  VAL A 244      34.228  49.666  30.489  1.00 45.81           C  
+ATOM   1859  CG1 VAL A 244      34.744  50.510  31.696  1.00 40.13           C  
+ATOM   1860  CG2 VAL A 244      35.242  48.692  29.969  1.00 45.66           C  
+ATOM   1861  N   ARG A 245      33.153  46.525  30.424  1.00 48.86           N  
+ATOM   1862  CA  ARG A 245      32.960  45.307  29.640  1.00 53.46           C  
+ATOM   1863  C   ARG A 245      31.458  45.040  29.403  1.00 56.24           C  
+ATOM   1864  O   ARG A 245      31.077  44.506  28.361  1.00 57.65           O  
+ATOM   1865  CB  ARG A 245      33.623  44.104  30.328  1.00 51.97           C  
+ATOM   1866  CG  ARG A 245      32.666  43.097  30.884  1.00 57.07           C  
+ATOM   1867  CD  ARG A 245      32.838  41.736  30.261  1.00 47.52           C  
+ATOM   1868  NE  ARG A 245      33.987  41.005  30.770  1.00 48.81           N  
+ATOM   1869  CZ  ARG A 245      34.198  40.705  32.051  1.00 44.98           C  
+ATOM   1870  NH1 ARG A 245      35.282  40.021  32.409  1.00 44.36           N  
+ATOM   1871  NH2 ARG A 245      33.342  41.088  32.974  1.00 44.06           N  
+ATOM   1872  N   ALA A 246      30.603  45.412  30.357  1.00 55.46           N  
+ATOM   1873  CA  ALA A 246      29.163  45.215  30.174  1.00 54.83           C  
+ATOM   1874  C   ALA A 246      28.581  46.261  29.215  1.00 55.22           C  
+ATOM   1875  O   ALA A 246      27.626  45.986  28.484  1.00 53.54           O  
+ATOM   1876  CB  ALA A 246      28.443  45.276  31.514  1.00 55.39           C  
+ATOM   1877  N   LYS A 247      29.160  47.458  29.224  1.00 52.79           N  
+ATOM   1878  CA  LYS A 247      28.715  48.536  28.358  1.00 53.43           C  
+ATOM   1879  C   LYS A 247      29.128  48.258  26.923  1.00 52.53           C  
+ATOM   1880  O   LYS A 247      28.376  48.546  25.993  1.00 52.90           O  
+ATOM   1881  CB  LYS A 247      29.313  49.870  28.810  1.00 55.34           C  
+ATOM   1882  CG  LYS A 247      28.679  50.445  30.065  1.00 59.73           C  
+ATOM   1883  CD  LYS A 247      27.304  51.019  29.767  1.00 62.64           C  
+ATOM   1884  CE  LYS A 247      26.719  51.696  30.990  1.00 64.23           C  
+ATOM   1885  NZ  LYS A 247      25.372  52.269  30.701  1.00 67.48           N  
+ATOM   1886  N   LEU A 248      30.326  47.703  26.748  1.00 49.18           N  
+ATOM   1887  CA  LEU A 248      30.825  47.380  25.420  1.00 49.93           C  
+ATOM   1888  C   LEU A 248      30.026  46.220  24.817  1.00 53.39           C  
+ATOM   1889  O   LEU A 248      30.008  46.040  23.593  1.00 54.44           O  
+ATOM   1890  CB  LEU A 248      32.307  47.011  25.464  1.00 45.92           C  
+ATOM   1891  CG  LEU A 248      33.350  48.114  25.682  1.00 49.86           C  
+ATOM   1892  CD1 LEU A 248      34.738  47.484  25.756  1.00 43.04           C  
+ATOM   1893  CD2 LEU A 248      33.284  49.131  24.547  1.00 49.81           C  
+ATOM   1894  N   MET A 249      29.383  45.421  25.668  1.00 53.68           N  
+ATOM   1895  CA  MET A 249      28.578  44.315  25.163  1.00 57.59           C  
+ATOM   1896  C   MET A 249      27.344  44.863  24.457  1.00 57.11           C  
+ATOM   1897  O   MET A 249      26.917  44.325  23.440  1.00 59.00           O  
+ATOM   1898  CB  MET A 249      28.179  43.357  26.287  1.00 55.72           C  
+ATOM   1899  CG  MET A 249      29.331  42.467  26.719  1.00 58.68           C  
+ATOM   1900  SD  MET A 249      28.906  41.289  28.013  1.00 63.02           S  
+ATOM   1901  CE  MET A 249      28.609  42.361  29.372  1.00 63.36           C  
+ATOM   1902  N   ASN A 250      26.785  45.950  24.973  1.00 57.32           N  
+ATOM   1903  CA  ASN A 250      25.622  46.543  24.332  1.00 57.74           C  
+ATOM   1904  C   ASN A 250      26.063  47.164  23.013  1.00 58.15           C  
+ATOM   1905  O   ASN A 250      25.326  47.130  22.025  1.00 56.21           O  
+ATOM   1906  CB  ASN A 250      24.979  47.624  25.216  1.00 57.93           C  
+ATOM   1907  CG  ASN A 250      24.475  47.077  26.556  1.00 62.54           C  
+ATOM   1908  OD1 ASN A 250      24.197  45.878  26.699  1.00 58.59           O  
+ATOM   1909  ND2 ASN A 250      24.335  47.966  27.539  1.00 61.20           N  
+ATOM   1910  N   ALA A 251      27.276  47.715  22.996  1.00 57.54           N  
+ATOM   1911  CA  ALA A 251      27.823  48.362  21.796  1.00 55.25           C  
+ATOM   1912  C   ALA A 251      28.258  47.385  20.705  1.00 52.88           C  
+ATOM   1913  O   ALA A 251      28.216  47.719  19.528  1.00 55.84           O  
+ATOM   1914  CB  ALA A 251      29.001  49.265  22.173  1.00 52.97           C  
+ATOM   1915  N   TYR A 252      28.677  46.189  21.103  1.00 51.77           N  
+ATOM   1916  CA  TYR A 252      29.139  45.160  20.170  1.00 51.37           C  
+ATOM   1917  C   TYR A 252      28.438  43.836  20.493  1.00 51.76           C  
+ATOM   1918  O   TYR A 252      29.064  42.838  20.867  1.00 50.50           O  
+ATOM   1919  CB  TYR A 252      30.659  45.008  20.301  1.00 49.21           C  
+ATOM   1920  CG  TYR A 252      31.427  46.263  19.942  1.00 48.35           C  
+ATOM   1921  CD1 TYR A 252      31.550  46.677  18.621  1.00 40.87           C  
+ATOM   1922  CD2 TYR A 252      32.019  47.052  20.936  1.00 51.01           C  
+ATOM   1923  CE1 TYR A 252      32.243  47.838  18.298  1.00 43.86           C  
+ATOM   1924  CE2 TYR A 252      32.714  48.221  20.615  1.00 44.15           C  
+ATOM   1925  CZ  TYR A 252      32.826  48.606  19.301  1.00 47.18           C  
+ATOM   1926  OH  TYR A 252      33.548  49.750  18.985  1.00 46.71           O  
+ATOM   1927  N   PRO A 253      27.112  43.814  20.336  1.00 54.10           N  
+ATOM   1928  CA  PRO A 253      26.281  42.639  20.612  1.00 54.70           C  
+ATOM   1929  C   PRO A 253      26.858  41.337  20.064  1.00 55.69           C  
+ATOM   1930  O   PRO A 253      27.178  41.253  18.886  1.00 53.47           O  
+ATOM   1931  CB  PRO A 253      24.951  42.998  19.962  1.00 54.94           C  
+ATOM   1932  CG  PRO A 253      24.929  44.497  20.010  1.00 54.29           C  
+ATOM   1933  CD  PRO A 253      26.341  44.860  19.642  1.00 53.61           C  
+ATOM   1934  N   SER A 254      26.992  40.341  20.938  1.00 56.67           N  
+ATOM   1935  CA  SER A 254      27.496  39.016  20.584  1.00 59.60           C  
+ATOM   1936  C   SER A 254      28.973  38.882  20.233  1.00 58.55           C  
+ATOM   1937  O   SER A 254      29.401  37.860  19.705  1.00 61.64           O  
+ATOM   1938  CB  SER A 254      26.654  38.434  19.443  1.00 64.14           C  
+ATOM   1939  OG  SER A 254      25.329  38.172  19.892  1.00 69.06           O  
+ATOM   1940  N   TYR A 255      29.759  39.902  20.532  1.00 57.89           N  
+ATOM   1941  CA  TYR A 255      31.184  39.858  20.240  1.00 56.58           C  
+ATOM   1942  C   TYR A 255      32.013  39.638  21.496  1.00 54.58           C  
+ATOM   1943  O   TYR A 255      33.157  39.212  21.412  1.00 56.39           O  
+ATOM   1944  CB  TYR A 255      31.632  41.170  19.574  1.00 56.53           C  
+ATOM   1945  CG  TYR A 255      31.369  41.253  18.082  1.00 59.50           C  
+ATOM   1946  CD1 TYR A 255      30.627  42.297  17.536  1.00 60.11           C  
+ATOM   1947  CD2 TYR A 255      31.913  40.310  17.209  1.00 60.46           C  
+ATOM   1948  CE1 TYR A 255      30.441  42.399  16.153  1.00 58.51           C  
+ATOM   1949  CE2 TYR A 255      31.734  40.405  15.842  1.00 57.06           C  
+ATOM   1950  CZ  TYR A 255      30.999  41.448  15.316  1.00 61.08           C  
+ATOM   1951  OH  TYR A 255      30.840  41.531  13.943  1.00 59.81           O  
+ATOM   1952  N   ILE A 256      31.428  39.903  22.660  1.00 53.74           N  
+ATOM   1953  CA  ILE A 256      32.175  39.800  23.909  1.00 54.01           C  
+ATOM   1954  C   ILE A 256      31.543  38.913  24.979  1.00 52.08           C  
+ATOM   1955  O   ILE A 256      30.351  38.978  25.210  1.00 55.01           O  
+ATOM   1956  CB  ILE A 256      32.373  41.212  24.510  1.00 52.12           C  
+ATOM   1957  CG1 ILE A 256      33.084  42.104  23.491  1.00 50.47           C  
+ATOM   1958  CG2 ILE A 256      33.159  41.120  25.820  1.00 51.76           C  
+ATOM   1959  CD1 ILE A 256      32.957  43.590  23.789  1.00 52.24           C  
+ATOM   1960  N   SER A 257      32.365  38.103  25.634  1.00 51.77           N  
+ATOM   1961  CA  SER A 257      31.917  37.203  26.694  1.00 52.05           C  
+ATOM   1962  C   SER A 257      31.727  37.947  28.034  1.00 53.59           C  
+ATOM   1963  O   SER A 257      32.477  38.862  28.372  1.00 54.28           O  
+ATOM   1964  CB  SER A 257      32.938  36.081  26.861  1.00 47.38           C  
+ATOM   1965  OG  SER A 257      32.686  35.323  28.031  1.00 54.64           O  
+ATOM   1966  N   PRO A 258      30.705  37.564  28.804  1.00 54.66           N  
+ATOM   1967  CA  PRO A 258      30.398  38.176  30.103  1.00 52.68           C  
+ATOM   1968  C   PRO A 258      31.506  37.944  31.113  1.00 48.60           C  
+ATOM   1969  O   PRO A 258      31.593  38.639  32.132  1.00 47.21           O  
+ATOM   1970  CB  PRO A 258      29.102  37.465  30.532  1.00 57.33           C  
+ATOM   1971  CG  PRO A 258      28.499  36.993  29.223  1.00 56.86           C  
+ATOM   1972  CD  PRO A 258      29.709  36.534  28.459  1.00 56.55           C  
+ATOM   1973  N   ILE A 259      32.336  36.941  30.851  1.00 45.70           N  
+ATOM   1974  CA  ILE A 259      33.416  36.632  31.768  1.00 48.63           C  
+ATOM   1975  C   ILE A 259      34.797  36.797  31.143  1.00 48.41           C  
+ATOM   1976  O   ILE A 259      35.813  36.559  31.805  1.00 47.89           O  
+ATOM   1977  CB  ILE A 259      33.330  35.176  32.272  1.00 48.93           C  
+ATOM   1978  CG1 ILE A 259      33.595  34.223  31.101  1.00 50.35           C  
+ATOM   1979  CG2 ILE A 259      31.978  34.927  32.945  1.00 46.42           C  
+ATOM   1980  CD1 ILE A 259      34.060  32.833  31.526  1.00 50.29           C  
+ATOM   1981  N   GLY A 260      34.839  37.207  29.881  1.00 47.41           N  
+ATOM   1982  CA  GLY A 260      36.123  37.325  29.217  1.00 49.62           C  
+ATOM   1983  C   GLY A 260      36.830  38.668  29.204  1.00 52.45           C  
+ATOM   1984  O   GLY A 260      36.289  39.702  29.615  1.00 52.34           O  
+ATOM   1985  N   CYS A 261      38.074  38.625  28.740  1.00 50.98           N  
+ATOM   1986  CA  CYS A 261      38.897  39.811  28.598  1.00 49.33           C  
+ATOM   1987  C   CYS A 261      38.270  40.688  27.508  1.00 50.48           C  
+ATOM   1988  O   CYS A 261      37.478  40.212  26.682  1.00 49.15           O  
+ATOM   1989  CB  CYS A 261      40.306  39.419  28.163  1.00 44.67           C  
+ATOM   1990  SG  CYS A 261      41.324  38.589  29.435  1.00 55.23           S  
+ATOM   1991  N   LEU A 262      38.630  41.965  27.513  1.00 46.05           N  
+ATOM   1992  CA  LEU A 262      38.141  42.906  26.529  1.00 47.30           C  
+ATOM   1993  C   LEU A 262      38.980  42.726  25.288  1.00 45.85           C  
+ATOM   1994  O   LEU A 262      40.195  42.626  25.374  1.00 45.26           O  
+ATOM   1995  CB  LEU A 262      38.309  44.334  27.039  1.00 48.06           C  
+ATOM   1996  CG  LEU A 262      37.507  44.594  28.305  1.00 50.82           C  
+ATOM   1997  CD1 LEU A 262      37.797  45.995  28.864  1.00 46.03           C  
+ATOM   1998  CD2 LEU A 262      36.023  44.407  27.962  1.00 49.54           C  
+ATOM   1999  N   PRO A 263      38.341  42.639  24.116  1.00 45.39           N  
+ATOM   2000  CA  PRO A 263      39.132  42.475  22.900  1.00 46.53           C  
+ATOM   2001  C   PRO A 263      39.987  43.736  22.704  1.00 45.65           C  
+ATOM   2002  O   PRO A 263      39.493  44.856  22.799  1.00 46.36           O  
+ATOM   2003  CB  PRO A 263      38.065  42.293  21.822  1.00 50.08           C  
+ATOM   2004  CG  PRO A 263      36.970  41.567  22.571  1.00 48.47           C  
+ATOM   2005  CD  PRO A 263      36.915  42.384  23.858  1.00 46.15           C  
+ATOM   2006  N   ALA A 264      41.273  43.535  22.439  1.00 44.69           N  
+ATOM   2007  CA  ALA A 264      42.232  44.619  22.259  1.00 43.71           C  
+ATOM   2008  C   ALA A 264      41.875  45.780  21.300  1.00 45.19           C  
+ATOM   2009  O   ALA A 264      42.269  46.944  21.541  1.00 41.81           O  
+ATOM   2010  CB  ALA A 264      43.556  44.021  21.860  1.00 44.14           C  
+ATOM   2011  N   HIS A 265      41.128  45.486  20.234  1.00 41.80           N  
+ATOM   2012  CA  HIS A 265      40.780  46.516  19.245  1.00 40.05           C  
+ATOM   2013  C   HIS A 265      39.545  47.350  19.526  1.00 39.56           C  
+ATOM   2014  O   HIS A 265      39.189  48.186  18.717  1.00 38.58           O  
+ATOM   2015  CB  HIS A 265      40.625  45.877  17.859  1.00 44.97           C  
+ATOM   2016  CG  HIS A 265      39.442  44.966  17.745  1.00 44.22           C  
+ATOM   2017  ND1 HIS A 265      39.290  43.842  18.528  1.00 43.94           N  
+ATOM   2018  CD2 HIS A 265      38.364  45.003  16.924  1.00 48.01           C  
+ATOM   2019  CE1 HIS A 265      38.172  43.221  18.191  1.00 50.36           C  
+ATOM   2020  NE2 HIS A 265      37.592  43.905  17.218  1.00 49.18           N  
+ATOM   2021  N   LEU A 266      38.895  47.144  20.666  1.00 41.62           N  
+ATOM   2022  CA  LEU A 266      37.687  47.893  20.988  1.00 42.13           C  
+ATOM   2023  C   LEU A 266      37.849  48.908  22.130  1.00 43.88           C  
+ATOM   2024  O   LEU A 266      36.860  49.332  22.710  1.00 44.94           O  
+ATOM   2025  CB  LEU A 266      36.568  46.909  21.375  1.00 43.06           C  
+ATOM   2026  CG  LEU A 266      36.255  45.749  20.408  1.00 44.20           C  
+ATOM   2027  CD1 LEU A 266      35.110  44.868  20.938  1.00 41.05           C  
+ATOM   2028  CD2 LEU A 266      35.879  46.322  19.062  1.00 42.96           C  
+ATOM   2029  N   LEU A 267      39.070  49.333  22.439  1.00 47.16           N  
+ATOM   2030  CA  LEU A 267      39.258  50.214  23.599  1.00 45.45           C  
+ATOM   2031  C   LEU A 267      39.411  51.717  23.431  1.00 46.77           C  
+ATOM   2032  O   LEU A 267      39.669  52.417  24.407  1.00 46.05           O  
+ATOM   2033  CB  LEU A 267      40.433  49.707  24.428  1.00 42.24           C  
+ATOM   2034  CG  LEU A 267      40.412  48.222  24.808  1.00 43.22           C  
+ATOM   2035  CD1 LEU A 267      41.832  47.787  25.244  1.00 40.19           C  
+ATOM   2036  CD2 LEU A 267      39.376  47.984  25.896  1.00 39.57           C  
+ATOM   2037  N   GLY A 268      39.301  52.248  22.226  1.00 44.30           N  
+ATOM   2038  CA  GLY A 268      39.396  53.695  22.164  1.00 47.84           C  
+ATOM   2039  C   GLY A 268      40.634  54.315  21.577  1.00 43.23           C  
+ATOM   2040  O   GLY A 268      40.639  55.499  21.276  1.00 48.01           O  
+ATOM   2041  N   ASP A 269      41.705  53.549  21.476  1.00 40.64           N  
+ATOM   2042  CA  ASP A 269      42.889  54.049  20.820  1.00 40.84           C  
+ATOM   2043  C   ASP A 269      43.555  52.814  20.270  1.00 37.55           C  
+ATOM   2044  O   ASP A 269      43.048  51.706  20.456  1.00 39.95           O  
+ATOM   2045  CB  ASP A 269      43.774  54.968  21.723  1.00 42.78           C  
+ATOM   2046  CG  ASP A 269      44.590  54.234  22.809  1.00 45.47           C  
+ATOM   2047  OD1 ASP A 269      44.828  54.899  23.835  1.00 46.89           O  
+ATOM   2048  OD2 ASP A 269      45.045  53.078  22.659  1.00 38.91           O  
+ATOM   2049  N   MET A 270      44.653  52.983  19.571  1.00 35.89           N  
+ATOM   2050  CA  MET A 270      45.278  51.848  18.931  1.00 39.83           C  
+ATOM   2051  C   MET A 270      45.809  50.725  19.827  1.00 42.98           C  
+ATOM   2052  O   MET A 270      46.071  49.615  19.338  1.00 42.26           O  
+ATOM   2053  CB  MET A 270      46.382  52.364  18.017  1.00 35.76           C  
+ATOM   2054  CG  MET A 270      47.108  51.283  17.183  1.00 42.06           C  
+ATOM   2055  SD  MET A 270      45.997  50.369  16.080  1.00 41.55           S  
+ATOM   2056  CE  MET A 270      46.251  51.328  14.575  1.00 43.14           C  
+ATOM   2057  N   TRP A 271      45.917  50.980  21.128  1.00 40.81           N  
+ATOM   2058  CA  TRP A 271      46.519  49.990  22.024  1.00 41.86           C  
+ATOM   2059  C   TRP A 271      45.723  49.732  23.296  1.00 43.64           C  
+ATOM   2060  O   TRP A 271      45.896  48.698  23.943  1.00 44.34           O  
+ATOM   2061  CB  TRP A 271      47.917  50.472  22.446  1.00 39.11           C  
+ATOM   2062  CG  TRP A 271      48.789  50.949  21.323  1.00 40.52           C  
+ATOM   2063  CD1 TRP A 271      49.653  50.195  20.571  1.00 39.74           C  
+ATOM   2064  CD2 TRP A 271      48.849  52.278  20.788  1.00 36.12           C  
+ATOM   2065  NE1 TRP A 271      50.236  50.974  19.603  1.00 39.32           N  
+ATOM   2066  CE2 TRP A 271      49.759  52.256  19.719  1.00 38.13           C  
+ATOM   2067  CE3 TRP A 271      48.220  53.487  21.115  1.00 41.33           C  
+ATOM   2068  CZ2 TRP A 271      50.060  53.397  18.971  1.00 39.75           C  
+ATOM   2069  CZ3 TRP A 271      48.521  54.620  20.372  1.00 34.52           C  
+ATOM   2070  CH2 TRP A 271      49.428  54.566  19.317  1.00 37.02           C  
+ATOM   2071  N   GLY A 272      44.841  50.661  23.639  1.00 41.58           N  
+ATOM   2072  CA  GLY A 272      44.113  50.537  24.881  1.00 39.79           C  
+ATOM   2073  C   GLY A 272      44.940  51.215  25.984  1.00 41.54           C  
+ATOM   2074  O   GLY A 272      44.819  50.885  27.175  1.00 41.22           O  
+ATOM   2075  N   ARG A 273      45.802  52.153  25.588  1.00 37.39           N  
+ATOM   2076  CA  ARG A 273      46.620  52.873  26.542  1.00 40.30           C  
+ATOM   2077  C   ARG A 273      45.726  53.664  27.477  1.00 41.56           C  
+ATOM   2078  O   ARG A 273      45.967  53.719  28.697  1.00 37.84           O  
+ATOM   2079  CB  ARG A 273      47.597  53.811  25.833  1.00 40.26           C  
+ATOM   2080  CG  ARG A 273      48.532  54.489  26.803  1.00 39.38           C  
+ATOM   2081  CD  ARG A 273      49.452  55.493  26.149  1.00 45.63           C  
+ATOM   2082  NE  ARG A 273      50.275  56.140  27.164  1.00 41.66           N  
+ATOM   2083  CZ  ARG A 273      50.931  57.275  26.986  1.00 43.32           C  
+ATOM   2084  NH1 ARG A 273      51.656  57.769  27.982  1.00 44.53           N  
+ATOM   2085  NH2 ARG A 273      50.860  57.916  25.824  1.00 40.97           N  
+ATOM   2086  N   PHE A 274      44.693  54.282  26.907  1.00 38.90           N  
+ATOM   2087  CA  PHE A 274      43.721  55.045  27.705  1.00 39.04           C  
+ATOM   2088  C   PHE A 274      42.349  54.594  27.209  1.00 37.66           C  
+ATOM   2089  O   PHE A 274      42.240  54.215  26.057  1.00 39.14           O  
+ATOM   2090  CB  PHE A 274      43.867  56.546  27.453  1.00 37.20           C  
+ATOM   2091  CG  PHE A 274      45.239  57.087  27.731  1.00 39.25           C  
+ATOM   2092  CD1 PHE A 274      46.022  57.570  26.698  1.00 37.67           C  
+ATOM   2093  CD2 PHE A 274      45.718  57.184  29.045  1.00 38.03           C  
+ATOM   2094  CE1 PHE A 274      47.266  58.159  26.950  1.00 39.70           C  
+ATOM   2095  CE2 PHE A 274      46.956  57.763  29.319  1.00 35.36           C  
+ATOM   2096  CZ  PHE A 274      47.735  58.258  28.269  1.00 41.82           C  
+ATOM   2097  N   TRP A 275      41.327  54.607  28.064  1.00 36.87           N  
+ATOM   2098  CA  TRP A 275      39.977  54.209  27.656  1.00 36.95           C  
+ATOM   2099  C   TRP A 275      39.140  55.469  27.501  1.00 38.02           C  
+ATOM   2100  O   TRP A 275      37.910  55.418  27.392  1.00 36.08           O  
+ATOM   2101  CB  TRP A 275      39.318  53.282  28.689  1.00 35.56           C  
+ATOM   2102  CG  TRP A 275      39.941  51.944  28.787  1.00 39.12           C  
+ATOM   2103  CD1 TRP A 275      40.930  51.441  27.992  1.00 36.47           C  
+ATOM   2104  CD2 TRP A 275      39.626  50.912  29.740  1.00 41.36           C  
+ATOM   2105  NE1 TRP A 275      41.254  50.165  28.389  1.00 39.10           N  
+ATOM   2106  CE2 TRP A 275      40.467  49.815  29.458  1.00 39.91           C  
+ATOM   2107  CE3 TRP A 275      38.713  50.808  30.794  1.00 41.90           C  
+ATOM   2108  CZ2 TRP A 275      40.421  48.627  30.193  1.00 39.29           C  
+ATOM   2109  CZ3 TRP A 275      38.667  49.621  31.524  1.00 44.43           C  
+ATOM   2110  CH2 TRP A 275      39.516  48.548  31.217  1.00 41.76           C  
+ATOM   2111  N   THR A 276      39.827  56.605  27.494  1.00 39.75           N  
+ATOM   2112  CA  THR A 276      39.188  57.912  27.344  1.00 43.76           C  
+ATOM   2113  C   THR A 276      38.050  57.929  26.318  1.00 42.63           C  
+ATOM   2114  O   THR A 276      36.949  58.393  26.592  1.00 42.49           O  
+ATOM   2115  CB  THR A 276      40.206  58.977  26.873  1.00 44.61           C  
+ATOM   2116  OG1 THR A 276      41.411  58.867  27.633  1.00 46.54           O  
+ATOM   2117  CG2 THR A 276      39.629  60.370  27.041  1.00 37.67           C  
+ATOM   2118  N   ASN A 277      38.329  57.434  25.123  1.00 44.46           N  
+ATOM   2119  CA  ASN A 277      37.323  57.455  24.062  1.00 47.76           C  
+ATOM   2120  C   ASN A 277      36.142  56.504  24.222  1.00 48.52           C  
+ATOM   2121  O   ASN A 277      35.252  56.489  23.387  1.00 51.85           O  
+ATOM   2122  CB  ASN A 277      38.012  57.244  22.720  1.00 44.98           C  
+ATOM   2123  CG  ASN A 277      39.066  58.304  22.458  1.00 45.62           C  
+ATOM   2124  OD1 ASN A 277      40.152  58.027  21.916  1.00 43.37           O  
+ATOM   2125  ND2 ASN A 277      38.754  59.527  22.845  1.00 42.40           N  
+ATOM   2126  N   LEU A 278      36.127  55.732  25.303  1.00 46.88           N  
+ATOM   2127  CA  LEU A 278      35.025  54.821  25.576  1.00 45.32           C  
+ATOM   2128  C   LEU A 278      33.966  55.589  26.352  1.00 45.07           C  
+ATOM   2129  O   LEU A 278      33.000  55.007  26.842  1.00 50.24           O  
+ATOM   2130  CB  LEU A 278      35.512  53.635  26.427  1.00 44.45           C  
+ATOM   2131  CG  LEU A 278      35.771  52.274  25.770  1.00 46.14           C  
+ATOM   2132  CD1 LEU A 278      36.271  52.472  24.370  1.00 37.88           C  
+ATOM   2133  CD2 LEU A 278      36.732  51.447  26.606  1.00 41.63           C  
+ATOM   2134  N   TYR A 279      34.121  56.900  26.461  1.00 42.94           N  
+ATOM   2135  CA  TYR A 279      33.160  57.661  27.246  1.00 46.45           C  
+ATOM   2136  C   TYR A 279      31.724  57.689  26.717  1.00 48.49           C  
+ATOM   2137  O   TYR A 279      30.778  57.541  27.486  1.00 52.76           O  
+ATOM   2138  CB  TYR A 279      33.653  59.092  27.472  1.00 43.06           C  
+ATOM   2139  CG  TYR A 279      32.864  59.797  28.538  1.00 42.63           C  
+ATOM   2140  CD1 TYR A 279      32.872  59.339  29.840  1.00 44.25           C  
+ATOM   2141  CD2 TYR A 279      32.086  60.920  28.240  1.00 50.65           C  
+ATOM   2142  CE1 TYR A 279      32.136  59.971  30.826  1.00 47.24           C  
+ATOM   2143  CE2 TYR A 279      31.335  61.566  29.227  1.00 46.96           C  
+ATOM   2144  CZ  TYR A 279      31.369  61.087  30.518  1.00 49.91           C  
+ATOM   2145  OH  TYR A 279      30.644  61.717  31.514  1.00 46.68           O  
+ATOM   2146  N   SER A 280      31.546  57.882  25.421  1.00 51.46           N  
+ATOM   2147  CA  SER A 280      30.197  57.901  24.849  1.00 54.18           C  
+ATOM   2148  C   SER A 280      29.477  56.553  24.972  1.00 56.54           C  
+ATOM   2149  O   SER A 280      28.250  56.497  24.993  1.00 60.84           O  
+ATOM   2150  CB  SER A 280      30.265  58.295  23.381  1.00 55.89           C  
+ATOM   2151  OG  SER A 280      30.545  59.679  23.264  1.00 65.57           O  
+ATOM   2152  N   LEU A 281      30.238  55.469  25.056  1.00 54.85           N  
+ATOM   2153  CA  LEU A 281      29.661  54.145  25.171  1.00 51.46           C  
+ATOM   2154  C   LEU A 281      29.502  53.715  26.631  1.00 52.26           C  
+ATOM   2155  O   LEU A 281      28.791  52.745  26.921  1.00 52.24           O  
+ATOM   2156  CB  LEU A 281      30.550  53.113  24.458  1.00 53.12           C  
+ATOM   2157  CG  LEU A 281      31.178  53.383  23.080  1.00 57.28           C  
+ATOM   2158  CD1 LEU A 281      32.202  54.534  23.165  1.00 58.73           C  
+ATOM   2159  CD2 LEU A 281      31.896  52.119  22.591  1.00 54.54           C  
+ATOM   2160  N   THR A 282      30.151  54.421  27.558  1.00 50.05           N  
+ATOM   2161  CA  THR A 282      30.084  54.019  28.969  1.00 45.80           C  
+ATOM   2162  C   THR A 282      29.502  55.041  29.948  1.00 46.39           C  
+ATOM   2163  O   THR A 282      29.266  54.718  31.108  1.00 48.41           O  
+ATOM   2164  CB  THR A 282      31.505  53.618  29.495  1.00 47.16           C  
+ATOM   2165  OG1 THR A 282      32.417  54.712  29.314  1.00 43.93           O  
+ATOM   2166  CG2 THR A 282      32.054  52.410  28.759  1.00 39.95           C  
+ATOM   2167  N   VAL A 283      29.277  56.269  29.499  1.00 47.31           N  
+ATOM   2168  CA  VAL A 283      28.755  57.307  30.389  1.00 50.63           C  
+ATOM   2169  C   VAL A 283      27.532  56.890  31.228  1.00 53.38           C  
+ATOM   2170  O   VAL A 283      26.466  56.597  30.697  1.00 55.63           O  
+ATOM   2171  CB  VAL A 283      28.439  58.612  29.584  1.00 52.30           C  
+ATOM   2172  CG1 VAL A 283      27.356  58.352  28.543  1.00 49.66           C  
+ATOM   2173  CG2 VAL A 283      28.041  59.733  30.534  1.00 53.12           C  
+ATOM   2174  N   PRO A 284      27.683  56.875  32.568  1.00 54.51           N  
+ATOM   2175  CA  PRO A 284      26.654  56.507  33.546  1.00 53.83           C  
+ATOM   2176  C   PRO A 284      25.283  57.195  33.387  1.00 56.67           C  
+ATOM   2177  O   PRO A 284      24.242  56.546  33.528  1.00 53.90           O  
+ATOM   2178  CB  PRO A 284      27.314  56.849  34.881  1.00 55.88           C  
+ATOM   2179  CG  PRO A 284      28.777  56.630  34.608  1.00 52.36           C  
+ATOM   2180  CD  PRO A 284      28.936  57.260  33.245  1.00 52.28           C  
+ATOM   2181  N   PHE A 285      25.285  58.505  33.133  1.00 58.13           N  
+ATOM   2182  CA  PHE A 285      24.046  59.270  32.967  1.00 58.08           C  
+ATOM   2183  C   PHE A 285      24.184  60.222  31.791  1.00 61.38           C  
+ATOM   2184  O   PHE A 285      24.461  61.415  31.962  1.00 60.14           O  
+ATOM   2185  CB  PHE A 285      23.723  60.068  34.238  1.00 57.05           C  
+ATOM   2186  CG  PHE A 285      23.690  59.226  35.481  1.00 55.35           C  
+ATOM   2187  CD1 PHE A 285      24.833  59.053  36.244  1.00 50.97           C  
+ATOM   2188  CD2 PHE A 285      22.538  58.525  35.830  1.00 55.10           C  
+ATOM   2189  CE1 PHE A 285      24.838  58.188  37.331  1.00 52.39           C  
+ATOM   2190  CE2 PHE A 285      22.529  57.658  36.912  1.00 51.78           C  
+ATOM   2191  CZ  PHE A 285      23.683  57.485  37.666  1.00 54.98           C  
+ATOM   2192  N   GLY A 286      23.969  59.685  30.594  1.00 64.48           N  
+ATOM   2193  CA  GLY A 286      24.089  60.472  29.377  1.00 67.86           C  
+ATOM   2194  C   GLY A 286      23.246  61.725  29.246  1.00 69.82           C  
+ATOM   2195  O   GLY A 286      23.513  62.561  28.382  1.00 71.29           O  
+ATOM   2196  N   GLN A 287      22.239  61.872  30.097  1.00 72.64           N  
+ATOM   2197  CA  GLN A 287      21.355  63.033  30.044  1.00 76.93           C  
+ATOM   2198  C   GLN A 287      21.937  64.255  30.744  1.00 78.69           C  
+ATOM   2199  O   GLN A 287      21.737  65.385  30.298  1.00 78.01           O  
+ATOM   2200  CB  GLN A 287      20.005  62.685  30.669  1.00 78.90           C  
+ATOM   2201  CG  GLN A 287      19.745  61.179  30.771  1.00 81.98           C  
+ATOM   2202  CD  GLN A 287      20.634  60.494  31.805  1.00 80.09           C  
+ATOM   2203  OE1 GLN A 287      20.591  59.278  31.967  1.00 82.34           O  
+ATOM   2204  NE2 GLN A 287      21.436  61.279  32.508  1.00 80.85           N  
+ATOM   2205  N   LYS A 288      22.649  64.027  31.846  1.00 81.22           N  
+ATOM   2206  CA  LYS A 288      23.257  65.123  32.596  1.00 82.29           C  
+ATOM   2207  C   LYS A 288      24.296  65.833  31.741  1.00 84.76           C  
+ATOM   2208  O   LYS A 288      25.082  65.199  31.038  1.00 84.74           O  
+ATOM   2209  CB  LYS A 288      23.916  64.599  33.874  1.00 78.72           C  
+ATOM   2210  CG  LYS A 288      22.942  64.146  34.955  1.00 78.05           C  
+ATOM   2211  CD  LYS A 288      22.213  65.332  35.573  1.00 78.57           C  
+ATOM   2212  CE  LYS A 288      21.128  64.891  36.552  1.00 77.75           C  
+ATOM   2213  NZ  LYS A 288      21.674  64.134  37.710  1.00 79.05           N  
+ATOM   2214  N   PRO A 289      24.297  67.172  31.780  1.00 87.73           N  
+ATOM   2215  CA  PRO A 289      25.241  67.996  31.015  1.00 89.87           C  
+ATOM   2216  C   PRO A 289      26.661  67.925  31.585  1.00 90.14           C  
+ATOM   2217  O   PRO A 289      26.873  68.107  32.785  1.00 89.55           O  
+ATOM   2218  CB  PRO A 289      24.654  69.406  31.134  1.00 89.46           C  
+ATOM   2219  CG  PRO A 289      23.188  69.153  31.365  1.00 89.87           C  
+ATOM   2220  CD  PRO A 289      23.213  67.998  32.333  1.00 88.11           C  
+ATOM   2221  N   ASN A 290      27.622  67.656  30.711  1.00 90.23           N  
+ATOM   2222  CA  ASN A 290      29.023  67.577  31.095  1.00 91.50           C  
+ATOM   2223  C   ASN A 290      29.545  69.014  31.218  1.00 91.36           C  
+ATOM   2224  O   ASN A 290      29.580  69.746  30.226  1.00 92.26           O  
+ATOM   2225  CB  ASN A 290      29.793  66.816  30.010  1.00 94.49           C  
+ATOM   2226  CG  ASN A 290      31.269  66.656  30.329  1.00 96.32           C  
+ATOM   2227  OD1 ASN A 290      31.646  65.937  31.258  1.00 98.27           O  
+ATOM   2228  ND2 ASN A 290      32.115  67.325  29.552  1.00 97.07           N  
+ATOM   2229  N   ILE A 291      29.933  69.421  32.426  1.00 88.24           N  
+ATOM   2230  CA  ILE A 291      30.442  70.778  32.648  1.00 85.48           C  
+ATOM   2231  C   ILE A 291      31.436  71.186  31.566  1.00 83.39           C  
+ATOM   2232  O   ILE A 291      32.433  70.505  31.342  1.00 84.33           O  
+ATOM   2233  CB  ILE A 291      31.146  70.910  34.017  1.00 84.81           C  
+ATOM   2234  CG1 ILE A 291      30.149  70.676  35.151  1.00 83.20           C  
+ATOM   2235  CG2 ILE A 291      31.750  72.293  34.152  1.00 85.29           C  
+ATOM   2236  CD1 ILE A 291      30.726  70.939  36.523  1.00 82.70           C  
+ATOM   2237  N   ASP A 292      31.166  72.305  30.903  1.00 81.44           N  
+ATOM   2238  CA  ASP A 292      32.035  72.785  29.831  1.00 80.43           C  
+ATOM   2239  C   ASP A 292      31.846  74.278  29.578  1.00 79.80           C  
+ATOM   2240  O   ASP A 292      30.974  74.679  28.805  1.00 79.92           O  
+ATOM   2241  CB  ASP A 292      31.751  72.012  28.546  1.00 78.75           C  
+ATOM   2242  CG  ASP A 292      32.539  72.538  27.376  1.00 80.95           C  
+ATOM   2243  OD1 ASP A 292      32.497  71.909  26.297  1.00 82.66           O  
+ATOM   2244  OD2 ASP A 292      33.199  73.588  27.536  1.00 77.89           O  
+ATOM   2245  N   VAL A 293      32.693  75.089  30.206  1.00 77.30           N  
+ATOM   2246  CA  VAL A 293      32.616  76.541  30.087  1.00 76.06           C  
+ATOM   2247  C   VAL A 293      33.213  77.126  28.801  1.00 73.74           C  
+ATOM   2248  O   VAL A 293      33.327  78.339  28.670  1.00 68.81           O  
+ATOM   2249  CB  VAL A 293      33.305  77.212  31.303  1.00 78.83           C  
+ATOM   2250  CG1 VAL A 293      33.105  78.717  31.252  1.00 81.41           C  
+ATOM   2251  CG2 VAL A 293      32.744  76.651  32.606  1.00 76.26           C  
+ATOM   2252  N   THR A 294      33.564  76.275  27.843  1.00 73.29           N  
+ATOM   2253  CA  THR A 294      34.169  76.751  26.604  1.00 75.81           C  
+ATOM   2254  C   THR A 294      33.257  77.683  25.802  1.00 77.27           C  
+ATOM   2255  O   THR A 294      33.611  78.127  24.705  1.00 74.06           O  
+ATOM   2256  CB  THR A 294      34.624  75.562  25.711  1.00 77.49           C  
+ATOM   2257  OG1 THR A 294      35.395  76.057  24.610  1.00 81.45           O  
+ATOM   2258  CG2 THR A 294      33.432  74.800  25.169  1.00 83.19           C  
+ATOM   2259  N   ASP A 295      32.090  77.981  26.368  1.00 79.11           N  
+ATOM   2260  CA  ASP A 295      31.104  78.857  25.740  1.00 79.44           C  
+ATOM   2261  C   ASP A 295      30.964  80.125  26.573  1.00 77.82           C  
+ATOM   2262  O   ASP A 295      30.854  81.227  26.037  1.00 76.29           O  
+ATOM   2263  CB  ASP A 295      29.751  78.136  25.631  1.00 82.71           C  
+ATOM   2264  CG  ASP A 295      29.795  76.937  24.667  1.00 87.03           C  
+ATOM   2265  OD1 ASP A 295      29.788  77.170  23.438  1.00 82.40           O  
+ATOM   2266  OD2 ASP A 295      29.847  75.768  25.137  1.00 87.55           O  
+ATOM   2267  N   ALA A 296      30.987  79.960  27.893  1.00 77.86           N  
+ATOM   2268  CA  ALA A 296      30.876  81.089  28.810  1.00 76.03           C  
+ATOM   2269  C   ALA A 296      32.112  81.981  28.705  1.00 77.71           C  
+ATOM   2270  O   ALA A 296      32.079  83.152  29.089  1.00 78.92           O  
+ATOM   2271  CB  ALA A 296      30.712  80.588  30.234  1.00 74.57           C  
+ATOM   2272  N   MET A 297      33.203  81.414  28.193  1.00 78.03           N  
+ATOM   2273  CA  MET A 297      34.451  82.149  28.015  1.00 77.84           C  
+ATOM   2274  C   MET A 297      34.252  83.092  26.834  1.00 79.13           C  
+ATOM   2275  O   MET A 297      34.599  84.274  26.888  1.00 78.04           O  
+ATOM   2276  CB  MET A 297      35.611  81.182  27.722  1.00 75.49           C  
+ATOM   2277  CG  MET A 297      36.143  80.407  28.941  1.00 73.03           C  
+ATOM   2278  SD  MET A 297      37.219  78.999  28.490  1.00 70.90           S  
+ATOM   2279  CE  MET A 297      38.643  79.845  27.782  1.00 70.88           C  
+ATOM   2280  N   VAL A 298      33.681  82.553  25.766  1.00 80.81           N  
+ATOM   2281  CA  VAL A 298      33.418  83.332  24.567  1.00 82.43           C  
+ATOM   2282  C   VAL A 298      32.520  84.534  24.870  1.00 84.19           C  
+ATOM   2283  O   VAL A 298      32.919  85.685  24.672  1.00 82.45           O  
+ATOM   2284  CB  VAL A 298      32.750  82.456  23.494  1.00 81.27           C  
+ATOM   2285  CG1 VAL A 298      32.468  83.277  22.249  1.00 78.82           C  
+ATOM   2286  CG2 VAL A 298      33.650  81.276  23.172  1.00 79.22           C  
+ATOM   2287  N   ASP A 299      31.314  84.263  25.366  1.00 86.50           N  
+ATOM   2288  CA  ASP A 299      30.356  85.320  25.689  1.00 88.48           C  
+ATOM   2289  C   ASP A 299      30.939  86.410  26.598  1.00 88.47           C  
+ATOM   2290  O   ASP A 299      30.386  87.507  26.703  1.00 88.26           O  
+ATOM   2291  CB  ASP A 299      29.099  84.710  26.327  1.00 90.88           C  
+ATOM   2292  CG  ASP A 299      28.028  85.756  26.649  1.00 93.78           C  
+ATOM   2293  OD1 ASP A 299      27.976  86.237  27.810  1.00 91.49           O  
+ATOM   2294  OD2 ASP A 299      27.240  86.101  25.733  1.00 94.34           O  
+ATOM   2295  N   GLN A 300      32.054  86.117  27.255  1.00 88.45           N  
+ATOM   2296  CA  GLN A 300      32.676  87.107  28.123  1.00 87.74           C  
+ATOM   2297  C   GLN A 300      33.873  87.731  27.412  1.00 87.11           C  
+ATOM   2298  O   GLN A 300      34.631  88.507  27.998  1.00 86.34           O  
+ATOM   2299  CB  GLN A 300      33.106  86.467  29.444  1.00 89.08           C  
+ATOM   2300  CG  GLN A 300      31.954  85.848  30.219  1.00 88.83           C  
+ATOM   2301  CD  GLN A 300      32.281  85.616  31.679  1.00 88.77           C  
+ATOM   2302  OE1 GLN A 300      31.487  85.038  32.413  1.00 90.05           O  
+ATOM   2303  NE2 GLN A 300      33.450  86.075  32.110  1.00 88.77           N  
+ATOM   2304  N   ALA A 301      34.023  87.390  26.136  1.00 85.45           N  
+ATOM   2305  CA  ALA A 301      35.107  87.912  25.322  1.00 84.74           C  
+ATOM   2306  C   ALA A 301      36.444  87.642  25.976  1.00 85.18           C  
+ATOM   2307  O   ALA A 301      37.194  88.575  26.265  1.00 86.31           O  
+ATOM   2308  CB  ALA A 301      34.929  89.410  25.109  1.00 84.56           C  
+ATOM   2309  N   TRP A 302      36.733  86.366  26.222  1.00 85.13           N  
+ATOM   2310  CA  TRP A 302      37.999  85.967  26.833  1.00 82.82           C  
+ATOM   2311  C   TRP A 302      38.998  85.663  25.736  1.00 81.86           C  
+ATOM   2312  O   TRP A 302      38.628  85.189  24.664  1.00 81.86           O  
+ATOM   2313  CB  TRP A 302      37.819  84.725  27.714  1.00 82.02           C  
+ATOM   2314  CG  TRP A 302      37.455  85.029  29.141  1.00 80.11           C  
+ATOM   2315  CD1 TRP A 302      36.563  85.963  29.578  1.00 79.82           C  
+ATOM   2316  CD2 TRP A 302      37.941  84.361  30.313  1.00 78.92           C  
+ATOM   2317  NE1 TRP A 302      36.461  85.918  30.947  1.00 79.29           N  
+ATOM   2318  CE2 TRP A 302      37.295  84.942  31.423  1.00 78.02           C  
+ATOM   2319  CE3 TRP A 302      38.859  83.330  30.532  1.00 78.72           C  
+ATOM   2320  CZ2 TRP A 302      37.537  84.526  32.733  1.00 78.05           C  
+ATOM   2321  CZ3 TRP A 302      39.100  82.919  31.838  1.00 78.68           C  
+ATOM   2322  CH2 TRP A 302      38.440  83.516  32.919  1.00 77.07           C  
+ATOM   2323  N   ASP A 303      40.267  85.944  26.009  1.00 81.65           N  
+ATOM   2324  CA  ASP A 303      41.329  85.700  25.043  1.00 81.18           C  
+ATOM   2325  C   ASP A 303      42.539  85.092  25.735  1.00 78.21           C  
+ATOM   2326  O   ASP A 303      42.576  84.987  26.962  1.00 77.41           O  
+ATOM   2327  CB  ASP A 303      41.724  87.009  24.339  1.00 83.55           C  
+ATOM   2328  CG  ASP A 303      41.913  88.165  25.311  1.00 87.32           C  
+ATOM   2329  OD1 ASP A 303      42.853  88.116  26.138  1.00 88.91           O  
+ATOM   2330  OD2 ASP A 303      41.115  89.128  25.250  1.00 89.82           O  
+ATOM   2331  N   ALA A 304      43.519  84.699  24.930  1.00 73.86           N  
+ATOM   2332  CA  ALA A 304      44.746  84.097  25.412  1.00 72.08           C  
+ATOM   2333  C   ALA A 304      45.300  84.820  26.633  1.00 71.83           C  
+ATOM   2334  O   ALA A 304      45.597  84.205  27.656  1.00 73.08           O  
+ATOM   2335  CB  ALA A 304      45.776  84.090  24.301  1.00 70.06           C  
+ATOM   2336  N   GLN A 305      45.441  86.131  26.529  1.00 72.04           N  
+ATOM   2337  CA  GLN A 305      45.976  86.916  27.635  1.00 71.09           C  
+ATOM   2338  C   GLN A 305      45.206  86.718  28.935  1.00 68.38           C  
+ATOM   2339  O   GLN A 305      45.807  86.551  30.000  1.00 66.84           O  
+ATOM   2340  CB  GLN A 305      45.979  88.395  27.263  1.00 72.34           C  
+ATOM   2341  CG  GLN A 305      46.879  88.720  26.090  1.00 78.53           C  
+ATOM   2342  CD  GLN A 305      48.350  88.561  26.421  1.00 79.61           C  
+ATOM   2343  OE1 GLN A 305      48.843  89.124  27.408  1.00 77.68           O  
+ATOM   2344  NE2 GLN A 305      49.066  87.802  25.591  1.00 77.89           N  
+ATOM   2345  N   ARG A 306      43.878  86.753  28.843  1.00 65.42           N  
+ATOM   2346  CA  ARG A 306      43.024  86.588  30.010  1.00 63.53           C  
+ATOM   2347  C   ARG A 306      43.170  85.175  30.577  1.00 61.22           C  
+ATOM   2348  O   ARG A 306      43.162  84.982  31.787  1.00 59.95           O  
+ATOM   2349  CB  ARG A 306      41.565  86.860  29.635  1.00 64.27           C  
+ATOM   2350  CG  ARG A 306      40.587  86.732  30.792  1.00 64.46           C  
+ATOM   2351  CD  ARG A 306      40.897  87.727  31.894  1.00 66.37           C  
+ATOM   2352  NE  ARG A 306      39.969  87.603  33.012  1.00 66.44           N  
+ATOM   2353  CZ  ARG A 306      38.645  87.675  32.898  1.00 70.47           C  
+ATOM   2354  NH1 ARG A 306      38.086  87.871  31.706  1.00 69.50           N  
+ATOM   2355  NH2 ARG A 306      37.877  87.550  33.977  1.00 70.09           N  
+ATOM   2356  N   ILE A 307      43.301  84.194  29.692  1.00 59.26           N  
+ATOM   2357  CA  ILE A 307      43.476  82.811  30.116  1.00 60.94           C  
+ATOM   2358  C   ILE A 307      44.739  82.663  30.976  1.00 63.07           C  
+ATOM   2359  O   ILE A 307      44.665  82.169  32.103  1.00 62.91           O  
+ATOM   2360  CB  ILE A 307      43.557  81.884  28.905  1.00 57.81           C  
+ATOM   2361  CG1 ILE A 307      42.147  81.712  28.328  1.00 57.73           C  
+ATOM   2362  CG2 ILE A 307      44.211  80.569  29.288  1.00 55.36           C  
+ATOM   2363  CD1 ILE A 307      42.060  80.807  27.136  1.00 53.75           C  
+ATOM   2364  N   PHE A 308      45.881  83.122  30.462  1.00 63.69           N  
+ATOM   2365  CA  PHE A 308      47.147  83.036  31.198  1.00 64.77           C  
+ATOM   2366  C   PHE A 308      47.221  84.004  32.373  1.00 66.20           C  
+ATOM   2367  O   PHE A 308      47.977  83.792  33.326  1.00 69.17           O  
+ATOM   2368  CB  PHE A 308      48.325  83.274  30.253  1.00 61.00           C  
+ATOM   2369  CG  PHE A 308      48.643  82.093  29.388  1.00 59.75           C  
+ATOM   2370  CD1 PHE A 308      49.555  81.131  29.813  1.00 58.51           C  
+ATOM   2371  CD2 PHE A 308      47.998  81.913  28.174  1.00 55.31           C  
+ATOM   2372  CE1 PHE A 308      49.820  80.004  29.043  1.00 54.92           C  
+ATOM   2373  CE2 PHE A 308      48.251  80.797  27.399  1.00 56.37           C  
+ATOM   2374  CZ  PHE A 308      49.167  79.832  27.836  1.00 58.76           C  
+ATOM   2375  N   LYS A 309      46.427  85.062  32.319  1.00 67.37           N  
+ATOM   2376  CA  LYS A 309      46.425  86.031  33.399  1.00 67.90           C  
+ATOM   2377  C   LYS A 309      45.637  85.427  34.550  1.00 69.03           C  
+ATOM   2378  O   LYS A 309      45.945  85.661  35.725  1.00 69.86           O  
+ATOM   2379  CB  LYS A 309      45.781  87.344  32.946  1.00 70.16           C  
+ATOM   2380  CG  LYS A 309      45.900  88.469  33.964  1.00 69.59           C  
+ATOM   2381  CD  LYS A 309      46.846  89.560  33.482  1.00 66.63           C  
+ATOM   2382  CE  LYS A 309      48.148  88.980  32.988  1.00 64.75           C  
+ATOM   2383  NZ  LYS A 309      49.128  90.049  32.650  1.00 66.67           N  
+ATOM   2384  N   GLU A 310      44.620  84.639  34.214  1.00 67.04           N  
+ATOM   2385  CA  GLU A 310      43.809  83.993  35.241  1.00 66.36           C  
+ATOM   2386  C   GLU A 310      44.623  82.845  35.875  1.00 61.34           C  
+ATOM   2387  O   GLU A 310      44.538  82.601  37.071  1.00 57.37           O  
+ATOM   2388  CB  GLU A 310      42.503  83.474  34.622  1.00 70.17           C  
+ATOM   2389  CG  GLU A 310      41.305  83.478  35.567  1.00 73.34           C  
+ATOM   2390  CD  GLU A 310      40.844  84.879  35.961  1.00 74.84           C  
+ATOM   2391  OE1 GLU A 310      40.572  85.701  35.058  1.00 77.11           O  
+ATOM   2392  OE2 GLU A 310      40.737  85.152  37.176  1.00 73.90           O  
+ATOM   2393  N   ALA A 311      45.421  82.158  35.061  1.00 60.07           N  
+ATOM   2394  CA  ALA A 311      46.276  81.080  35.553  1.00 59.38           C  
+ATOM   2395  C   ALA A 311      47.306  81.713  36.492  1.00 60.52           C  
+ATOM   2396  O   ALA A 311      47.557  81.209  37.584  1.00 62.27           O  
+ATOM   2397  CB  ALA A 311      46.980  80.380  34.390  1.00 53.16           C  
+ATOM   2398  N   GLU A 312      47.894  82.828  36.070  1.00 60.75           N  
+ATOM   2399  CA  GLU A 312      48.872  83.515  36.903  1.00 59.58           C  
+ATOM   2400  C   GLU A 312      48.248  83.917  38.230  1.00 58.16           C  
+ATOM   2401  O   GLU A 312      48.881  83.807  39.285  1.00 60.02           O  
+ATOM   2402  CB  GLU A 312      49.413  84.756  36.186  1.00 59.99           C  
+ATOM   2403  CG  GLU A 312      50.310  85.640  37.055  1.00 59.73           C  
+ATOM   2404  CD  GLU A 312      50.803  86.877  36.309  1.00 63.65           C  
+ATOM   2405  OE1 GLU A 312      49.957  87.634  35.784  1.00 64.41           O  
+ATOM   2406  OE2 GLU A 312      52.031  87.091  36.244  1.00 61.95           O  
+ATOM   2407  N   LYS A 313      47.002  84.373  38.184  1.00 56.13           N  
+ATOM   2408  CA  LYS A 313      46.324  84.789  39.400  1.00 57.03           C  
+ATOM   2409  C   LYS A 313      46.070  83.587  40.317  1.00 58.09           C  
+ATOM   2410  O   LYS A 313      46.035  83.725  41.549  1.00 56.43           O  
+ATOM   2411  CB  LYS A 313      45.006  85.495  39.063  1.00 59.15           C  
+ATOM   2412  CG  LYS A 313      44.215  85.960  40.281  1.00 62.86           C  
+ATOM   2413  CD  LYS A 313      43.058  86.891  39.908  1.00 66.57           C  
+ATOM   2414  CE  LYS A 313      42.282  87.307  41.161  1.00 69.92           C  
+ATOM   2415  NZ  LYS A 313      41.104  88.193  40.895  1.00 72.54           N  
+ATOM   2416  N   PHE A 314      45.889  82.409  39.719  1.00 55.71           N  
+ATOM   2417  CA  PHE A 314      45.657  81.206  40.503  1.00 51.53           C  
+ATOM   2418  C   PHE A 314      46.861  80.886  41.390  1.00 50.55           C  
+ATOM   2419  O   PHE A 314      46.701  80.552  42.559  1.00 48.36           O  
+ATOM   2420  CB  PHE A 314      45.376  80.019  39.588  1.00 54.32           C  
+ATOM   2421  CG  PHE A 314      45.547  78.687  40.264  1.00 54.76           C  
+ATOM   2422  CD1 PHE A 314      44.609  78.229  41.170  1.00 56.52           C  
+ATOM   2423  CD2 PHE A 314      46.657  77.898  39.995  1.00 53.92           C  
+ATOM   2424  CE1 PHE A 314      44.766  77.003  41.797  1.00 57.78           C  
+ATOM   2425  CE2 PHE A 314      46.824  76.676  40.616  1.00 56.93           C  
+ATOM   2426  CZ  PHE A 314      45.874  76.226  41.519  1.00 57.91           C  
+ATOM   2427  N   PHE A 315      48.066  80.989  40.835  1.00 50.89           N  
+ATOM   2428  CA  PHE A 315      49.280  80.692  41.596  1.00 54.06           C  
+ATOM   2429  C   PHE A 315      49.566  81.713  42.696  1.00 57.15           C  
+ATOM   2430  O   PHE A 315      49.811  81.343  43.860  1.00 58.31           O  
+ATOM   2431  CB  PHE A 315      50.468  80.580  40.654  1.00 51.02           C  
+ATOM   2432  CG  PHE A 315      50.384  79.413  39.715  1.00 50.90           C  
+ATOM   2433  CD1 PHE A 315      50.583  78.122  40.174  1.00 52.79           C  
+ATOM   2434  CD2 PHE A 315      50.078  79.600  38.380  1.00 48.60           C  
+ATOM   2435  CE1 PHE A 315      50.474  77.030  39.310  1.00 50.99           C  
+ATOM   2436  CE2 PHE A 315      49.969  78.522  37.519  1.00 47.80           C  
+ATOM   2437  CZ  PHE A 315      50.167  77.238  37.987  1.00 49.31           C  
+ATOM   2438  N   VAL A 316      49.525  82.992  42.337  1.00 58.00           N  
+ATOM   2439  CA  VAL A 316      49.746  84.058  43.306  1.00 58.29           C  
+ATOM   2440  C   VAL A 316      48.790  83.853  44.482  1.00 58.40           C  
+ATOM   2441  O   VAL A 316      49.137  84.102  45.634  1.00 57.94           O  
+ATOM   2442  CB  VAL A 316      49.493  85.457  42.666  1.00 59.02           C  
+ATOM   2443  CG1 VAL A 316      49.357  86.526  43.741  1.00 55.37           C  
+ATOM   2444  CG2 VAL A 316      50.646  85.806  41.737  1.00 57.63           C  
+ATOM   2445  N   SER A 317      47.589  83.372  44.193  1.00 59.73           N  
+ATOM   2446  CA  SER A 317      46.602  83.159  45.245  1.00 60.58           C  
+ATOM   2447  C   SER A 317      47.072  82.163  46.299  1.00 61.85           C  
+ATOM   2448  O   SER A 317      46.529  82.144  47.400  1.00 61.36           O  
+ATOM   2449  CB  SER A 317      45.278  82.680  44.654  1.00 60.84           C  
+ATOM   2450  OG  SER A 317      45.329  81.293  44.383  1.00 64.65           O  
+ATOM   2451  N   VAL A 318      48.057  81.323  45.974  1.00 60.17           N  
+ATOM   2452  CA  VAL A 318      48.558  80.378  46.979  1.00 60.09           C  
+ATOM   2453  C   VAL A 318      49.994  80.680  47.430  1.00 60.99           C  
+ATOM   2454  O   VAL A 318      50.670  79.816  48.004  1.00 59.00           O  
+ATOM   2455  CB  VAL A 318      48.491  78.891  46.506  1.00 58.68           C  
+ATOM   2456  CG1 VAL A 318      47.049  78.481  46.261  1.00 57.78           C  
+ATOM   2457  CG2 VAL A 318      49.334  78.691  45.266  1.00 56.09           C  
+ATOM   2458  N   GLY A 319      50.461  81.898  47.161  1.00 60.20           N  
+ATOM   2459  CA  GLY A 319      51.795  82.280  47.596  1.00 64.44           C  
+ATOM   2460  C   GLY A 319      52.947  82.208  46.601  1.00 66.64           C  
+ATOM   2461  O   GLY A 319      54.086  82.566  46.943  1.00 65.92           O  
+ATOM   2462  N   LEU A 320      52.677  81.738  45.385  1.00 64.71           N  
+ATOM   2463  CA  LEU A 320      53.723  81.653  44.376  1.00 62.85           C  
+ATOM   2464  C   LEU A 320      53.821  83.019  43.715  1.00 62.26           C  
+ATOM   2465  O   LEU A 320      52.903  83.834  43.825  1.00 64.89           O  
+ATOM   2466  CB  LEU A 320      53.393  80.560  43.347  1.00 59.02           C  
+ATOM   2467  CG  LEU A 320      53.355  79.142  43.935  1.00 60.33           C  
+ATOM   2468  CD1 LEU A 320      52.785  78.152  42.930  1.00 57.01           C  
+ATOM   2469  CD2 LEU A 320      54.753  78.731  44.350  1.00 58.50           C  
+ATOM   2470  N   PRO A 321      54.948  83.297  43.038  1.00 63.45           N  
+ATOM   2471  CA  PRO A 321      55.196  84.566  42.351  1.00 62.37           C  
+ATOM   2472  C   PRO A 321      54.505  84.738  41.007  1.00 64.75           C  
+ATOM   2473  O   PRO A 321      54.094  83.767  40.371  1.00 63.47           O  
+ATOM   2474  CB  PRO A 321      56.716  84.578  42.207  1.00 62.24           C  
+ATOM   2475  CG  PRO A 321      57.036  83.145  42.005  1.00 61.80           C  
+ATOM   2476  CD  PRO A 321      56.178  82.480  43.071  1.00 62.84           C  
+ATOM   2477  N   ASN A 322      54.386  85.995  40.588  1.00 65.70           N  
+ATOM   2478  CA  ASN A 322      53.779  86.355  39.308  1.00 66.11           C  
+ATOM   2479  C   ASN A 322      54.709  85.833  38.229  1.00 64.76           C  
+ATOM   2480  O   ASN A 322      55.862  85.507  38.500  1.00 64.59           O  
+ATOM   2481  CB  ASN A 322      53.704  87.884  39.158  1.00 66.94           C  
+ATOM   2482  CG  ASN A 322      52.399  88.476  39.662  1.00 70.28           C  
+ATOM   2483  OD1 ASN A 322      51.320  88.152  39.158  1.00 71.26           O  
+ATOM   2484  ND2 ASN A 322      52.492  89.366  40.647  1.00 70.85           N  
+ATOM   2485  N   MET A 323      54.215  85.745  37.005  1.00 63.56           N  
+ATOM   2486  CA  MET A 323      55.074  85.324  35.909  1.00 64.21           C  
+ATOM   2487  C   MET A 323      56.100  86.451  35.777  1.00 65.94           C  
+ATOM   2488  O   MET A 323      55.854  87.565  36.256  1.00 68.85           O  
+ATOM   2489  CB  MET A 323      54.262  85.211  34.627  1.00 62.19           C  
+ATOM   2490  CG  MET A 323      53.399  83.971  34.567  1.00 62.18           C  
+ATOM   2491  SD  MET A 323      54.449  82.507  34.539  1.00 63.01           S  
+ATOM   2492  CE  MET A 323      54.516  82.118  36.283  1.00 58.67           C  
+ATOM   2493  N   THR A 324      57.247  86.190  35.157  1.00 62.85           N  
+ATOM   2494  CA  THR A 324      58.223  87.257  35.014  1.00 60.96           C  
+ATOM   2495  C   THR A 324      57.893  88.184  33.859  1.00 64.79           C  
+ATOM   2496  O   THR A 324      57.130  87.840  32.946  1.00 61.95           O  
+ATOM   2497  CB  THR A 324      59.638  86.755  34.727  1.00 60.70           C  
+ATOM   2498  OG1 THR A 324      59.668  86.131  33.435  1.00 56.80           O  
+ATOM   2499  CG2 THR A 324      60.110  85.800  35.815  1.00 59.12           C  
+ATOM   2500  N   GLN A 325      58.484  89.373  33.927  1.00 67.22           N  
+ATOM   2501  CA  GLN A 325      58.354  90.377  32.885  1.00 70.68           C  
+ATOM   2502  C   GLN A 325      59.224  89.723  31.823  1.00 69.02           C  
+ATOM   2503  O   GLN A 325      60.359  89.342  32.097  1.00 71.29           O  
+ATOM   2504  CB  GLN A 325      58.980  91.694  33.364  1.00 74.71           C  
+ATOM   2505  CG  GLN A 325      58.790  92.887  32.433  1.00 82.47           C  
+ATOM   2506  CD  GLN A 325      59.388  92.662  31.061  1.00 85.05           C  
+ATOM   2507  OE1 GLN A 325      60.579  92.356  30.927  1.00 87.17           O  
+ATOM   2508  NE2 GLN A 325      58.565  92.814  30.028  1.00 88.76           N  
+ATOM   2509  N   GLY A 326      58.723  89.564  30.615  1.00 68.77           N  
+ATOM   2510  CA  GLY A 326      59.562  88.898  29.632  1.00 68.84           C  
+ATOM   2511  C   GLY A 326      58.888  87.590  29.307  1.00 66.80           C  
+ATOM   2512  O   GLY A 326      58.877  87.157  28.157  1.00 68.69           O  
+ATOM   2513  N   PHE A 327      58.345  86.943  30.334  1.00 65.23           N  
+ATOM   2514  CA  PHE A 327      57.589  85.732  30.107  1.00 63.53           C  
+ATOM   2515  C   PHE A 327      56.440  86.247  29.244  1.00 60.74           C  
+ATOM   2516  O   PHE A 327      56.150  85.704  28.190  1.00 60.91           O  
+ATOM   2517  CB  PHE A 327      57.040  85.157  31.418  1.00 63.39           C  
+ATOM   2518  CG  PHE A 327      55.828  84.287  31.223  1.00 63.17           C  
+ATOM   2519  CD1 PHE A 327      54.548  84.806  31.393  1.00 60.27           C  
+ATOM   2520  CD2 PHE A 327      55.965  82.969  30.805  1.00 62.40           C  
+ATOM   2521  CE1 PHE A 327      53.435  84.038  31.149  1.00 59.35           C  
+ATOM   2522  CE2 PHE A 327      54.855  82.193  30.556  1.00 62.11           C  
+ATOM   2523  CZ  PHE A 327      53.581  82.727  30.727  1.00 61.99           C  
+ATOM   2524  N   TRP A 328      55.809  87.327  29.687  1.00 60.40           N  
+ATOM   2525  CA  TRP A 328      54.707  87.927  28.932  1.00 65.01           C  
+ATOM   2526  C   TRP A 328      55.143  88.519  27.583  1.00 66.23           C  
+ATOM   2527  O   TRP A 328      54.373  88.527  26.620  1.00 65.77           O  
+ATOM   2528  CB  TRP A 328      54.033  89.028  29.752  1.00 62.91           C  
+ATOM   2529  CG  TRP A 328      53.282  88.530  30.935  1.00 60.27           C  
+ATOM   2530  CD1 TRP A 328      53.610  88.703  32.242  1.00 58.56           C  
+ATOM   2531  CD2 TRP A 328      52.059  87.783  30.921  1.00 60.56           C  
+ATOM   2532  NE1 TRP A 328      52.667  88.113  33.050  1.00 60.93           N  
+ATOM   2533  CE2 TRP A 328      51.705  87.539  32.262  1.00 61.89           C  
+ATOM   2534  CE3 TRP A 328      51.232  87.295  29.908  1.00 58.20           C  
+ATOM   2535  CZ2 TRP A 328      50.555  86.833  32.612  1.00 62.86           C  
+ATOM   2536  CZ3 TRP A 328      50.094  86.599  30.255  1.00 56.47           C  
+ATOM   2537  CH2 TRP A 328      49.764  86.372  31.592  1.00 61.15           C  
+ATOM   2538  N   GLU A 329      56.379  89.004  27.516  1.00 69.20           N  
+ATOM   2539  CA  GLU A 329      56.895  89.599  26.286  1.00 73.05           C  
+ATOM   2540  C   GLU A 329      57.499  88.607  25.294  1.00 73.39           C  
+ATOM   2541  O   GLU A 329      57.355  88.764  24.081  1.00 75.53           O  
+ATOM   2542  CB  GLU A 329      57.937  90.670  26.615  1.00 77.83           C  
+ATOM   2543  CG  GLU A 329      58.456  91.434  25.386  1.00 87.03           C  
+ATOM   2544  CD  GLU A 329      57.415  92.377  24.757  1.00 90.64           C  
+ATOM   2545  OE1 GLU A 329      56.279  91.931  24.468  1.00 91.19           O  
+ATOM   2546  OE2 GLU A 329      57.744  93.568  24.542  1.00 93.04           O  
+ATOM   2547  N   ASN A 330      58.169  87.579  25.796  1.00 73.29           N  
+ATOM   2548  CA  ASN A 330      58.797  86.597  24.917  1.00 71.70           C  
+ATOM   2549  C   ASN A 330      57.932  85.389  24.572  1.00 70.42           C  
+ATOM   2550  O   ASN A 330      58.254  84.650  23.643  1.00 70.99           O  
+ATOM   2551  CB  ASN A 330      60.098  86.119  25.548  1.00 71.80           C  
+ATOM   2552  CG  ASN A 330      61.005  87.258  25.911  1.00 71.46           C  
+ATOM   2553  OD1 ASN A 330      61.567  87.295  27.004  1.00 68.86           O  
+ATOM   2554  ND2 ASN A 330      61.159  88.203  24.987  1.00 72.24           N  
+ATOM   2555  N   SER A 331      56.850  85.184  25.320  1.00 70.20           N  
+ATOM   2556  CA  SER A 331      55.959  84.044  25.091  1.00 70.53           C  
+ATOM   2557  C   SER A 331      55.102  84.195  23.847  1.00 71.10           C  
+ATOM   2558  O   SER A 331      54.661  85.293  23.510  1.00 73.33           O  
+ATOM   2559  CB  SER A 331      55.000  83.835  26.280  1.00 69.64           C  
+ATOM   2560  OG  SER A 331      55.636  83.352  27.447  1.00 67.38           O  
+ATOM   2561  N   MET A 332      54.868  83.079  23.173  1.00 71.54           N  
+ATOM   2562  CA  MET A 332      54.002  83.052  22.007  1.00 72.01           C  
+ATOM   2563  C   MET A 332      52.752  82.345  22.520  1.00 72.59           C  
+ATOM   2564  O   MET A 332      52.658  81.121  22.472  1.00 72.63           O  
+ATOM   2565  CB  MET A 332      54.619  82.243  20.860  1.00 70.56           C  
+ATOM   2566  CG  MET A 332      53.677  82.077  19.680  1.00 72.34           C  
+ATOM   2567  SD  MET A 332      54.361  81.198  18.259  1.00 74.33           S  
+ATOM   2568  CE  MET A 332      55.301  82.531  17.492  1.00 77.67           C  
+ATOM   2569  N   LEU A 333      51.807  83.123  23.032  1.00 72.53           N  
+ATOM   2570  CA  LEU A 333      50.564  82.589  23.570  1.00 74.00           C  
+ATOM   2571  C   LEU A 333      49.454  82.362  22.529  1.00 76.36           C  
+ATOM   2572  O   LEU A 333      48.372  81.887  22.875  1.00 74.89           O  
+ATOM   2573  CB  LEU A 333      50.055  83.521  24.679  1.00 70.63           C  
+ATOM   2574  CG  LEU A 333      50.547  83.281  26.110  1.00 71.79           C  
+ATOM   2575  CD1 LEU A 333      51.949  82.741  26.094  1.00 73.43           C  
+ATOM   2576  CD2 LEU A 333      50.468  84.575  26.912  1.00 70.26           C  
+ATOM   2577  N   THR A 334      49.720  82.692  21.263  1.00 80.29           N  
+ATOM   2578  CA  THR A 334      48.726  82.530  20.184  1.00 82.33           C  
+ATOM   2579  C   THR A 334      49.359  82.101  18.861  1.00 83.11           C  
+ATOM   2580  O   THR A 334      50.516  82.409  18.596  1.00 83.36           O  
+ATOM   2581  CB  THR A 334      47.957  83.850  19.926  1.00 82.53           C  
+ATOM   2582  OG1 THR A 334      48.883  84.944  19.922  1.00 83.58           O  
+ATOM   2583  CG2 THR A 334      46.903  84.091  20.998  1.00 83.76           C  
+ATOM   2584  N   ASP A 335      48.606  81.391  18.025  1.00 86.17           N  
+ATOM   2585  CA  ASP A 335      49.142  80.964  16.736  1.00 89.66           C  
+ATOM   2586  C   ASP A 335      49.241  82.202  15.860  1.00 91.18           C  
+ATOM   2587  O   ASP A 335      48.256  82.914  15.671  1.00 91.35           O  
+ATOM   2588  CB  ASP A 335      48.229  79.923  16.071  1.00 90.09           C  
+ATOM   2589  CG  ASP A 335      48.834  79.339  14.791  1.00 92.03           C  
+ATOM   2590  OD1 ASP A 335      48.311  78.318  14.287  1.00 90.12           O  
+ATOM   2591  OD2 ASP A 335      49.832  79.903  14.285  1.00 93.16           O  
+ATOM   2592  N   PRO A 336      50.441  82.484  15.330  1.00 92.85           N  
+ATOM   2593  CA  PRO A 336      50.697  83.644  14.468  1.00 95.62           C  
+ATOM   2594  C   PRO A 336      49.967  83.563  13.126  1.00 97.31           C  
+ATOM   2595  O   PRO A 336      50.051  84.482  12.308  1.00 96.59           O  
+ATOM   2596  CB  PRO A 336      52.215  83.622  14.298  1.00 94.92           C  
+ATOM   2597  CG  PRO A 336      52.693  82.910  15.512  1.00 93.46           C  
+ATOM   2598  CD  PRO A 336      51.699  81.793  15.646  1.00 92.84           C  
+ATOM   2599  N   GLY A 337      49.261  82.454  12.912  1.00 99.66           N  
+ATOM   2600  CA  GLY A 337      48.512  82.257  11.683  1.00100.75           C  
+ATOM   2601  C   GLY A 337      49.342  81.768  10.511  1.00102.54           C  
+ATOM   2602  O   GLY A 337      50.238  80.932  10.664  1.00102.48           O  
+ATOM   2603  N   ASN A 338      49.030  82.299   9.332  1.00103.92           N  
+ATOM   2604  CA  ASN A 338      49.717  81.945   8.094  1.00104.06           C  
+ATOM   2605  C   ASN A 338      51.009  82.741   7.915  1.00103.66           C  
+ATOM   2606  O   ASN A 338      51.116  83.879   8.379  1.00104.24           O  
+ATOM   2607  CB  ASN A 338      48.789  82.203   6.900  1.00105.29           C  
+ATOM   2608  CG  ASN A 338      48.267  83.640   6.860  1.00106.94           C  
+ATOM   2609  OD1 ASN A 338      47.590  84.043   5.911  1.00107.47           O  
+ATOM   2610  ND2 ASN A 338      48.579  84.416   7.896  1.00106.57           N  
+ATOM   2611  N   VAL A 339      51.983  82.138   7.237  1.00102.57           N  
+ATOM   2612  CA  VAL A 339      53.268  82.787   6.980  1.00102.77           C  
+ATOM   2613  C   VAL A 339      54.125  82.832   8.249  1.00102.90           C  
+ATOM   2614  O   VAL A 339      55.241  83.362   8.255  1.00102.47           O  
+ATOM   2615  CB  VAL A 339      53.064  84.228   6.435  1.00102.66           C  
+ATOM   2616  CG1 VAL A 339      54.392  84.808   5.969  1.00102.72           C  
+ATOM   2617  CG2 VAL A 339      52.063  84.214   5.286  1.00101.81           C  
+ATOM   2618  N   GLN A 340      53.588  82.268   9.324  1.00102.89           N  
+ATOM   2619  CA  GLN A 340      54.283  82.208  10.605  1.00100.89           C  
+ATOM   2620  C   GLN A 340      54.111  80.808  11.171  1.00100.04           C  
+ATOM   2621  O   GLN A 340      53.737  80.629  12.330  1.00101.80           O  
+ATOM   2622  CB  GLN A 340      53.706  83.239  11.577  1.00100.23           C  
+ATOM   2623  CG  GLN A 340      54.397  84.596  11.556  1.00 96.32           C  
+ATOM   2624  CD  GLN A 340      55.776  84.557  12.191  1.00 94.09           C  
+ATOM   2625  OE1 GLN A 340      56.647  83.801  11.760  1.00 94.00           O  
+ATOM   2626  NE2 GLN A 340      55.980  85.374  13.221  1.00 90.31           N  
+ATOM   2627  N   LYS A 341      54.377  79.815  10.333  1.00 98.15           N  
+ATOM   2628  CA  LYS A 341      54.255  78.430  10.741  1.00 98.17           C  
+ATOM   2629  C   LYS A 341      55.049  78.181  12.021  1.00 97.76           C  
+ATOM   2630  O   LYS A 341      56.148  78.712  12.209  1.00 97.01           O  
+ATOM   2631  CB  LYS A 341      54.741  77.509   9.615  1.00 99.02           C  
+ATOM   2632  CG  LYS A 341      56.146  77.816   9.109  1.00100.81           C  
+ATOM   2633  CD  LYS A 341      56.485  77.040   7.830  1.00101.63           C  
+ATOM   2634  CE  LYS A 341      56.471  75.525   8.031  1.00100.48           C  
+ATOM   2635  NZ  LYS A 341      55.119  74.985   8.358  1.00 98.34           N  
+ATOM   2636  N   ALA A 342      54.470  77.378  12.906  1.00 96.23           N  
+ATOM   2637  CA  ALA A 342      55.102  77.045  14.173  1.00 94.00           C  
+ATOM   2638  C   ALA A 342      54.520  75.744  14.686  1.00 92.37           C  
+ATOM   2639  O   ALA A 342      53.439  75.330  14.267  1.00 92.49           O  
+ATOM   2640  CB  ALA A 342      54.855  78.154  15.186  1.00 92.37           C  
+ATOM   2641  N   VAL A 343      55.240  75.088  15.585  1.00 90.77           N  
+ATOM   2642  CA  VAL A 343      54.735  73.855  16.161  1.00 88.70           C  
+ATOM   2643  C   VAL A 343      53.806  74.322  17.290  1.00 87.55           C  
+ATOM   2644  O   VAL A 343      54.197  75.140  18.124  1.00 86.22           O  
+ATOM   2645  CB  VAL A 343      55.891  72.986  16.705  1.00 88.74           C  
+ATOM   2646  CG1 VAL A 343      57.110  73.143  15.802  1.00 87.66           C  
+ATOM   2647  CG2 VAL A 343      56.221  73.364  18.133  1.00 89.49           C  
+ATOM   2648  N   CYS A 344      52.570  73.828  17.303  1.00 86.40           N  
+ATOM   2649  CA  CYS A 344      51.609  74.245  18.321  1.00 83.34           C  
+ATOM   2650  C   CYS A 344      51.461  73.362  19.550  1.00 79.64           C  
+ATOM   2651  O   CYS A 344      50.598  73.616  20.389  1.00 79.64           O  
+ATOM   2652  CB  CYS A 344      50.230  74.443  17.697  1.00 85.40           C  
+ATOM   2653  SG  CYS A 344      50.047  75.973  16.728  1.00 86.77           S  
+ATOM   2654  N   HIS A 345      52.272  72.320  19.659  1.00 76.96           N  
+ATOM   2655  CA  HIS A 345      52.196  71.463  20.837  1.00 74.09           C  
+ATOM   2656  C   HIS A 345      52.480  72.369  22.032  1.00 67.87           C  
+ATOM   2657  O   HIS A 345      53.483  73.071  22.060  1.00 64.87           O  
+ATOM   2658  CB  HIS A 345      53.248  70.353  20.768  1.00 77.44           C  
+ATOM   2659  CG  HIS A 345      53.119  69.470  19.564  1.00 84.94           C  
+ATOM   2660  ND1 HIS A 345      53.202  69.952  18.274  1.00 88.34           N  
+ATOM   2661  CD2 HIS A 345      52.933  68.132  19.455  1.00 87.51           C  
+ATOM   2662  CE1 HIS A 345      53.075  68.948  17.421  1.00 88.83           C  
+ATOM   2663  NE2 HIS A 345      52.911  67.834  18.111  1.00 89.64           N  
+ATOM   2664  N   PRO A 346      51.581  72.392  23.020  1.00 65.05           N  
+ATOM   2665  CA  PRO A 346      51.804  73.242  24.197  1.00 64.53           C  
+ATOM   2666  C   PRO A 346      53.132  72.837  24.863  1.00 64.06           C  
+ATOM   2667  O   PRO A 346      53.414  71.644  25.025  1.00 64.16           O  
+ATOM   2668  CB  PRO A 346      50.598  72.927  25.087  1.00 66.00           C  
+ATOM   2669  CG  PRO A 346      49.554  72.436  24.107  1.00 64.05           C  
+ATOM   2670  CD  PRO A 346      50.347  71.602  23.156  1.00 60.69           C  
+ATOM   2671  N   THR A 347      53.947  73.816  25.234  1.00 59.37           N  
+ATOM   2672  CA  THR A 347      55.226  73.521  25.856  1.00 59.64           C  
+ATOM   2673  C   THR A 347      55.704  74.650  26.767  1.00 60.90           C  
+ATOM   2674  O   THR A 347      55.486  75.834  26.482  1.00 58.83           O  
+ATOM   2675  CB  THR A 347      56.308  73.247  24.801  1.00 59.14           C  
+ATOM   2676  OG1 THR A 347      56.288  74.293  23.830  1.00 62.12           O  
+ATOM   2677  CG2 THR A 347      56.081  71.908  24.113  1.00 58.65           C  
+ATOM   2678  N   ALA A 348      56.345  74.268  27.873  1.00 59.46           N  
+ATOM   2679  CA  ALA A 348      56.869  75.227  28.852  1.00 57.63           C  
+ATOM   2680  C   ALA A 348      58.383  75.254  28.716  1.00 54.03           C  
+ATOM   2681  O   ALA A 348      59.031  74.213  28.756  1.00 55.61           O  
+ATOM   2682  CB  ALA A 348      56.461  74.810  30.265  1.00 52.64           C  
+ATOM   2683  N   TRP A 349      58.958  76.437  28.559  1.00 53.50           N  
+ATOM   2684  CA  TRP A 349      60.394  76.511  28.368  1.00 53.08           C  
+ATOM   2685  C   TRP A 349      61.184  77.163  29.482  1.00 52.65           C  
+ATOM   2686  O   TRP A 349      60.784  78.181  30.046  1.00 55.24           O  
+ATOM   2687  CB  TRP A 349      60.731  77.260  27.071  1.00 55.09           C  
+ATOM   2688  CG  TRP A 349      60.219  76.650  25.798  1.00 55.44           C  
+ATOM   2689  CD1 TRP A 349      58.916  76.378  25.487  1.00 54.58           C  
+ATOM   2690  CD2 TRP A 349      60.985  76.334  24.625  1.00 53.32           C  
+ATOM   2691  NE1 TRP A 349      58.824  75.921  24.198  1.00 55.38           N  
+ATOM   2692  CE2 TRP A 349      60.074  75.883  23.643  1.00 54.35           C  
+ATOM   2693  CE3 TRP A 349      62.348  76.393  24.308  1.00 55.76           C  
+ATOM   2694  CZ2 TRP A 349      60.481  75.495  22.358  1.00 54.17           C  
+ATOM   2695  CZ3 TRP A 349      62.756  76.011  23.031  1.00 58.47           C  
+ATOM   2696  CH2 TRP A 349      61.820  75.566  22.070  1.00 58.83           C  
+ATOM   2697  N   ASP A 350      62.329  76.563  29.767  1.00 53.35           N  
+ATOM   2698  CA  ASP A 350      63.269  77.063  30.761  1.00 53.91           C  
+ATOM   2699  C   ASP A 350      64.542  77.219  29.920  1.00 49.88           C  
+ATOM   2700  O   ASP A 350      65.363  76.326  29.839  1.00 48.44           O  
+ATOM   2701  CB  ASP A 350      63.440  76.031  31.886  1.00 53.82           C  
+ATOM   2702  CG  ASP A 350      64.463  76.462  32.941  1.00 60.89           C  
+ATOM   2703  OD1 ASP A 350      64.383  75.950  34.076  1.00 61.59           O  
+ATOM   2704  OD2 ASP A 350      65.352  77.296  32.648  1.00 62.12           O  
+ATOM   2705  N   LEU A 351      64.687  78.359  29.261  1.00 53.49           N  
+ATOM   2706  CA  LEU A 351      65.836  78.562  28.384  1.00 55.43           C  
+ATOM   2707  C   LEU A 351      67.156  78.784  29.080  1.00 55.79           C  
+ATOM   2708  O   LEU A 351      68.214  78.597  28.482  1.00 58.25           O  
+ATOM   2709  CB  LEU A 351      65.578  79.727  27.425  1.00 60.71           C  
+ATOM   2710  CG  LEU A 351      64.406  79.559  26.452  1.00 61.76           C  
+ATOM   2711  CD1 LEU A 351      63.098  79.861  27.176  1.00 63.36           C  
+ATOM   2712  CD2 LEU A 351      64.588  80.505  25.265  1.00 62.33           C  
+ATOM   2713  N   GLY A 352      67.092  79.170  30.345  1.00 54.80           N  
+ATOM   2714  CA  GLY A 352      68.294  79.428  31.096  1.00 54.51           C  
+ATOM   2715  C   GLY A 352      68.345  80.889  31.481  1.00 55.27           C  
+ATOM   2716  O   GLY A 352      67.493  81.688  31.078  1.00 49.60           O  
+ATOM   2717  N   LYS A 353      69.346  81.223  32.286  1.00 58.42           N  
+ATOM   2718  CA  LYS A 353      69.573  82.580  32.755  1.00 60.24           C  
+ATOM   2719  C   LYS A 353      68.295  83.355  33.089  1.00 60.81           C  
+ATOM   2720  O   LYS A 353      68.111  84.500  32.649  1.00 61.67           O  
+ATOM   2721  CB  LYS A 353      70.405  83.333  31.718  1.00 63.28           C  
+ATOM   2722  CG  LYS A 353      70.922  84.677  32.217  1.00 73.55           C  
+ATOM   2723  CD  LYS A 353      71.545  84.571  33.620  1.00 77.29           C  
+ATOM   2724  CE  LYS A 353      71.997  85.948  34.132  1.00 79.86           C  
+ATOM   2725  NZ  LYS A 353      70.884  86.952  34.139  1.00 77.02           N  
+ATOM   2726  N   GLY A 354      67.417  82.726  33.875  1.00 58.38           N  
+ATOM   2727  CA  GLY A 354      66.173  83.360  34.273  1.00 55.23           C  
+ATOM   2728  C   GLY A 354      65.157  83.629  33.168  1.00 54.49           C  
+ATOM   2729  O   GLY A 354      64.223  84.416  33.349  1.00 51.95           O  
+ATOM   2730  N   ASP A 355      65.323  82.978  32.023  1.00 54.41           N  
+ATOM   2731  CA  ASP A 355      64.405  83.177  30.902  1.00 53.95           C  
+ATOM   2732  C   ASP A 355      63.359  82.048  30.818  1.00 53.87           C  
+ATOM   2733  O   ASP A 355      63.678  80.902  30.490  1.00 53.03           O  
+ATOM   2734  CB  ASP A 355      65.221  83.255  29.616  1.00 54.46           C  
+ATOM   2735  CG  ASP A 355      64.390  83.645  28.411  1.00 57.94           C  
+ATOM   2736  OD1 ASP A 355      64.999  84.023  27.392  1.00 63.76           O  
+ATOM   2737  OD2 ASP A 355      63.145  83.572  28.470  1.00 57.97           O  
+ATOM   2738  N   PHE A 356      62.108  82.379  31.112  1.00 55.02           N  
+ATOM   2739  CA  PHE A 356      61.031  81.394  31.097  1.00 56.97           C  
+ATOM   2740  C   PHE A 356      59.973  81.774  30.070  1.00 57.94           C  
+ATOM   2741  O   PHE A 356      59.608  82.939  29.966  1.00 58.12           O  
+ATOM   2742  CB  PHE A 356      60.394  81.305  32.488  1.00 51.38           C  
+ATOM   2743  CG  PHE A 356      61.387  81.046  33.589  1.00 55.82           C  
+ATOM   2744  CD1 PHE A 356      61.916  82.094  34.330  1.00 51.94           C  
+ATOM   2745  CD2 PHE A 356      61.827  79.749  33.861  1.00 54.62           C  
+ATOM   2746  CE1 PHE A 356      62.874  81.857  35.331  1.00 54.67           C  
+ATOM   2747  CE2 PHE A 356      62.781  79.506  34.853  1.00 54.70           C  
+ATOM   2748  CZ  PHE A 356      63.306  80.559  35.591  1.00 51.98           C  
+ATOM   2749  N   ARG A 357      59.475  80.798  29.315  1.00 57.83           N  
+ATOM   2750  CA  ARG A 357      58.452  81.086  28.309  1.00 57.06           C  
+ATOM   2751  C   ARG A 357      57.522  79.923  28.062  1.00 56.90           C  
+ATOM   2752  O   ARG A 357      57.901  78.760  28.232  1.00 59.94           O  
+ATOM   2753  CB  ARG A 357      59.083  81.429  26.959  1.00 54.96           C  
+ATOM   2754  CG  ARG A 357      60.120  82.523  26.987  1.00 61.07           C  
+ATOM   2755  CD  ARG A 357      60.738  82.731  25.615  1.00 59.53           C  
+ATOM   2756  NE  ARG A 357      61.934  83.561  25.716  1.00 62.08           N  
+ATOM   2757  CZ  ARG A 357      62.637  83.999  24.677  1.00 58.61           C  
+ATOM   2758  NH1 ARG A 357      63.713  84.741  24.884  1.00 54.24           N  
+ATOM   2759  NH2 ARG A 357      62.263  83.702  23.437  1.00 56.09           N  
+ATOM   2760  N   ILE A 358      56.299  80.244  27.655  1.00 57.34           N  
+ATOM   2761  CA  ILE A 358      55.326  79.220  27.278  1.00 54.97           C  
+ATOM   2762  C   ILE A 358      54.999  79.431  25.796  1.00 56.47           C  
+ATOM   2763  O   ILE A 358      54.769  80.564  25.344  1.00 55.29           O  
+ATOM   2764  CB  ILE A 358      54.024  79.296  28.108  1.00 52.18           C  
+ATOM   2765  CG1 ILE A 358      54.246  78.632  29.479  1.00 46.78           C  
+ATOM   2766  CG2 ILE A 358      52.882  78.613  27.339  1.00 48.60           C  
+ATOM   2767  CD1 ILE A 358      53.045  78.695  30.433  1.00 44.56           C  
+ATOM   2768  N   LEU A 359      55.027  78.336  25.045  1.00 57.24           N  
+ATOM   2769  CA  LEU A 359      54.718  78.328  23.626  1.00 55.38           C  
+ATOM   2770  C   LEU A 359      53.443  77.521  23.497  1.00 59.75           C  
+ATOM   2771  O   LEU A 359      53.414  76.330  23.819  1.00 58.48           O  
+ATOM   2772  CB  LEU A 359      55.843  77.658  22.825  1.00 58.15           C  
+ATOM   2773  CG  LEU A 359      55.533  77.196  21.388  1.00 61.77           C  
+ATOM   2774  CD1 LEU A 359      54.716  78.233  20.646  1.00 60.54           C  
+ATOM   2775  CD2 LEU A 359      56.829  76.927  20.655  1.00 59.42           C  
+ATOM   2776  N   MET A 360      52.381  78.169  23.037  1.00 61.42           N  
+ATOM   2777  CA  MET A 360      51.110  77.495  22.894  1.00 62.46           C  
+ATOM   2778  C   MET A 360      50.184  78.328  22.008  1.00 66.12           C  
+ATOM   2779  O   MET A 360      50.044  79.541  22.202  1.00 64.89           O  
+ATOM   2780  CB  MET A 360      50.494  77.311  24.280  1.00 62.47           C  
+ATOM   2781  CG  MET A 360      49.380  76.283  24.389  1.00 62.52           C  
+ATOM   2782  SD  MET A 360      48.647  76.269  26.062  1.00 68.28           S  
+ATOM   2783  CE  MET A 360      46.930  76.500  25.722  1.00 63.98           C  
+ATOM   2784  N   CYS A 361      49.557  77.681  21.031  1.00 69.72           N  
+ATOM   2785  CA  CYS A 361      48.624  78.380  20.147  1.00 73.15           C  
+ATOM   2786  C   CYS A 361      47.289  78.267  20.854  1.00 73.33           C  
+ATOM   2787  O   CYS A 361      46.464  77.414  20.528  1.00 73.54           O  
+ATOM   2788  CB  CYS A 361      48.583  77.709  18.770  1.00 75.89           C  
+ATOM   2789  SG  CYS A 361      50.256  77.465  18.091  1.00 80.51           S  
+ATOM   2790  N   THR A 362      47.103  79.143  21.837  1.00 73.91           N  
+ATOM   2791  CA  THR A 362      45.913  79.166  22.670  1.00 75.18           C  
+ATOM   2792  C   THR A 362      44.592  79.491  21.975  1.00 76.55           C  
+ATOM   2793  O   THR A 362      44.488  80.461  21.230  1.00 76.71           O  
+ATOM   2794  CB  THR A 362      46.109  80.151  23.836  1.00 76.49           C  
+ATOM   2795  OG1 THR A 362      47.339  79.852  24.507  1.00 79.43           O  
+ATOM   2796  CG2 THR A 362      44.971  80.043  24.832  1.00 76.38           C  
+ATOM   2797  N   LYS A 363      43.591  78.657  22.244  1.00 77.11           N  
+ATOM   2798  CA  LYS A 363      42.239  78.811  21.715  1.00 77.20           C  
+ATOM   2799  C   LYS A 363      41.347  79.109  22.920  1.00 77.52           C  
+ATOM   2800  O   LYS A 363      41.654  78.688  24.039  1.00 78.50           O  
+ATOM   2801  CB  LYS A 363      41.766  77.515  21.060  1.00 78.12           C  
+ATOM   2802  CG  LYS A 363      42.675  76.975  19.967  1.00 82.55           C  
+ATOM   2803  CD  LYS A 363      42.169  75.616  19.468  1.00 83.61           C  
+ATOM   2804  CE  LYS A 363      43.057  75.037  18.369  1.00 85.33           C  
+ATOM   2805  NZ  LYS A 363      42.469  73.798  17.782  1.00 84.21           N  
+ATOM   2806  N   VAL A 364      40.246  79.821  22.704  1.00 75.77           N  
+ATOM   2807  CA  VAL A 364      39.348  80.155  23.804  1.00 75.46           C  
+ATOM   2808  C   VAL A 364      38.426  78.993  24.170  1.00 76.88           C  
+ATOM   2809  O   VAL A 364      37.212  79.065  23.980  1.00 78.19           O  
+ATOM   2810  CB  VAL A 364      38.491  81.387  23.464  1.00 73.98           C  
+ATOM   2811  CG1 VAL A 364      37.604  81.755  24.650  1.00 73.74           C  
+ATOM   2812  CG2 VAL A 364      39.396  82.550  23.108  1.00 73.02           C  
+ATOM   2813  N   THR A 365      39.011  77.926  24.708  1.00 76.08           N  
+ATOM   2814  CA  THR A 365      38.258  76.746  25.102  1.00 74.10           C  
+ATOM   2815  C   THR A 365      38.519  76.409  26.563  1.00 72.64           C  
+ATOM   2816  O   THR A 365      39.452  76.932  27.169  1.00 70.70           O  
+ATOM   2817  CB  THR A 365      38.660  75.544  24.249  1.00 75.67           C  
+ATOM   2818  OG1 THR A 365      38.410  75.845  22.872  1.00 78.42           O  
+ATOM   2819  CG2 THR A 365      37.853  74.304  24.644  1.00 79.97           C  
+ATOM   2820  N   MET A 366      37.687  75.545  27.134  1.00 70.73           N  
+ATOM   2821  CA  MET A 366      37.886  75.145  28.515  1.00 69.54           C  
+ATOM   2822  C   MET A 366      39.170  74.324  28.545  1.00 68.47           C  
+ATOM   2823  O   MET A 366      40.003  74.483  29.436  1.00 69.75           O  
+ATOM   2824  CB  MET A 366      36.719  74.296  29.015  1.00 68.14           C  
+ATOM   2825  CG  MET A 366      36.744  74.066  30.522  1.00 68.11           C  
+ATOM   2826  SD  MET A 366      35.450  72.964  31.126  1.00 67.95           S  
+ATOM   2827  CE  MET A 366      36.308  71.368  30.973  1.00 68.26           C  
+ATOM   2828  N   ASP A 367      39.339  73.462  27.551  1.00 65.68           N  
+ATOM   2829  CA  ASP A 367      40.525  72.630  27.487  1.00 66.12           C  
+ATOM   2830  C   ASP A 367      41.837  73.411  27.497  1.00 66.73           C  
+ATOM   2831  O   ASP A 367      42.803  72.975  28.119  1.00 67.81           O  
+ATOM   2832  CB  ASP A 367      40.480  71.719  26.259  1.00 66.63           C  
+ATOM   2833  CG  ASP A 367      39.492  70.566  26.421  1.00 70.64           C  
+ATOM   2834  OD1 ASP A 367      38.884  70.442  27.511  1.00 69.09           O  
+ATOM   2835  OD2 ASP A 367      39.328  69.780  25.460  1.00 72.64           O  
+ATOM   2836  N   ASP A 368      41.886  74.556  26.821  1.00 65.42           N  
+ATOM   2837  CA  ASP A 368      43.120  75.343  26.783  1.00 63.63           C  
+ATOM   2838  C   ASP A 368      43.317  76.192  28.015  1.00 60.43           C  
+ATOM   2839  O   ASP A 368      44.418  76.661  28.284  1.00 60.17           O  
+ATOM   2840  CB  ASP A 368      43.167  76.214  25.529  1.00 63.95           C  
+ATOM   2841  CG  ASP A 368      43.517  75.416  24.309  1.00 64.04           C  
+ATOM   2842  OD1 ASP A 368      42.975  74.302  24.178  1.00 66.89           O  
+ATOM   2843  OD2 ASP A 368      44.326  75.888  23.484  1.00 70.78           O  
+ATOM   2844  N   PHE A 369      42.238  76.392  28.756  1.00 57.90           N  
+ATOM   2845  CA  PHE A 369      42.291  77.159  29.987  1.00 56.90           C  
+ATOM   2846  C   PHE A 369      42.954  76.269  31.052  1.00 56.20           C  
+ATOM   2847  O   PHE A 369      43.662  76.757  31.933  1.00 56.44           O  
+ATOM   2848  CB  PHE A 369      40.863  77.568  30.385  1.00 52.69           C  
+ATOM   2849  CG  PHE A 369      40.707  77.981  31.832  1.00 56.45           C  
+ATOM   2850  CD1 PHE A 369      40.384  77.042  32.807  1.00 53.75           C  
+ATOM   2851  CD2 PHE A 369      40.828  79.308  32.206  1.00 56.10           C  
+ATOM   2852  CE1 PHE A 369      40.181  77.415  34.123  1.00 51.89           C  
+ATOM   2853  CE2 PHE A 369      40.624  79.693  33.525  1.00 59.72           C  
+ATOM   2854  CZ  PHE A 369      40.297  78.739  34.486  1.00 58.76           C  
+ATOM   2855  N   LEU A 370      42.730  74.958  30.942  1.00 56.91           N  
+ATOM   2856  CA  LEU A 370      43.291  73.976  31.872  1.00 55.54           C  
+ATOM   2857  C   LEU A 370      44.726  73.651  31.483  1.00 55.81           C  
+ATOM   2858  O   LEU A 370      45.573  73.422  32.347  1.00 56.10           O  
+ATOM   2859  CB  LEU A 370      42.468  72.690  31.852  1.00 52.74           C  
+ATOM   2860  CG  LEU A 370      40.990  72.834  32.200  1.00 54.62           C  
+ATOM   2861  CD1 LEU A 370      40.272  71.517  31.947  1.00 51.33           C  
+ATOM   2862  CD2 LEU A 370      40.850  73.279  33.654  1.00 54.74           C  
+ATOM   2863  N   THR A 371      44.998  73.622  30.180  1.00 53.53           N  
+ATOM   2864  CA  THR A 371      46.348  73.335  29.708  1.00 53.64           C  
+ATOM   2865  C   THR A 371      47.290  74.468  30.106  1.00 54.37           C  
+ATOM   2866  O   THR A 371      48.477  74.249  30.403  1.00 54.24           O  
+ATOM   2867  CB  THR A 371      46.377  73.135  28.184  1.00 51.86           C  
+ATOM   2868  OG1 THR A 371      45.777  71.878  27.867  1.00 50.38           O  
+ATOM   2869  CG2 THR A 371      47.787  73.132  27.671  1.00 47.48           C  
+ATOM   2870  N   ALA A 372      46.746  75.678  30.132  1.00 52.99           N  
+ATOM   2871  CA  ALA A 372      47.517  76.849  30.515  1.00 52.05           C  
+ATOM   2872  C   ALA A 372      47.942  76.725  31.983  1.00 51.28           C  
+ATOM   2873  O   ALA A 372      49.060  77.096  32.342  1.00 51.10           O  
+ATOM   2874  CB  ALA A 372      46.683  78.109  30.319  1.00 52.64           C  
+ATOM   2875  N   HIS A 373      47.040  76.240  32.832  1.00 48.19           N  
+ATOM   2876  CA  HIS A 373      47.360  76.066  34.240  1.00 49.40           C  
+ATOM   2877  C   HIS A 373      48.414  74.963  34.369  1.00 50.74           C  
+ATOM   2878  O   HIS A 373      49.432  75.127  35.054  1.00 48.51           O  
+ATOM   2879  CB  HIS A 373      46.113  75.691  35.040  1.00 50.96           C  
+ATOM   2880  CG  HIS A 373      45.216  76.849  35.337  1.00 53.25           C  
+ATOM   2881  ND1 HIS A 373      44.382  77.408  34.394  1.00 56.26           N  
+ATOM   2882  CD2 HIS A 373      45.038  77.567  36.470  1.00 53.91           C  
+ATOM   2883  CE1 HIS A 373      43.729  78.423  34.934  1.00 55.38           C  
+ATOM   2884  NE2 HIS A 373      44.109  78.540  36.193  1.00 54.56           N  
+ATOM   2885  N   HIS A 374      48.171  73.841  33.693  1.00 48.51           N  
+ATOM   2886  CA  HIS A 374      49.117  72.741  33.718  1.00 45.77           C  
+ATOM   2887  C   HIS A 374      50.488  73.254  33.299  1.00 48.37           C  
+ATOM   2888  O   HIS A 374      51.467  73.108  34.037  1.00 47.48           O  
+ATOM   2889  CB  HIS A 374      48.654  71.625  32.774  1.00 41.31           C  
+ATOM   2890  CG  HIS A 374      49.703  70.593  32.490  1.00 32.87           C  
+ATOM   2891  ND1 HIS A 374      49.507  69.249  32.730  1.00 37.53           N  
+ATOM   2892  CD2 HIS A 374      50.934  70.698  31.933  1.00 39.56           C  
+ATOM   2893  CE1 HIS A 374      50.571  68.571  32.325  1.00 40.23           C  
+ATOM   2894  NE2 HIS A 374      51.455  69.428  31.836  1.00 31.38           N  
+ATOM   2895  N   GLU A 375      50.557  73.867  32.114  1.00 52.44           N  
+ATOM   2896  CA  GLU A 375      51.818  74.385  31.606  1.00 50.62           C  
+ATOM   2897  C   GLU A 375      52.401  75.495  32.478  1.00 49.22           C  
+ATOM   2898  O   GLU A 375      53.610  75.551  32.685  1.00 48.47           O  
+ATOM   2899  CB  GLU A 375      51.661  74.863  30.166  1.00 56.18           C  
+ATOM   2900  CG  GLU A 375      51.352  73.737  29.168  1.00 62.55           C  
+ATOM   2901  CD  GLU A 375      52.421  72.653  29.127  1.00 63.98           C  
+ATOM   2902  OE1 GLU A 375      53.623  72.993  29.116  1.00 68.72           O  
+ATOM   2903  OE2 GLU A 375      52.064  71.457  29.091  1.00 67.20           O  
+ATOM   2904  N   MET A 376      51.577  76.386  33.007  1.00 46.59           N  
+ATOM   2905  CA  MET A 376      52.175  77.397  33.851  1.00 47.32           C  
+ATOM   2906  C   MET A 376      52.666  76.722  35.134  1.00 49.32           C  
+ATOM   2907  O   MET A 376      53.447  77.303  35.875  1.00 52.45           O  
+ATOM   2908  CB  MET A 376      51.182  78.507  34.188  1.00 49.52           C  
+ATOM   2909  CG  MET A 376      51.853  79.726  34.826  1.00 51.19           C  
+ATOM   2910  SD  MET A 376      50.716  81.086  35.160  1.00 57.91           S  
+ATOM   2911  CE  MET A 376      50.733  81.841  33.517  1.00 47.14           C  
+ATOM   2912  N   GLY A 377      52.199  75.498  35.393  1.00 51.40           N  
+ATOM   2913  CA  GLY A 377      52.616  74.768  36.579  1.00 45.62           C  
+ATOM   2914  C   GLY A 377      54.081  74.413  36.439  1.00 45.65           C  
+ATOM   2915  O   GLY A 377      54.858  74.501  37.394  1.00 44.49           O  
+ATOM   2916  N   HIS A 378      54.455  74.017  35.228  1.00 41.87           N  
+ATOM   2917  CA  HIS A 378      55.830  73.672  34.911  1.00 43.25           C  
+ATOM   2918  C   HIS A 378      56.785  74.849  35.067  1.00 44.95           C  
+ATOM   2919  O   HIS A 378      57.928  74.690  35.510  1.00 40.55           O  
+ATOM   2920  CB  HIS A 378      55.947  73.222  33.474  1.00 46.34           C  
+ATOM   2921  CG  HIS A 378      55.372  71.877  33.208  1.00 52.07           C  
+ATOM   2922  ND1 HIS A 378      55.812  70.744  33.855  1.00 51.10           N  
+ATOM   2923  CD2 HIS A 378      54.475  71.463  32.285  1.00 50.01           C  
+ATOM   2924  CE1 HIS A 378      55.218  69.687  33.334  1.00 48.65           C  
+ATOM   2925  NE2 HIS A 378      54.402  70.097  32.380  1.00 49.95           N  
+ATOM   2926  N   ILE A 379      56.334  76.017  34.625  1.00 44.77           N  
+ATOM   2927  CA  ILE A 379      57.148  77.213  34.702  1.00 47.13           C  
+ATOM   2928  C   ILE A 379      57.458  77.497  36.173  1.00 48.54           C  
+ATOM   2929  O   ILE A 379      58.609  77.725  36.569  1.00 48.67           O  
+ATOM   2930  CB  ILE A 379      56.401  78.420  34.093  1.00 46.86           C  
+ATOM   2931  CG1 ILE A 379      56.088  78.149  32.618  1.00 41.03           C  
+ATOM   2932  CG2 ILE A 379      57.261  79.689  34.249  1.00 43.97           C  
+ATOM   2933  CD1 ILE A 379      57.331  78.100  31.722  1.00 41.27           C  
+ATOM   2934  N   GLN A 380      56.406  77.452  36.972  1.00 48.00           N  
+ATOM   2935  CA  GLN A 380      56.495  77.695  38.392  1.00 49.85           C  
+ATOM   2936  C   GLN A 380      57.582  76.804  38.992  1.00 51.15           C  
+ATOM   2937  O   GLN A 380      58.432  77.254  39.772  1.00 52.83           O  
+ATOM   2938  CB  GLN A 380      55.145  77.372  39.017  1.00 52.54           C  
+ATOM   2939  CG  GLN A 380      54.891  78.097  40.280  1.00 56.88           C  
+ATOM   2940  CD  GLN A 380      54.733  79.567  40.042  1.00 59.43           C  
+ATOM   2941  OE1 GLN A 380      55.236  80.372  40.804  1.00 62.15           O  
+ATOM   2942  NE2 GLN A 380      54.022  79.929  38.980  1.00 59.81           N  
+ATOM   2943  N   TYR A 381      57.551  75.537  38.606  1.00 49.33           N  
+ATOM   2944  CA  TYR A 381      58.500  74.565  39.093  1.00 48.74           C  
+ATOM   2945  C   TYR A 381      59.887  74.972  38.627  1.00 46.53           C  
+ATOM   2946  O   TYR A 381      60.849  74.889  39.387  1.00 49.42           O  
+ATOM   2947  CB  TYR A 381      58.122  73.175  38.562  1.00 46.71           C  
+ATOM   2948  CG  TYR A 381      58.723  71.992  39.297  1.00 42.59           C  
+ATOM   2949  CD1 TYR A 381      58.226  70.702  39.082  1.00 43.78           C  
+ATOM   2950  CD2 TYR A 381      59.773  72.151  40.197  1.00 38.11           C  
+ATOM   2951  CE1 TYR A 381      58.754  69.600  39.747  1.00 46.37           C  
+ATOM   2952  CE2 TYR A 381      60.314  71.054  40.871  1.00 40.94           C  
+ATOM   2953  CZ  TYR A 381      59.799  69.781  40.639  1.00 43.15           C  
+ATOM   2954  OH  TYR A 381      60.344  68.683  41.243  1.00 37.50           O  
+ATOM   2955  N   ASP A 382      59.993  75.419  37.383  1.00 46.09           N  
+ATOM   2956  CA  ASP A 382      61.276  75.850  36.836  1.00 46.60           C  
+ATOM   2957  C   ASP A 382      61.846  77.066  37.578  1.00 48.34           C  
+ATOM   2958  O   ASP A 382      63.057  77.165  37.813  1.00 46.23           O  
+ATOM   2959  CB  ASP A 382      61.121  76.228  35.375  1.00 52.40           C  
+ATOM   2960  CG  ASP A 382      60.798  75.048  34.500  1.00 53.50           C  
+ATOM   2961  OD1 ASP A 382      61.357  73.956  34.748  1.00 53.39           O  
+ATOM   2962  OD2 ASP A 382      60.006  75.227  33.550  1.00 58.46           O  
+ATOM   2963  N   MET A 383      60.961  77.994  37.923  1.00 46.98           N  
+ATOM   2964  CA  MET A 383      61.353  79.200  38.624  1.00 48.26           C  
+ATOM   2965  C   MET A 383      61.778  78.895  40.048  1.00 49.45           C  
+ATOM   2966  O   MET A 383      62.772  79.437  40.535  1.00 53.71           O  
+ATOM   2967  CB  MET A 383      60.198  80.197  38.626  1.00 47.34           C  
+ATOM   2968  CG  MET A 383      59.877  80.767  37.246  1.00 49.35           C  
+ATOM   2969  SD  MET A 383      58.356  81.709  37.263  1.00 57.14           S  
+ATOM   2970  CE  MET A 383      58.675  82.868  38.540  1.00 54.75           C  
+ATOM   2971  N   ALA A 384      61.036  78.013  40.707  1.00 48.84           N  
+ATOM   2972  CA  ALA A 384      61.331  77.652  42.085  1.00 47.77           C  
+ATOM   2973  C   ALA A 384      62.732  77.081  42.273  1.00 47.56           C  
+ATOM   2974  O   ALA A 384      63.361  77.307  43.302  1.00 52.46           O  
+ATOM   2975  CB  ALA A 384      60.271  76.668  42.607  1.00 43.45           C  
+ATOM   2976  N   TYR A 385      63.245  76.356  41.290  1.00 46.37           N  
+ATOM   2977  CA  TYR A 385      64.581  75.793  41.446  1.00 44.77           C  
+ATOM   2978  C   TYR A 385      65.660  76.437  40.568  1.00 43.10           C  
+ATOM   2979  O   TYR A 385      66.722  75.857  40.355  1.00 40.24           O  
+ATOM   2980  CB  TYR A 385      64.539  74.270  41.215  1.00 46.25           C  
+ATOM   2981  CG  TYR A 385      64.056  73.790  39.851  1.00 44.41           C  
+ATOM   2982  CD1 TYR A 385      63.221  72.680  39.756  1.00 46.01           C  
+ATOM   2983  CD2 TYR A 385      64.520  74.360  38.658  1.00 44.93           C  
+ATOM   2984  CE1 TYR A 385      62.862  72.126  38.523  1.00 45.71           C  
+ATOM   2985  CE2 TYR A 385      64.164  73.807  37.404  1.00 46.38           C  
+ATOM   2986  CZ  TYR A 385      63.332  72.679  37.359  1.00 46.42           C  
+ATOM   2987  OH  TYR A 385      62.992  72.068  36.167  1.00 47.82           O  
+ATOM   2988  N   ALA A 386      65.384  77.634  40.059  1.00 41.59           N  
+ATOM   2989  CA  ALA A 386      66.344  78.327  39.206  1.00 45.67           C  
+ATOM   2990  C   ALA A 386      67.690  78.618  39.889  1.00 49.81           C  
+ATOM   2991  O   ALA A 386      68.708  78.737  39.210  1.00 52.25           O  
+ATOM   2992  CB  ALA A 386      65.736  79.620  38.692  1.00 44.26           C  
+ATOM   2993  N   ALA A 387      67.704  78.710  41.220  1.00 51.16           N  
+ATOM   2994  CA  ALA A 387      68.941  79.008  41.955  1.00 52.08           C  
+ATOM   2995  C   ALA A 387      69.845  77.808  42.159  1.00 54.31           C  
+ATOM   2996  O   ALA A 387      70.994  77.949  42.595  1.00 57.25           O  
+ATOM   2997  CB  ALA A 387      68.611  79.615  43.304  1.00 51.77           C  
+ATOM   2998  N   GLN A 388      69.334  76.620  41.874  1.00 52.05           N  
+ATOM   2999  CA  GLN A 388      70.142  75.413  42.034  1.00 49.91           C  
+ATOM   3000  C   GLN A 388      71.190  75.373  40.927  1.00 49.59           C  
+ATOM   3001  O   GLN A 388      71.031  76.018  39.901  1.00 52.59           O  
+ATOM   3002  CB  GLN A 388      69.243  74.173  41.910  1.00 49.98           C  
+ATOM   3003  CG  GLN A 388      68.204  74.019  43.010  1.00 48.72           C  
+ATOM   3004  CD  GLN A 388      68.807  73.588  44.333  1.00 48.68           C  
+ATOM   3005  OE1 GLN A 388      69.839  72.924  44.364  1.00 50.29           O  
+ATOM   3006  NE2 GLN A 388      68.144  73.936  45.436  1.00 49.44           N  
+ATOM   3007  N   PRO A 389      72.303  74.660  41.132  1.00 49.11           N  
+ATOM   3008  CA  PRO A 389      73.233  74.660  40.001  1.00 48.59           C  
+ATOM   3009  C   PRO A 389      72.576  73.973  38.778  1.00 50.73           C  
+ATOM   3010  O   PRO A 389      71.689  73.127  38.919  1.00 46.30           O  
+ATOM   3011  CB  PRO A 389      74.436  73.877  40.527  1.00 45.84           C  
+ATOM   3012  CG  PRO A 389      73.882  73.096  41.695  1.00 49.32           C  
+ATOM   3013  CD  PRO A 389      72.911  74.043  42.320  1.00 47.40           C  
+ATOM   3014  N   PHE A 390      73.032  74.361  37.591  1.00 49.55           N  
+ATOM   3015  CA  PHE A 390      72.538  73.852  36.320  1.00 50.31           C  
+ATOM   3016  C   PHE A 390      72.077  72.395  36.286  1.00 48.30           C  
+ATOM   3017  O   PHE A 390      70.942  72.103  35.899  1.00 43.65           O  
+ATOM   3018  CB  PHE A 390      73.614  74.038  35.252  1.00 51.05           C  
+ATOM   3019  CG  PHE A 390      73.152  73.697  33.879  1.00 50.39           C  
+ATOM   3020  CD1 PHE A 390      72.534  74.648  33.093  1.00 52.81           C  
+ATOM   3021  CD2 PHE A 390      73.297  72.410  33.388  1.00 49.69           C  
+ATOM   3022  CE1 PHE A 390      72.059  74.318  31.829  1.00 56.80           C  
+ATOM   3023  CE2 PHE A 390      72.827  72.071  32.135  1.00 53.17           C  
+ATOM   3024  CZ  PHE A 390      72.206  73.024  31.351  1.00 55.11           C  
+ATOM   3025  N   LEU A 391      72.973  71.488  36.663  1.00 48.73           N  
+ATOM   3026  CA  LEU A 391      72.682  70.055  36.653  1.00 48.44           C  
+ATOM   3027  C   LEU A 391      71.623  69.581  37.642  1.00 49.16           C  
+ATOM   3028  O   LEU A 391      71.117  68.459  37.512  1.00 52.08           O  
+ATOM   3029  CB  LEU A 391      73.968  69.256  36.877  1.00 48.43           C  
+ATOM   3030  CG  LEU A 391      74.922  69.227  35.686  1.00 50.85           C  
+ATOM   3031  CD1 LEU A 391      76.318  68.784  36.125  1.00 44.60           C  
+ATOM   3032  CD2 LEU A 391      74.344  68.308  34.612  1.00 41.24           C  
+ATOM   3033  N   LEU A 392      71.273  70.415  38.619  1.00 44.35           N  
+ATOM   3034  CA  LEU A 392      70.261  70.019  39.597  1.00 41.46           C  
+ATOM   3035  C   LEU A 392      68.924  70.676  39.306  1.00 40.58           C  
+ATOM   3036  O   LEU A 392      67.982  70.579  40.096  1.00 38.60           O  
+ATOM   3037  CB  LEU A 392      70.714  70.391  41.013  1.00 45.43           C  
+ATOM   3038  CG  LEU A 392      71.573  69.372  41.752  1.00 49.77           C  
+ATOM   3039  CD1 LEU A 392      72.241  68.440  40.770  1.00 44.42           C  
+ATOM   3040  CD2 LEU A 392      72.584  70.103  42.639  1.00 49.13           C  
+ATOM   3041  N   ARG A 393      68.841  71.366  38.179  1.00 41.91           N  
+ATOM   3042  CA  ARG A 393      67.596  72.018  37.822  1.00 44.80           C  
+ATOM   3043  C   ARG A 393      66.684  71.084  37.025  1.00 45.56           C  
+ATOM   3044  O   ARG A 393      66.710  71.072  35.794  1.00 42.93           O  
+ATOM   3045  CB  ARG A 393      67.861  73.279  36.999  1.00 47.83           C  
+ATOM   3046  CG  ARG A 393      68.545  74.393  37.740  1.00 50.77           C  
+ATOM   3047  CD  ARG A 393      68.599  75.619  36.856  1.00 54.94           C  
+ATOM   3048  NE  ARG A 393      69.808  76.385  37.103  1.00 59.28           N  
+ATOM   3049  CZ  ARG A 393      70.351  77.222  36.229  1.00 62.41           C  
+ATOM   3050  NH1 ARG A 393      69.792  77.404  35.039  1.00 58.97           N  
+ATOM   3051  NH2 ARG A 393      71.462  77.872  36.549  1.00 65.62           N  
+ATOM   3052  N   ASN A 394      65.891  70.296  37.739  1.00 47.29           N  
+ATOM   3053  CA  ASN A 394      64.946  69.384  37.121  1.00 49.31           C  
+ATOM   3054  C   ASN A 394      64.054  68.844  38.227  1.00 49.99           C  
+ATOM   3055  O   ASN A 394      64.274  69.155  39.402  1.00 47.03           O  
+ATOM   3056  CB  ASN A 394      65.680  68.253  36.415  1.00 52.55           C  
+ATOM   3057  CG  ASN A 394      64.899  67.719  35.215  1.00 60.15           C  
+ATOM   3058  OD1 ASN A 394      65.474  67.114  34.313  1.00 61.68           O  
+ATOM   3059  ND2 ASN A 394      63.581  67.937  35.209  1.00 54.73           N  
+ATOM   3060  N   GLY A 395      63.031  68.073  37.864  1.00 44.97           N  
+ATOM   3061  CA  GLY A 395      62.156  67.512  38.883  1.00 45.31           C  
+ATOM   3062  C   GLY A 395      62.916  66.511  39.749  1.00 42.29           C  
+ATOM   3063  O   GLY A 395      63.913  65.960  39.287  1.00 39.51           O  
+ATOM   3064  N   ALA A 396      62.453  66.276  40.983  1.00 42.63           N  
+ATOM   3065  CA  ALA A 396      63.110  65.328  41.905  1.00 40.13           C  
+ATOM   3066  C   ALA A 396      63.433  64.030  41.174  1.00 42.50           C  
+ATOM   3067  O   ALA A 396      64.531  63.478  41.329  1.00 45.18           O  
+ATOM   3068  CB  ALA A 396      62.231  65.077  43.133  1.00 37.31           C  
+ATOM   3069  N   ASN A 397      62.471  63.507  40.409  1.00 41.92           N  
+ATOM   3070  CA  ASN A 397      62.734  62.354  39.550  1.00 39.35           C  
+ATOM   3071  C   ASN A 397      61.851  62.445  38.294  1.00 38.55           C  
+ATOM   3072  O   ASN A 397      61.036  63.354  38.194  1.00 31.74           O  
+ATOM   3073  CB  ASN A 397      62.614  60.994  40.292  1.00 42.73           C  
+ATOM   3074  CG  ASN A 397      61.207  60.611  40.657  1.00 45.82           C  
+ATOM   3075  OD1 ASN A 397      60.990  59.962  41.702  1.00 47.27           O  
+ATOM   3076  ND2 ASN A 397      60.241  60.965  39.814  1.00 32.60           N  
+ATOM   3077  N   GLU A 398      62.026  61.517  37.353  1.00 37.75           N  
+ATOM   3078  CA  GLU A 398      61.305  61.533  36.079  1.00 39.11           C  
+ATOM   3079  C   GLU A 398      59.816  61.791  36.160  1.00 42.81           C  
+ATOM   3080  O   GLU A 398      59.232  62.389  35.256  1.00 47.15           O  
+ATOM   3081  CB  GLU A 398      61.568  60.236  35.286  1.00 37.96           C  
+ATOM   3082  CG  GLU A 398      61.142  58.941  35.985  1.00 38.30           C  
+ATOM   3083  CD  GLU A 398      61.335  57.715  35.108  1.00 43.76           C  
+ATOM   3084  OE1 GLU A 398      62.239  57.699  34.249  1.00 48.51           O  
+ATOM   3085  OE2 GLU A 398      60.586  56.739  35.279  1.00 50.04           O  
+ATOM   3086  N   GLY A 399      59.203  61.413  37.269  1.00 44.53           N  
+ATOM   3087  CA  GLY A 399      57.775  61.600  37.394  1.00 37.37           C  
+ATOM   3088  C   GLY A 399      57.223  62.780  38.153  1.00 38.12           C  
+ATOM   3089  O   GLY A 399      56.010  62.845  38.284  1.00 37.72           O  
+ATOM   3090  N   PHE A 400      58.053  63.707  38.645  1.00 38.07           N  
+ATOM   3091  CA  PHE A 400      57.541  64.883  39.415  1.00 37.87           C  
+ATOM   3092  C   PHE A 400      56.926  66.080  38.625  1.00 33.11           C  
+ATOM   3093  O   PHE A 400      55.900  66.624  39.013  1.00 36.58           O  
+ATOM   3094  CB  PHE A 400      58.670  65.464  40.303  1.00 42.26           C  
+ATOM   3095  CG  PHE A 400      58.767  64.850  41.698  1.00 45.69           C  
+ATOM   3096  CD1 PHE A 400      58.907  63.479  41.870  1.00 46.72           C  
+ATOM   3097  CD2 PHE A 400      58.758  65.665  42.831  1.00 41.91           C  
+ATOM   3098  CE1 PHE A 400      59.042  62.922  43.155  1.00 48.00           C  
+ATOM   3099  CE2 PHE A 400      58.896  65.118  44.121  1.00 43.80           C  
+ATOM   3100  CZ  PHE A 400      59.038  63.746  44.279  1.00 42.05           C  
+ATOM   3101  N   HIS A 401      57.587  66.515  37.554  1.00 36.09           N  
+ATOM   3102  CA  HIS A 401      57.139  67.662  36.754  1.00 38.52           C  
+ATOM   3103  C   HIS A 401      55.695  67.511  36.251  1.00 38.30           C  
+ATOM   3104  O   HIS A 401      54.862  68.399  36.467  1.00 39.97           O  
+ATOM   3105  CB  HIS A 401      58.111  67.877  35.567  1.00 36.53           C  
+ATOM   3106  CG  HIS A 401      58.824  69.196  35.597  1.00 38.15           C  
+ATOM   3107  ND1 HIS A 401      58.164  70.401  35.472  1.00 37.42           N  
+ATOM   3108  CD2 HIS A 401      60.134  69.502  35.769  1.00 35.60           C  
+ATOM   3109  CE1 HIS A 401      59.033  71.392  35.567  1.00 40.17           C  
+ATOM   3110  NE2 HIS A 401      60.235  70.873  35.748  1.00 42.09           N  
+ATOM   3111  N   GLU A 402      55.383  66.391  35.602  1.00 34.92           N  
+ATOM   3112  CA  GLU A 402      54.016  66.200  35.124  1.00 41.19           C  
+ATOM   3113  C   GLU A 402      53.032  66.032  36.280  1.00 42.38           C  
+ATOM   3114  O   GLU A 402      51.867  66.410  36.167  1.00 45.36           O  
+ATOM   3115  CB  GLU A 402      53.942  65.006  34.156  1.00 42.14           C  
+ATOM   3116  CG  GLU A 402      54.634  65.306  32.828  1.00 41.72           C  
+ATOM   3117  CD  GLU A 402      53.997  66.484  32.102  1.00 45.80           C  
+ATOM   3118  OE1 GLU A 402      54.697  67.175  31.330  1.00 45.82           O  
+ATOM   3119  OE2 GLU A 402      52.783  66.719  32.287  1.00 47.88           O  
+ATOM   3120  N   ALA A 403      53.474  65.471  37.401  1.00 41.82           N  
+ATOM   3121  CA  ALA A 403      52.556  65.342  38.535  1.00 41.70           C  
+ATOM   3122  C   ALA A 403      52.198  66.758  38.972  1.00 40.48           C  
+ATOM   3123  O   ALA A 403      51.044  67.054  39.294  1.00 41.53           O  
+ATOM   3124  CB  ALA A 403      53.225  64.584  39.705  1.00 43.61           C  
+ATOM   3125  N   VAL A 404      53.202  67.637  38.988  1.00 40.08           N  
+ATOM   3126  CA  VAL A 404      52.973  69.027  39.376  1.00 42.00           C  
+ATOM   3127  C   VAL A 404      52.031  69.729  38.374  1.00 43.60           C  
+ATOM   3128  O   VAL A 404      51.116  70.475  38.754  1.00 40.36           O  
+ATOM   3129  CB  VAL A 404      54.317  69.790  39.472  1.00 43.92           C  
+ATOM   3130  CG1 VAL A 404      54.060  71.306  39.575  1.00 41.40           C  
+ATOM   3131  CG2 VAL A 404      55.111  69.279  40.706  1.00 43.53           C  
+ATOM   3132  N   GLY A 405      52.254  69.477  37.090  1.00 43.96           N  
+ATOM   3133  CA  GLY A 405      51.395  70.069  36.083  1.00 46.63           C  
+ATOM   3134  C   GLY A 405      49.954  69.589  36.161  1.00 45.41           C  
+ATOM   3135  O   GLY A 405      49.039  70.413  36.096  1.00 45.16           O  
+ATOM   3136  N   GLU A 406      49.751  68.273  36.301  1.00 43.68           N  
+ATOM   3137  CA  GLU A 406      48.406  67.675  36.384  1.00 45.08           C  
+ATOM   3138  C   GLU A 406      47.616  68.175  37.587  1.00 47.62           C  
+ATOM   3139  O   GLU A 406      46.386  68.303  37.559  1.00 47.05           O  
+ATOM   3140  CB  GLU A 406      48.497  66.150  36.480  1.00 45.55           C  
+ATOM   3141  CG  GLU A 406      49.011  65.450  35.238  1.00 50.52           C  
+ATOM   3142  CD  GLU A 406      48.019  65.470  34.079  1.00 55.92           C  
+ATOM   3143  OE1 GLU A 406      46.809  65.688  34.313  1.00 53.37           O  
+ATOM   3144  OE2 GLU A 406      48.458  65.247  32.929  1.00 60.24           O  
+ATOM   3145  N   ILE A 407      48.336  68.427  38.664  1.00 49.01           N  
+ATOM   3146  CA  ILE A 407      47.737  68.918  39.889  1.00 51.71           C  
+ATOM   3147  C   ILE A 407      47.029  70.255  39.666  1.00 51.14           C  
+ATOM   3148  O   ILE A 407      45.992  70.525  40.258  1.00 52.59           O  
+ATOM   3149  CB  ILE A 407      48.847  69.081  40.958  1.00 56.26           C  
+ATOM   3150  CG1 ILE A 407      49.198  67.704  41.509  1.00 57.12           C  
+ATOM   3151  CG2 ILE A 407      48.447  70.060  42.019  1.00 57.42           C  
+ATOM   3152  CD1 ILE A 407      48.010  66.846  41.690  1.00 56.81           C  
+ATOM   3153  N   MET A 408      47.590  71.100  38.812  1.00 48.90           N  
+ATOM   3154  CA  MET A 408      46.995  72.399  38.578  1.00 47.72           C  
+ATOM   3155  C   MET A 408      45.647  72.335  37.848  1.00 49.77           C  
+ATOM   3156  O   MET A 408      44.725  73.069  38.204  1.00 51.58           O  
+ATOM   3157  CB  MET A 408      47.989  73.294  37.827  1.00 48.63           C  
+ATOM   3158  CG  MET A 408      49.327  73.453  38.528  1.00 46.03           C  
+ATOM   3159  SD  MET A 408      49.147  73.611  40.318  1.00 57.77           S  
+ATOM   3160  CE  MET A 408      50.766  73.120  40.879  1.00 51.69           C  
+ATOM   3161  N   SER A 409      45.520  71.458  36.854  1.00 48.48           N  
+ATOM   3162  CA  SER A 409      44.265  71.337  36.119  1.00 54.12           C  
+ATOM   3163  C   SER A 409      43.181  70.803  37.028  1.00 55.88           C  
+ATOM   3164  O   SER A 409      42.012  71.200  36.926  1.00 58.25           O  
+ATOM   3165  CB  SER A 409      44.401  70.380  34.933  1.00 56.38           C  
+ATOM   3166  OG  SER A 409      45.485  70.741  34.112  1.00 58.27           O  
+ATOM   3167  N   LEU A 410      43.567  69.888  37.912  1.00 55.09           N  
+ATOM   3168  CA  LEU A 410      42.620  69.296  38.842  1.00 53.52           C  
+ATOM   3169  C   LEU A 410      41.870  70.405  39.583  1.00 54.67           C  
+ATOM   3170  O   LEU A 410      40.648  70.467  39.527  1.00 59.15           O  
+ATOM   3171  CB  LEU A 410      43.358  68.384  39.825  1.00 55.07           C  
+ATOM   3172  CG  LEU A 410      42.855  66.941  39.947  1.00 58.22           C  
+ATOM   3173  CD1 LEU A 410      42.712  66.302  38.565  1.00 49.75           C  
+ATOM   3174  CD2 LEU A 410      43.813  66.153  40.825  1.00 56.96           C  
+ATOM   3175  N   SER A 411      42.590  71.307  40.244  1.00 52.43           N  
+ATOM   3176  CA  SER A 411      41.935  72.400  40.973  1.00 52.06           C  
+ATOM   3177  C   SER A 411      41.155  73.379  40.083  1.00 50.75           C  
+ATOM   3178  O   SER A 411      40.098  73.881  40.460  1.00 50.54           O  
+ATOM   3179  CB  SER A 411      42.969  73.212  41.768  1.00 48.92           C  
+ATOM   3180  OG  SER A 411      43.258  72.627  43.019  1.00 55.17           O  
+ATOM   3181  N   ALA A 412      41.695  73.653  38.906  1.00 50.99           N  
+ATOM   3182  CA  ALA A 412      41.100  74.613  37.989  1.00 50.95           C  
+ATOM   3183  C   ALA A 412      39.801  74.161  37.318  1.00 51.23           C  
+ATOM   3184  O   ALA A 412      38.972  74.993  36.961  1.00 47.09           O  
+ATOM   3185  CB  ALA A 412      42.130  75.008  36.947  1.00 53.37           C  
+ATOM   3186  N   ALA A 413      39.614  72.855  37.161  1.00 52.26           N  
+ATOM   3187  CA  ALA A 413      38.390  72.338  36.543  1.00 54.48           C  
+ATOM   3188  C   ALA A 413      37.222  72.143  37.521  1.00 56.05           C  
+ATOM   3189  O   ALA A 413      36.070  72.010  37.103  1.00 55.80           O  
+ATOM   3190  CB  ALA A 413      38.677  71.025  35.830  1.00 49.44           C  
+ATOM   3191  N   THR A 414      37.499  72.121  38.821  1.00 56.18           N  
+ATOM   3192  CA  THR A 414      36.418  71.918  39.783  1.00 55.42           C  
+ATOM   3193  C   THR A 414      35.299  72.938  39.604  1.00 59.62           C  
+ATOM   3194  O   THR A 414      35.547  74.111  39.314  1.00 60.51           O  
+ATOM   3195  CB  THR A 414      36.918  72.035  41.237  1.00 51.85           C  
+ATOM   3196  OG1 THR A 414      37.377  73.371  41.475  1.00 54.09           O  
+ATOM   3197  CG2 THR A 414      38.043  71.054  41.500  1.00 46.72           C  
+ATOM   3198  N   PRO A 415      34.046  72.508  39.791  1.00 62.18           N  
+ATOM   3199  CA  PRO A 415      32.894  73.401  39.655  1.00 65.74           C  
+ATOM   3200  C   PRO A 415      33.069  74.636  40.543  1.00 68.50           C  
+ATOM   3201  O   PRO A 415      32.756  75.760  40.151  1.00 71.11           O  
+ATOM   3202  CB  PRO A 415      31.736  72.528  40.122  1.00 65.81           C  
+ATOM   3203  CG  PRO A 415      32.182  71.153  39.725  1.00 62.42           C  
+ATOM   3204  CD  PRO A 415      33.612  71.152  40.158  1.00 63.52           C  
+ATOM   3205  N   LYS A 416      33.592  74.410  41.741  1.00 70.11           N  
+ATOM   3206  CA  LYS A 416      33.806  75.472  42.709  1.00 70.41           C  
+ATOM   3207  C   LYS A 416      34.802  76.513  42.220  1.00 71.27           C  
+ATOM   3208  O   LYS A 416      34.703  77.692  42.567  1.00 70.56           O  
+ATOM   3209  CB  LYS A 416      34.286  74.858  44.021  1.00 74.79           C  
+ATOM   3210  CG  LYS A 416      34.458  75.823  45.170  1.00 78.16           C  
+ATOM   3211  CD  LYS A 416      34.724  75.047  46.450  1.00 81.31           C  
+ATOM   3212  CE  LYS A 416      35.858  74.046  46.252  1.00 82.23           C  
+ATOM   3213  NZ  LYS A 416      36.077  73.234  47.484  1.00 86.56           N  
+ATOM   3214  N   HIS A 417      35.773  76.088  41.420  1.00 70.27           N  
+ATOM   3215  CA  HIS A 417      36.744  77.043  40.924  1.00 67.36           C  
+ATOM   3216  C   HIS A 417      36.127  77.854  39.793  1.00 68.25           C  
+ATOM   3217  O   HIS A 417      36.253  79.081  39.765  1.00 65.91           O  
+ATOM   3218  CB  HIS A 417      37.997  76.349  40.417  1.00 63.13           C  
+ATOM   3219  CG  HIS A 417      39.093  77.301  40.068  1.00 60.36           C  
+ATOM   3220  ND1 HIS A 417      39.808  77.991  41.025  1.00 62.06           N  
+ATOM   3221  CD2 HIS A 417      39.544  77.742  38.870  1.00 57.69           C  
+ATOM   3222  CE1 HIS A 417      40.650  78.818  40.430  1.00 59.71           C  
+ATOM   3223  NE2 HIS A 417      40.508  78.688  39.122  1.00 58.04           N  
+ATOM   3224  N   LEU A 418      35.465  77.165  38.863  1.00 69.29           N  
+ATOM   3225  CA  LEU A 418      34.821  77.832  37.735  1.00 71.05           C  
+ATOM   3226  C   LEU A 418      33.778  78.847  38.193  1.00 73.17           C  
+ATOM   3227  O   LEU A 418      33.498  79.819  37.491  1.00 74.15           O  
+ATOM   3228  CB  LEU A 418      34.162  76.818  36.794  1.00 70.93           C  
+ATOM   3229  CG  LEU A 418      35.070  75.996  35.876  1.00 69.31           C  
+ATOM   3230  CD1 LEU A 418      36.101  76.888  35.218  1.00 70.23           C  
+ATOM   3231  CD2 LEU A 418      35.772  74.952  36.677  1.00 72.71           C  
+ATOM   3232  N   LYS A 419      33.194  78.632  39.365  1.00 73.84           N  
+ATOM   3233  CA  LYS A 419      32.211  79.584  39.857  1.00 76.06           C  
+ATOM   3234  C   LYS A 419      32.904  80.853  40.340  1.00 77.50           C  
+ATOM   3235  O   LYS A 419      32.656  81.940  39.823  1.00 78.90           O  
+ATOM   3236  CB  LYS A 419      31.391  78.983  40.998  1.00 76.21           C  
+ATOM   3237  CG  LYS A 419      30.450  77.863  40.577  1.00 78.31           C  
+ATOM   3238  CD  LYS A 419      29.538  77.479  41.735  1.00 80.40           C  
+ATOM   3239  CE  LYS A 419      30.343  77.237  43.011  1.00 81.17           C  
+ATOM   3240  NZ  LYS A 419      29.479  76.943  44.187  1.00 82.31           N  
+ATOM   3241  N   SER A 420      33.778  80.709  41.331  1.00 78.79           N  
+ATOM   3242  CA  SER A 420      34.509  81.843  41.892  1.00 79.74           C  
+ATOM   3243  C   SER A 420      35.191  82.706  40.834  1.00 79.53           C  
+ATOM   3244  O   SER A 420      35.537  83.859  41.079  1.00 79.88           O  
+ATOM   3245  CB  SER A 420      35.563  81.338  42.873  1.00 81.01           C  
+ATOM   3246  OG  SER A 420      36.374  82.404  43.336  1.00 83.57           O  
+ATOM   3247  N   ILE A 421      35.385  82.127  39.659  1.00 79.86           N  
+ATOM   3248  CA  ILE A 421      36.039  82.801  38.551  1.00 78.87           C  
+ATOM   3249  C   ILE A 421      35.003  83.484  37.650  1.00 79.49           C  
+ATOM   3250  O   ILE A 421      35.343  84.330  36.818  1.00 78.57           O  
+ATOM   3251  CB  ILE A 421      36.879  81.770  37.748  1.00 78.86           C  
+ATOM   3252  CG1 ILE A 421      38.365  82.008  37.999  1.00 79.09           C  
+ATOM   3253  CG2 ILE A 421      36.541  81.829  36.276  1.00 80.53           C  
+ATOM   3254  CD1 ILE A 421      38.751  81.963  39.462  1.00 78.73           C  
+ATOM   3255  N   GLY A 422      33.736  83.118  37.826  1.00 77.79           N  
+ATOM   3256  CA  GLY A 422      32.679  83.712  37.029  1.00 76.56           C  
+ATOM   3257  C   GLY A 422      32.473  83.066  35.671  1.00 76.64           C  
+ATOM   3258  O   GLY A 422      31.813  83.632  34.806  1.00 75.94           O  
+ATOM   3259  N   LEU A 423      33.041  81.885  35.468  1.00 76.96           N  
+ATOM   3260  CA  LEU A 423      32.877  81.197  34.200  1.00 76.80           C  
+ATOM   3261  C   LEU A 423      31.746  80.186  34.275  1.00 78.30           C  
+ATOM   3262  O   LEU A 423      31.278  79.687  33.256  1.00 78.73           O  
+ATOM   3263  CB  LEU A 423      34.175  80.518  33.794  1.00 74.87           C  
+ATOM   3264  CG  LEU A 423      35.162  81.532  33.226  1.00 75.78           C  
+ATOM   3265  CD1 LEU A 423      36.381  80.830  32.653  1.00 73.77           C  
+ATOM   3266  CD2 LEU A 423      34.450  82.334  32.145  1.00 76.11           C  
+ATOM   3267  N   LEU A 424      31.316  79.889  35.494  1.00 79.76           N  
+ATOM   3268  CA  LEU A 424      30.214  78.971  35.723  1.00 82.17           C  
+ATOM   3269  C   LEU A 424      29.311  79.666  36.730  1.00 84.34           C  
+ATOM   3270  O   LEU A 424      29.769  80.119  37.784  1.00 82.48           O  
+ATOM   3271  CB  LEU A 424      30.710  77.640  36.292  1.00 81.16           C  
+ATOM   3272  CG  LEU A 424      29.637  76.573  36.540  1.00 80.31           C  
+ATOM   3273  CD1 LEU A 424      29.013  76.141  35.225  1.00 78.02           C  
+ATOM   3274  CD2 LEU A 424      30.267  75.380  37.232  1.00 82.18           C  
+ATOM   3275  N   SER A 425      28.032  79.773  36.391  1.00 87.54           N  
+ATOM   3276  CA  SER A 425      27.071  80.430  37.266  1.00 90.59           C  
+ATOM   3277  C   SER A 425      26.749  79.548  38.452  1.00 92.89           C  
+ATOM   3278  O   SER A 425      26.910  78.327  38.399  1.00 93.71           O  
+ATOM   3279  CB  SER A 425      25.779  80.718  36.511  1.00 90.38           C  
+ATOM   3280  OG  SER A 425      25.179  79.507  36.087  1.00 90.64           O  
+ATOM   3281  N   PRO A 426      26.299  80.162  39.551  1.00 95.14           N  
+ATOM   3282  CA  PRO A 426      25.945  79.412  40.759  1.00 97.25           C  
+ATOM   3283  C   PRO A 426      24.604  78.704  40.554  1.00 98.58           C  
+ATOM   3284  O   PRO A 426      23.986  78.223  41.504  1.00 98.70           O  
+ATOM   3285  CB  PRO A 426      25.883  80.499  41.833  1.00 97.28           C  
+ATOM   3286  CG  PRO A 426      25.444  81.715  41.056  1.00 96.55           C  
+ATOM   3287  CD  PRO A 426      26.273  81.615  39.797  1.00 95.39           C  
+ATOM   3288  N   ASP A 427      24.173  78.645  39.295  1.00101.18           N  
+ATOM   3289  CA  ASP A 427      22.905  78.021  38.917  1.00102.64           C  
+ATOM   3290  C   ASP A 427      23.103  76.581  38.428  1.00102.22           C  
+ATOM   3291  O   ASP A 427      22.140  75.819  38.299  1.00101.34           O  
+ATOM   3292  CB  ASP A 427      22.226  78.855  37.821  1.00105.33           C  
+ATOM   3293  CG  ASP A 427      20.778  78.445  37.575  1.00108.58           C  
+ATOM   3294  OD1 ASP A 427      20.135  79.026  36.670  1.00108.90           O  
+ATOM   3295  OD2 ASP A 427      20.281  77.546  38.286  1.00110.63           O  
+ATOM   3296  N   PHE A 428      24.348  76.209  38.151  1.00100.75           N  
+ATOM   3297  CA  PHE A 428      24.629  74.857  37.690  1.00 99.66           C  
+ATOM   3298  C   PHE A 428      24.719  73.937  38.901  1.00 99.30           C  
+ATOM   3299  O   PHE A 428      25.752  73.877  39.567  1.00101.21           O  
+ATOM   3300  CB  PHE A 428      25.939  74.820  36.898  1.00 98.13           C  
+ATOM   3301  CG  PHE A 428      26.240  73.478  36.293  1.00 96.42           C  
+ATOM   3302  CD1 PHE A 428      26.724  72.440  37.076  1.00 95.23           C  
+ATOM   3303  CD2 PHE A 428      26.005  73.244  34.944  1.00 95.21           C  
+ATOM   3304  CE1 PHE A 428      26.966  71.193  36.524  1.00 95.76           C  
+ATOM   3305  CE2 PHE A 428      26.244  71.999  34.385  1.00 94.19           C  
+ATOM   3306  CZ  PHE A 428      26.725  70.971  35.175  1.00 94.78           C  
+ATOM   3307  N   GLN A 429      23.636  73.221  39.186  1.00 97.94           N  
+ATOM   3308  CA  GLN A 429      23.614  72.327  40.333  1.00 95.99           C  
+ATOM   3309  C   GLN A 429      24.430  71.067  40.087  1.00 93.30           C  
+ATOM   3310  O   GLN A 429      24.352  70.451  39.025  1.00 91.86           O  
+ATOM   3311  CB  GLN A 429      22.174  71.940  40.706  1.00 99.09           C  
+ATOM   3312  CG  GLN A 429      21.545  70.833  39.857  1.00101.67           C  
+ATOM   3313  CD  GLN A 429      20.189  70.376  40.396  1.00104.48           C  
+ATOM   3314  OE1 GLN A 429      19.551  69.478  39.836  1.00104.89           O  
+ATOM   3315  NE2 GLN A 429      19.747  70.994  41.489  1.00104.79           N  
+ATOM   3316  N   GLU A 430      25.220  70.697  41.084  1.00 89.92           N  
+ATOM   3317  CA  GLU A 430      26.050  69.513  41.003  1.00 86.70           C  
+ATOM   3318  C   GLU A 430      25.250  68.372  41.626  1.00 84.88           C  
+ATOM   3319  O   GLU A 430      24.784  68.488  42.755  1.00 83.89           O  
+ATOM   3320  CB  GLU A 430      27.345  69.757  41.778  1.00 87.22           C  
+ATOM   3321  CG  GLU A 430      27.996  71.099  41.455  1.00 86.41           C  
+ATOM   3322  CD  GLU A 430      28.982  71.560  42.524  1.00 87.68           C  
+ATOM   3323  OE1 GLU A 430      29.476  72.703  42.423  1.00 86.31           O  
+ATOM   3324  OE2 GLU A 430      29.266  70.786  43.466  1.00 89.86           O  
+ATOM   3325  N   ASP A 431      25.078  67.280  40.885  1.00 83.48           N  
+ATOM   3326  CA  ASP A 431      24.323  66.124  41.375  1.00 82.59           C  
+ATOM   3327  C   ASP A 431      25.272  65.007  41.784  1.00 79.86           C  
+ATOM   3328  O   ASP A 431      26.476  65.091  41.567  1.00 80.92           O  
+ATOM   3329  CB  ASP A 431      23.400  65.573  40.278  1.00 84.27           C  
+ATOM   3330  CG  ASP A 431      22.565  66.647  39.618  1.00 88.05           C  
+ATOM   3331  OD1 ASP A 431      21.779  67.313  40.323  1.00 91.64           O  
+ATOM   3332  OD2 ASP A 431      22.692  66.827  38.388  1.00 90.86           O  
+ATOM   3333  N   ASN A 432      24.730  63.954  42.379  1.00 75.71           N  
+ATOM   3334  CA  ASN A 432      25.567  62.831  42.735  1.00 73.21           C  
+ATOM   3335  C   ASN A 432      25.845  62.100  41.411  1.00 72.27           C  
+ATOM   3336  O   ASN A 432      26.757  61.274  41.312  1.00 70.67           O  
+ATOM   3337  CB  ASN A 432      24.865  61.925  43.774  1.00 72.28           C  
+ATOM   3338  CG  ASN A 432      23.525  61.375  43.297  1.00 71.70           C  
+ATOM   3339  OD1 ASN A 432      22.904  61.903  42.375  1.00 73.93           O  
+ATOM   3340  ND2 ASN A 432      23.065  60.315  43.951  1.00 70.78           N  
+ATOM   3341  N   GLU A 433      25.073  62.455  40.383  1.00 67.73           N  
+ATOM   3342  CA  GLU A 433      25.213  61.858  39.061  1.00 66.25           C  
+ATOM   3343  C   GLU A 433      26.237  62.569  38.177  1.00 65.08           C  
+ATOM   3344  O   GLU A 433      26.956  61.926  37.411  1.00 63.19           O  
+ATOM   3345  CB  GLU A 433      23.850  61.814  38.366  1.00 66.12           C  
+ATOM   3346  CG  GLU A 433      23.049  60.575  38.707  1.00 67.52           C  
+ATOM   3347  CD  GLU A 433      21.591  60.688  38.316  1.00 70.37           C  
+ATOM   3348  OE1 GLU A 433      21.304  61.240  37.234  1.00 72.43           O  
+ATOM   3349  OE2 GLU A 433      20.731  60.213  39.094  1.00 71.93           O  
+ATOM   3350  N   THR A 434      26.291  63.894  38.267  1.00 64.08           N  
+ATOM   3351  CA  THR A 434      27.259  64.658  37.497  1.00 64.36           C  
+ATOM   3352  C   THR A 434      28.631  64.350  38.081  1.00 62.95           C  
+ATOM   3353  O   THR A 434      29.645  64.518  37.422  1.00 63.54           O  
+ATOM   3354  CB  THR A 434      26.995  66.171  37.598  1.00 68.59           C  
+ATOM   3355  OG1 THR A 434      26.830  66.542  38.980  1.00 67.83           O  
+ATOM   3356  CG2 THR A 434      25.739  66.546  36.796  1.00 66.90           C  
+ATOM   3357  N   GLU A 435      28.635  63.882  39.325  1.00 62.94           N  
+ATOM   3358  CA  GLU A 435      29.853  63.508  40.036  1.00 63.28           C  
+ATOM   3359  C   GLU A 435      30.376  62.162  39.505  1.00 61.49           C  
+ATOM   3360  O   GLU A 435      31.527  62.052  39.088  1.00 61.27           O  
+ATOM   3361  CB  GLU A 435      29.561  63.376  41.536  1.00 65.64           C  
+ATOM   3362  CG  GLU A 435      30.483  64.156  42.463  1.00 73.13           C  
+ATOM   3363  CD  GLU A 435      30.154  65.649  42.542  1.00 76.16           C  
+ATOM   3364  OE1 GLU A 435      30.387  66.384  41.556  1.00 80.64           O  
+ATOM   3365  OE2 GLU A 435      29.662  66.089  43.602  1.00 77.75           O  
+ATOM   3366  N   ILE A 436      29.530  61.137  39.528  1.00 58.89           N  
+ATOM   3367  CA  ILE A 436      29.940  59.831  39.046  1.00 57.00           C  
+ATOM   3368  C   ILE A 436      30.327  59.929  37.576  1.00 56.97           C  
+ATOM   3369  O   ILE A 436      31.261  59.257  37.137  1.00 56.86           O  
+ATOM   3370  CB  ILE A 436      28.822  58.791  39.246  1.00 59.26           C  
+ATOM   3371  CG1 ILE A 436      29.153  57.915  40.454  1.00 62.78           C  
+ATOM   3372  CG2 ILE A 436      28.706  57.897  38.037  1.00 59.45           C  
+ATOM   3373  CD1 ILE A 436      29.489  58.679  41.688  1.00 57.32           C  
+ATOM   3374  N   ASN A 437      29.623  60.782  36.826  1.00 52.24           N  
+ATOM   3375  CA  ASN A 437      29.910  60.994  35.408  1.00 50.02           C  
+ATOM   3376  C   ASN A 437      31.329  61.544  35.225  1.00 51.26           C  
+ATOM   3377  O   ASN A 437      32.027  61.227  34.246  1.00 50.71           O  
+ATOM   3378  CB  ASN A 437      28.940  62.020  34.819  1.00 50.45           C  
+ATOM   3379  CG  ASN A 437      27.773  61.387  34.089  1.00 54.43           C  
+ATOM   3380  OD1 ASN A 437      27.559  60.164  34.138  1.00 51.13           O  
+ATOM   3381  ND2 ASN A 437      26.995  62.226  33.411  1.00 48.18           N  
+ATOM   3382  N   PHE A 438      31.737  62.400  36.158  1.00 47.27           N  
+ATOM   3383  CA  PHE A 438      33.048  63.020  36.097  1.00 48.20           C  
+ATOM   3384  C   PHE A 438      34.153  62.046  36.521  1.00 46.48           C  
+ATOM   3385  O   PHE A 438      35.202  61.973  35.889  1.00 45.92           O  
+ATOM   3386  CB  PHE A 438      33.068  64.272  36.989  1.00 47.57           C  
+ATOM   3387  CG  PHE A 438      34.430  64.893  37.127  1.00 49.17           C  
+ATOM   3388  CD1 PHE A 438      35.043  65.497  36.042  1.00 49.40           C  
+ATOM   3389  CD2 PHE A 438      35.118  64.822  38.326  1.00 48.66           C  
+ATOM   3390  CE1 PHE A 438      36.328  66.017  36.143  1.00 48.53           C  
+ATOM   3391  CE2 PHE A 438      36.392  65.337  38.436  1.00 51.53           C  
+ATOM   3392  CZ  PHE A 438      37.001  65.934  37.344  1.00 50.78           C  
+ATOM   3393  N   LEU A 439      33.901  61.312  37.600  1.00 46.04           N  
+ATOM   3394  CA  LEU A 439      34.845  60.343  38.139  1.00 45.29           C  
+ATOM   3395  C   LEU A 439      35.067  59.163  37.177  1.00 44.71           C  
+ATOM   3396  O   LEU A 439      36.174  58.634  37.075  1.00 44.75           O  
+ATOM   3397  CB  LEU A 439      34.327  59.850  39.498  1.00 47.48           C  
+ATOM   3398  CG  LEU A 439      35.049  60.254  40.796  1.00 50.56           C  
+ATOM   3399  CD1 LEU A 439      35.752  61.572  40.612  1.00 46.41           C  
+ATOM   3400  CD2 LEU A 439      34.062  60.305  41.961  1.00 43.85           C  
+ATOM   3401  N   LEU A 440      34.012  58.756  36.473  1.00 44.99           N  
+ATOM   3402  CA  LEU A 440      34.094  57.654  35.521  1.00 42.88           C  
+ATOM   3403  C   LEU A 440      34.933  58.172  34.367  1.00 41.88           C  
+ATOM   3404  O   LEU A 440      35.846  57.497  33.897  1.00 42.94           O  
+ATOM   3405  CB  LEU A 440      32.676  57.251  35.042  1.00 43.56           C  
+ATOM   3406  CG  LEU A 440      32.435  56.165  33.972  1.00 40.54           C  
+ATOM   3407  CD1 LEU A 440      32.845  56.688  32.586  1.00 39.65           C  
+ATOM   3408  CD2 LEU A 440      33.219  54.919  34.310  1.00 39.08           C  
+ATOM   3409  N   LYS A 441      34.648  59.391  33.920  1.00 41.64           N  
+ATOM   3410  CA  LYS A 441      35.434  59.948  32.822  1.00 43.83           C  
+ATOM   3411  C   LYS A 441      36.923  59.995  33.217  1.00 43.12           C  
+ATOM   3412  O   LYS A 441      37.798  59.660  32.430  1.00 40.67           O  
+ATOM   3413  CB  LYS A 441      34.954  61.360  32.469  1.00 44.90           C  
+ATOM   3414  CG  LYS A 441      35.560  61.894  31.166  1.00 49.04           C  
+ATOM   3415  CD  LYS A 441      35.280  63.378  30.981  1.00 55.46           C  
+ATOM   3416  CE  LYS A 441      35.557  63.813  29.548  1.00 62.64           C  
+ATOM   3417  NZ  LYS A 441      36.909  63.393  29.048  1.00 66.03           N  
+ATOM   3418  N   GLN A 442      37.193  60.430  34.442  1.00 43.24           N  
+ATOM   3419  CA  GLN A 442      38.560  60.514  34.962  1.00 41.68           C  
+ATOM   3420  C   GLN A 442      39.220  59.145  35.030  1.00 39.93           C  
+ATOM   3421  O   GLN A 442      40.378  58.990  34.660  1.00 38.10           O  
+ATOM   3422  CB  GLN A 442      38.530  61.102  36.368  1.00 43.89           C  
+ATOM   3423  CG  GLN A 442      38.221  62.570  36.395  1.00 43.00           C  
+ATOM   3424  CD  GLN A 442      39.417  63.365  35.987  1.00 44.75           C  
+ATOM   3425  OE1 GLN A 442      40.169  63.866  36.835  1.00 48.69           O  
+ATOM   3426  NE2 GLN A 442      39.630  63.477  34.689  1.00 46.08           N  
+ATOM   3427  N   ALA A 443      38.464  58.155  35.501  1.00 39.01           N  
+ATOM   3428  CA  ALA A 443      38.979  56.800  35.664  1.00 37.84           C  
+ATOM   3429  C   ALA A 443      39.329  56.100  34.339  1.00 38.77           C  
+ATOM   3430  O   ALA A 443      40.295  55.318  34.277  1.00 32.27           O  
+ATOM   3431  CB  ALA A 443      37.978  55.981  36.468  1.00 34.44           C  
+ATOM   3432  N   LEU A 444      38.564  56.400  33.284  1.00 39.68           N  
+ATOM   3433  CA  LEU A 444      38.805  55.807  31.959  1.00 43.76           C  
+ATOM   3434  C   LEU A 444      40.207  56.159  31.472  1.00 45.51           C  
+ATOM   3435  O   LEU A 444      40.870  55.370  30.783  1.00 44.47           O  
+ATOM   3436  CB  LEU A 444      37.791  56.333  30.945  1.00 41.04           C  
+ATOM   3437  CG  LEU A 444      36.607  55.487  30.481  1.00 45.01           C  
+ATOM   3438  CD1 LEU A 444      36.405  54.272  31.325  1.00 41.06           C  
+ATOM   3439  CD2 LEU A 444      35.387  56.380  30.445  1.00 40.57           C  
+ATOM   3440  N   THR A 445      40.645  57.371  31.797  1.00 45.86           N  
+ATOM   3441  CA  THR A 445      41.983  57.823  31.415  1.00 46.40           C  
+ATOM   3442  C   THR A 445      43.017  57.422  32.482  1.00 45.96           C  
+ATOM   3443  O   THR A 445      43.995  56.713  32.211  1.00 45.38           O  
+ATOM   3444  CB  THR A 445      42.024  59.357  31.277  1.00 47.62           C  
+ATOM   3445  OG1 THR A 445      41.034  59.763  30.330  1.00 54.34           O  
+ATOM   3446  CG2 THR A 445      43.390  59.834  30.810  1.00 40.24           C  
+ATOM   3447  N   ILE A 446      42.766  57.872  33.704  1.00 47.22           N  
+ATOM   3448  CA  ILE A 446      43.669  57.635  34.828  1.00 47.12           C  
+ATOM   3449  C   ILE A 446      43.811  56.205  35.338  1.00 43.90           C  
+ATOM   3450  O   ILE A 446      44.925  55.706  35.419  1.00 46.31           O  
+ATOM   3451  CB  ILE A 446      43.302  58.563  35.993  1.00 44.54           C  
+ATOM   3452  CG1 ILE A 446      43.595  60.011  35.586  1.00 42.94           C  
+ATOM   3453  CG2 ILE A 446      44.089  58.176  37.227  1.00 46.45           C  
+ATOM   3454  CD1 ILE A 446      42.670  61.021  36.222  1.00 38.38           C  
+ATOM   3455  N   VAL A 447      42.711  55.544  35.687  1.00 43.60           N  
+ATOM   3456  CA  VAL A 447      42.805  54.168  36.168  1.00 44.64           C  
+ATOM   3457  C   VAL A 447      43.026  53.164  35.023  1.00 46.71           C  
+ATOM   3458  O   VAL A 447      43.838  52.250  35.144  1.00 48.15           O  
+ATOM   3459  CB  VAL A 447      41.543  53.762  36.971  1.00 44.91           C  
+ATOM   3460  CG1 VAL A 447      41.638  52.298  37.398  1.00 42.67           C  
+ATOM   3461  CG2 VAL A 447      41.408  54.648  38.210  1.00 43.89           C  
+ATOM   3462  N   GLY A 448      42.319  53.334  33.907  1.00 46.29           N  
+ATOM   3463  CA  GLY A 448      42.475  52.405  32.799  1.00 39.54           C  
+ATOM   3464  C   GLY A 448      43.901  52.237  32.296  1.00 41.41           C  
+ATOM   3465  O   GLY A 448      44.294  51.160  31.857  1.00 41.88           O  
+ATOM   3466  N   THR A 449      44.696  53.295  32.383  1.00 39.51           N  
+ATOM   3467  CA  THR A 449      46.072  53.252  31.914  1.00 32.36           C  
+ATOM   3468  C   THR A 449      47.082  52.637  32.888  1.00 34.40           C  
+ATOM   3469  O   THR A 449      48.185  52.259  32.483  1.00 36.39           O  
+ATOM   3470  CB  THR A 449      46.568  54.672  31.582  1.00 36.57           C  
+ATOM   3471  OG1 THR A 449      47.686  54.587  30.699  1.00 37.71           O  
+ATOM   3472  CG2 THR A 449      47.013  55.401  32.860  1.00 31.19           C  
+ATOM   3473  N   LEU A 450      46.738  52.539  34.164  1.00 34.44           N  
+ATOM   3474  CA  LEU A 450      47.696  51.983  35.124  1.00 37.98           C  
+ATOM   3475  C   LEU A 450      48.081  50.529  34.838  1.00 36.55           C  
+ATOM   3476  O   LEU A 450      49.252  50.204  34.754  1.00 38.42           O  
+ATOM   3477  CB  LEU A 450      47.168  52.137  36.550  1.00 33.23           C  
+ATOM   3478  CG  LEU A 450      47.238  53.603  36.972  1.00 38.12           C  
+ATOM   3479  CD1 LEU A 450      46.638  53.784  38.363  1.00 40.35           C  
+ATOM   3480  CD2 LEU A 450      48.701  54.049  36.924  1.00 35.50           C  
+ATOM   3481  N   PRO A 451      47.100  49.648  34.648  1.00 38.72           N  
+ATOM   3482  CA  PRO A 451      47.472  48.266  34.377  1.00 36.81           C  
+ATOM   3483  C   PRO A 451      48.198  48.145  33.053  1.00 36.49           C  
+ATOM   3484  O   PRO A 451      49.114  47.333  32.917  1.00 38.86           O  
+ATOM   3485  CB  PRO A 451      46.119  47.545  34.367  1.00 39.41           C  
+ATOM   3486  CG  PRO A 451      45.264  48.396  35.228  1.00 38.90           C  
+ATOM   3487  CD  PRO A 451      45.639  49.770  34.747  1.00 40.67           C  
+ATOM   3488  N   PHE A 452      47.793  48.958  32.073  1.00 37.33           N  
+ATOM   3489  CA  PHE A 452      48.423  48.913  30.753  1.00 36.76           C  
+ATOM   3490  C   PHE A 452      49.875  49.353  30.859  1.00 36.53           C  
+ATOM   3491  O   PHE A 452      50.773  48.749  30.273  1.00 34.09           O  
+ATOM   3492  CB  PHE A 452      47.650  49.809  29.753  1.00 38.42           C  
+ATOM   3493  CG  PHE A 452      48.354  50.000  28.432  1.00 39.13           C  
+ATOM   3494  CD1 PHE A 452      49.479  50.825  28.339  1.00 38.22           C  
+ATOM   3495  CD2 PHE A 452      47.925  49.321  27.295  1.00 42.00           C  
+ATOM   3496  CE1 PHE A 452      50.164  50.966  27.149  1.00 40.64           C  
+ATOM   3497  CE2 PHE A 452      48.605  49.455  26.089  1.00 43.19           C  
+ATOM   3498  CZ  PHE A 452      49.732  50.279  26.015  1.00 42.00           C  
+ATOM   3499  N   THR A 453      50.106  50.404  31.636  1.00 39.07           N  
+ATOM   3500  CA  THR A 453      51.450  50.928  31.812  1.00 37.70           C  
+ATOM   3501  C   THR A 453      52.339  49.966  32.587  1.00 36.92           C  
+ATOM   3502  O   THR A 453      53.463  49.685  32.171  1.00 37.02           O  
+ATOM   3503  CB  THR A 453      51.399  52.286  32.541  1.00 42.80           C  
+ATOM   3504  OG1 THR A 453      50.592  53.178  31.772  1.00 36.54           O  
+ATOM   3505  CG2 THR A 453      52.822  52.862  32.758  1.00 34.78           C  
+ATOM   3506  N   TYR A 454      51.849  49.454  33.708  1.00 37.97           N  
+ATOM   3507  CA  TYR A 454      52.662  48.511  34.485  1.00 40.61           C  
+ATOM   3508  C   TYR A 454      52.990  47.262  33.658  1.00 39.50           C  
+ATOM   3509  O   TYR A 454      54.118  46.814  33.601  1.00 41.13           O  
+ATOM   3510  CB  TYR A 454      51.928  48.095  35.765  1.00 41.64           C  
+ATOM   3511  CG  TYR A 454      52.486  46.831  36.390  1.00 47.27           C  
+ATOM   3512  CD1 TYR A 454      51.672  45.739  36.635  1.00 49.56           C  
+ATOM   3513  CD2 TYR A 454      53.839  46.715  36.685  1.00 52.56           C  
+ATOM   3514  CE1 TYR A 454      52.182  44.558  37.149  1.00 54.31           C  
+ATOM   3515  CE2 TYR A 454      54.366  45.541  37.207  1.00 54.91           C  
+ATOM   3516  CZ  TYR A 454      53.528  44.462  37.433  1.00 54.91           C  
+ATOM   3517  OH  TYR A 454      54.046  43.287  37.923  1.00 56.50           O  
+ATOM   3518  N   MET A 455      51.995  46.699  32.996  1.00 45.02           N  
+ATOM   3519  CA  MET A 455      52.241  45.497  32.220  1.00 45.31           C  
+ATOM   3520  C   MET A 455      53.249  45.713  31.099  1.00 45.47           C  
+ATOM   3521  O   MET A 455      54.142  44.896  30.901  1.00 44.26           O  
+ATOM   3522  CB  MET A 455      50.916  44.953  31.686  1.00 46.68           C  
+ATOM   3523  CG  MET A 455      51.033  43.671  30.900  1.00 51.41           C  
+ATOM   3524  SD  MET A 455      51.106  43.984  29.141  1.00 50.89           S  
+ATOM   3525  CE  MET A 455      52.622  43.218  28.704  1.00 50.50           C  
+ATOM   3526  N   LEU A 456      53.140  46.819  30.370  1.00 46.79           N  
+ATOM   3527  CA  LEU A 456      54.098  47.079  29.292  1.00 43.24           C  
+ATOM   3528  C   LEU A 456      55.534  47.157  29.846  1.00 39.22           C  
+ATOM   3529  O   LEU A 456      56.437  46.491  29.340  1.00 40.49           O  
+ATOM   3530  CB  LEU A 456      53.683  48.362  28.544  1.00 42.09           C  
+ATOM   3531  CG  LEU A 456      54.517  49.343  27.690  1.00 43.03           C  
+ATOM   3532  CD1 LEU A 456      55.945  48.945  27.593  1.00 38.07           C  
+ATOM   3533  CD2 LEU A 456      53.871  49.481  26.285  1.00 41.28           C  
+ATOM   3534  N   GLU A 457      55.768  47.965  30.865  1.00 40.94           N  
+ATOM   3535  CA  GLU A 457      57.127  48.048  31.417  1.00 44.32           C  
+ATOM   3536  C   GLU A 457      57.635  46.726  32.014  1.00 43.10           C  
+ATOM   3537  O   GLU A 457      58.836  46.415  31.944  1.00 42.96           O  
+ATOM   3538  CB  GLU A 457      57.211  49.139  32.477  1.00 43.72           C  
+ATOM   3539  CG  GLU A 457      57.493  50.516  31.913  1.00 54.71           C  
+ATOM   3540  CD  GLU A 457      58.913  50.681  31.346  1.00 49.01           C  
+ATOM   3541  OE1 GLU A 457      59.643  51.560  31.842  1.00 46.41           O  
+ATOM   3542  OE2 GLU A 457      59.287  49.952  30.404  1.00 50.04           O  
+ATOM   3543  N   LYS A 458      56.729  45.956  32.605  1.00 44.86           N  
+ATOM   3544  CA  LYS A 458      57.105  44.674  33.186  1.00 47.57           C  
+ATOM   3545  C   LYS A 458      57.642  43.782  32.080  1.00 47.89           C  
+ATOM   3546  O   LYS A 458      58.694  43.140  32.235  1.00 48.23           O  
+ATOM   3547  CB  LYS A 458      55.902  44.005  33.841  1.00 52.29           C  
+ATOM   3548  CG  LYS A 458      56.210  42.623  34.402  1.00 58.15           C  
+ATOM   3549  CD  LYS A 458      57.205  42.695  35.555  1.00 61.05           C  
+ATOM   3550  CE  LYS A 458      57.292  41.355  36.316  1.00 64.23           C  
+ATOM   3551  NZ  LYS A 458      58.284  41.393  37.433  1.00 60.62           N  
+ATOM   3552  N   TRP A 459      56.941  43.771  30.945  1.00 42.81           N  
+ATOM   3553  CA  TRP A 459      57.376  42.964  29.830  1.00 42.85           C  
+ATOM   3554  C   TRP A 459      58.777  43.375  29.373  1.00 45.86           C  
+ATOM   3555  O   TRP A 459      59.623  42.517  29.102  1.00 46.73           O  
+ATOM   3556  CB  TRP A 459      56.386  43.078  28.678  1.00 44.21           C  
+ATOM   3557  CG  TRP A 459      56.739  42.226  27.496  1.00 38.68           C  
+ATOM   3558  CD1 TRP A 459      56.360  40.935  27.276  1.00 41.71           C  
+ATOM   3559  CD2 TRP A 459      57.514  42.616  26.358  1.00 38.64           C  
+ATOM   3560  NE1 TRP A 459      56.843  40.495  26.065  1.00 41.33           N  
+ATOM   3561  CE2 TRP A 459      57.553  41.508  25.480  1.00 37.34           C  
+ATOM   3562  CE3 TRP A 459      58.177  43.794  25.992  1.00 38.87           C  
+ATOM   3563  CZ2 TRP A 459      58.223  41.544  24.266  1.00 39.40           C  
+ATOM   3564  CZ3 TRP A 459      58.844  43.835  24.789  1.00 35.26           C  
+ATOM   3565  CH2 TRP A 459      58.863  42.717  23.933  1.00 45.15           C  
+ATOM   3566  N   ARG A 460      59.038  44.678  29.294  1.00 45.73           N  
+ATOM   3567  CA  ARG A 460      60.363  45.143  28.868  1.00 45.36           C  
+ATOM   3568  C   ARG A 460      61.428  44.822  29.906  1.00 42.05           C  
+ATOM   3569  O   ARG A 460      62.539  44.441  29.555  1.00 40.95           O  
+ATOM   3570  CB  ARG A 460      60.384  46.651  28.649  1.00 47.67           C  
+ATOM   3571  CG  ARG A 460      59.639  47.162  27.438  1.00 52.12           C  
+ATOM   3572  CD  ARG A 460      59.322  48.617  27.735  1.00 50.58           C  
+ATOM   3573  NE  ARG A 460      59.967  49.494  26.800  1.00 43.73           N  
+ATOM   3574  CZ  ARG A 460      59.942  50.814  26.877  1.00 41.12           C  
+ATOM   3575  NH1 ARG A 460      59.321  51.419  27.877  1.00 36.28           N  
+ATOM   3576  NH2 ARG A 460      60.463  51.525  25.885  1.00 38.85           N  
+ATOM   3577  N   TRP A 461      61.104  45.036  31.176  1.00 41.62           N  
+ATOM   3578  CA  TRP A 461      62.054  44.725  32.247  1.00 44.44           C  
+ATOM   3579  C   TRP A 461      62.502  43.268  32.137  1.00 43.25           C  
+ATOM   3580  O   TRP A 461      63.694  42.963  32.213  1.00 43.58           O  
+ATOM   3581  CB  TRP A 461      61.409  44.954  33.617  1.00 39.45           C  
+ATOM   3582  CG  TRP A 461      61.314  46.406  33.971  1.00 38.07           C  
+ATOM   3583  CD1 TRP A 461      62.043  47.429  33.429  1.00 34.51           C  
+ATOM   3584  CD2 TRP A 461      60.506  46.984  34.996  1.00 36.33           C  
+ATOM   3585  NE1 TRP A 461      61.741  48.606  34.064  1.00 37.41           N  
+ATOM   3586  CE2 TRP A 461      60.798  48.360  35.029  1.00 37.95           C  
+ATOM   3587  CE3 TRP A 461      59.559  46.472  35.889  1.00 41.65           C  
+ATOM   3588  CZ2 TRP A 461      60.183  49.229  35.923  1.00 34.89           C  
+ATOM   3589  CZ3 TRP A 461      58.947  47.329  36.772  1.00 41.80           C  
+ATOM   3590  CH2 TRP A 461      59.260  48.700  36.783  1.00 40.29           C  
+ATOM   3591  N   MET A 462      61.532  42.384  31.922  1.00 45.98           N  
+ATOM   3592  CA  MET A 462      61.799  40.961  31.800  1.00 49.34           C  
+ATOM   3593  C   MET A 462      62.562  40.616  30.533  1.00 51.27           C  
+ATOM   3594  O   MET A 462      63.447  39.744  30.543  1.00 51.75           O  
+ATOM   3595  CB  MET A 462      60.492  40.182  31.862  1.00 50.17           C  
+ATOM   3596  CG  MET A 462      59.808  40.255  33.218  1.00 46.71           C  
+ATOM   3597  SD  MET A 462      58.208  39.416  33.140  1.00 54.66           S  
+ATOM   3598  CE  MET A 462      58.677  37.768  33.742  1.00 53.65           C  
+ATOM   3599  N   VAL A 463      62.226  41.297  29.443  1.00 51.08           N  
+ATOM   3600  CA  VAL A 463      62.913  41.084  28.181  1.00 46.17           C  
+ATOM   3601  C   VAL A 463      64.376  41.485  28.369  1.00 51.44           C  
+ATOM   3602  O   VAL A 463      65.280  40.736  28.002  1.00 50.89           O  
+ATOM   3603  CB  VAL A 463      62.289  41.939  27.048  1.00 45.99           C  
+ATOM   3604  CG1 VAL A 463      63.236  42.004  25.864  1.00 41.47           C  
+ATOM   3605  CG2 VAL A 463      60.952  41.329  26.611  1.00 46.82           C  
+ATOM   3606  N   PHE A 464      64.616  42.657  28.954  1.00 51.54           N  
+ATOM   3607  CA  PHE A 464      65.995  43.119  29.154  1.00 56.23           C  
+ATOM   3608  C   PHE A 464      66.783  42.189  30.101  1.00 57.73           C  
+ATOM   3609  O   PHE A 464      67.999  41.998  29.933  1.00 57.08           O  
+ATOM   3610  CB  PHE A 464      66.007  44.565  29.687  1.00 55.00           C  
+ATOM   3611  CG  PHE A 464      65.452  45.577  28.713  1.00 56.80           C  
+ATOM   3612  CD1 PHE A 464      64.622  46.591  29.143  1.00 56.71           C  
+ATOM   3613  CD2 PHE A 464      65.748  45.500  27.369  1.00 60.24           C  
+ATOM   3614  CE1 PHE A 464      64.103  47.500  28.248  1.00 58.16           C  
+ATOM   3615  CE2 PHE A 464      65.230  46.408  26.472  1.00 59.52           C  
+ATOM   3616  CZ  PHE A 464      64.409  47.406  26.913  1.00 58.42           C  
+ATOM   3617  N   LYS A 465      66.094  41.618  31.091  1.00 57.30           N  
+ATOM   3618  CA  LYS A 465      66.745  40.694  32.021  1.00 56.37           C  
+ATOM   3619  C   LYS A 465      67.026  39.350  31.355  1.00 54.58           C  
+ATOM   3620  O   LYS A 465      67.836  38.580  31.837  1.00 56.29           O  
+ATOM   3621  CB  LYS A 465      65.878  40.462  33.255  1.00 52.43           C  
+ATOM   3622  CG  LYS A 465      65.829  41.629  34.194  1.00 55.44           C  
+ATOM   3623  CD  LYS A 465      64.910  41.344  35.368  1.00 57.64           C  
+ATOM   3624  CE  LYS A 465      65.114  42.387  36.459  1.00 57.74           C  
+ATOM   3625  NZ  LYS A 465      64.317  42.100  37.680  1.00 59.84           N  
+ATOM   3626  N   GLY A 466      66.361  39.075  30.241  1.00 54.49           N  
+ATOM   3627  CA  GLY A 466      66.566  37.808  29.562  1.00 54.99           C  
+ATOM   3628  C   GLY A 466      65.671  36.683  30.079  1.00 55.74           C  
+ATOM   3629  O   GLY A 466      65.979  35.515  29.885  1.00 58.07           O  
+ATOM   3630  N   GLU A 467      64.570  37.023  30.738  1.00 55.69           N  
+ATOM   3631  CA  GLU A 467      63.658  36.019  31.273  1.00 55.00           C  
+ATOM   3632  C   GLU A 467      62.617  35.602  30.255  1.00 56.38           C  
+ATOM   3633  O   GLU A 467      61.809  34.720  30.520  1.00 56.00           O  
+ATOM   3634  CB  GLU A 467      62.956  36.549  32.506  1.00 55.20           C  
+ATOM   3635  CG  GLU A 467      63.891  37.188  33.493  1.00 60.65           C  
+ATOM   3636  CD  GLU A 467      63.154  37.729  34.687  1.00 65.89           C  
+ATOM   3637  OE1 GLU A 467      62.160  38.458  34.483  1.00 69.84           O  
+ATOM   3638  OE2 GLU A 467      63.561  37.431  35.831  1.00 69.08           O  
+ATOM   3639  N   ILE A 468      62.617  36.247  29.095  1.00 56.58           N  
+ATOM   3640  CA  ILE A 468      61.676  35.872  28.060  1.00 58.00           C  
+ATOM   3641  C   ILE A 468      62.451  35.686  26.761  1.00 60.78           C  
+ATOM   3642  O   ILE A 468      62.882  36.648  26.132  1.00 62.90           O  
+ATOM   3643  CB  ILE A 468      60.589  36.932  27.835  1.00 55.23           C  
+ATOM   3644  CG1 ILE A 468      59.855  37.248  29.134  1.00 53.90           C  
+ATOM   3645  CG2 ILE A 468      59.596  36.412  26.819  1.00 54.33           C  
+ATOM   3646  CD1 ILE A 468      58.972  38.490  29.028  1.00 48.47           C  
+ATOM   3647  N   PRO A 469      62.646  34.432  26.352  1.00 62.64           N  
+ATOM   3648  CA  PRO A 469      63.370  34.075  25.127  1.00 62.10           C  
+ATOM   3649  C   PRO A 469      62.704  34.703  23.908  1.00 60.59           C  
+ATOM   3650  O   PRO A 469      61.479  34.798  23.851  1.00 60.73           O  
+ATOM   3651  CB  PRO A 469      63.266  32.549  25.096  1.00 63.43           C  
+ATOM   3652  CG  PRO A 469      63.094  32.183  26.567  1.00 66.07           C  
+ATOM   3653  CD  PRO A 469      62.137  33.235  27.044  1.00 61.61           C  
+ATOM   3654  N   LYS A 470      63.505  35.120  22.935  1.00 59.49           N  
+ATOM   3655  CA  LYS A 470      62.962  35.728  21.725  1.00 59.14           C  
+ATOM   3656  C   LYS A 470      61.760  34.928  21.223  1.00 57.91           C  
+ATOM   3657  O   LYS A 470      60.757  35.508  20.786  1.00 53.97           O  
+ATOM   3658  CB  LYS A 470      64.021  35.780  20.614  1.00 59.14           C  
+ATOM   3659  CG  LYS A 470      65.216  36.711  20.859  1.00 65.00           C  
+ATOM   3660  CD  LYS A 470      66.226  36.622  19.698  1.00 66.46           C  
+ATOM   3661  CE  LYS A 470      67.530  37.391  19.972  1.00 73.01           C  
+ATOM   3662  NZ  LYS A 470      67.379  38.896  20.015  1.00 75.77           N  
+ATOM   3663  N   ASP A 471      61.858  33.598  21.305  1.00 58.17           N  
+ATOM   3664  CA  ASP A 471      60.785  32.721  20.823  1.00 57.18           C  
+ATOM   3665  C   ASP A 471      59.505  32.716  21.639  1.00 53.35           C  
+ATOM   3666  O   ASP A 471      58.535  32.080  21.251  1.00 52.97           O  
+ATOM   3667  CB  ASP A 471      61.293  31.282  20.630  1.00 60.63           C  
+ATOM   3668  CG  ASP A 471      61.954  30.709  21.873  1.00 65.40           C  
+ATOM   3669  OD1 ASP A 471      61.250  30.418  22.872  1.00 63.29           O  
+ATOM   3670  OD2 ASP A 471      63.195  30.549  21.846  1.00 70.97           O  
+ATOM   3671  N   GLN A 472      59.495  33.436  22.759  1.00 52.97           N  
+ATOM   3672  CA  GLN A 472      58.289  33.539  23.586  1.00 52.36           C  
+ATOM   3673  C   GLN A 472      57.859  35.000  23.843  1.00 47.70           C  
+ATOM   3674  O   GLN A 472      56.965  35.246  24.654  1.00 45.88           O  
+ATOM   3675  CB  GLN A 472      58.500  32.867  24.939  1.00 53.68           C  
+ATOM   3676  CG  GLN A 472      58.987  31.445  24.866  1.00 61.34           C  
+ATOM   3677  CD  GLN A 472      58.549  30.660  26.078  1.00 65.61           C  
+ATOM   3678  OE1 GLN A 472      58.907  30.992  27.219  1.00 65.46           O  
+ATOM   3679  NE2 GLN A 472      57.748  29.621  25.846  1.00 65.94           N  
+ATOM   3680  N   TRP A 473      58.493  35.955  23.167  1.00 46.84           N  
+ATOM   3681  CA  TRP A 473      58.168  37.376  23.349  1.00 44.86           C  
+ATOM   3682  C   TRP A 473      56.680  37.668  23.209  1.00 43.74           C  
+ATOM   3683  O   TRP A 473      56.049  38.123  24.160  1.00 42.97           O  
+ATOM   3684  CB  TRP A 473      58.924  38.235  22.344  1.00 46.46           C  
+ATOM   3685  CG  TRP A 473      60.281  38.621  22.775  1.00 47.91           C  
+ATOM   3686  CD1 TRP A 473      60.962  38.151  23.849  1.00 50.16           C  
+ATOM   3687  CD2 TRP A 473      61.150  39.557  22.122  1.00 48.38           C  
+ATOM   3688  NE1 TRP A 473      62.211  38.733  23.914  1.00 47.12           N  
+ATOM   3689  CE2 TRP A 473      62.350  39.600  22.864  1.00 47.71           C  
+ATOM   3690  CE3 TRP A 473      61.027  40.362  20.984  1.00 46.44           C  
+ATOM   3691  CZ2 TRP A 473      63.423  40.415  22.507  1.00 48.24           C  
+ATOM   3692  CZ3 TRP A 473      62.092  41.174  20.626  1.00 49.93           C  
+ATOM   3693  CH2 TRP A 473      63.277  41.193  21.388  1.00 52.76           C  
+ATOM   3694  N   MET A 474      56.122  37.437  22.021  1.00 41.76           N  
+ATOM   3695  CA  MET A 474      54.704  37.692  21.826  1.00 41.62           C  
+ATOM   3696  C   MET A 474      53.839  36.796  22.695  1.00 45.31           C  
+ATOM   3697  O   MET A 474      52.816  37.242  23.231  1.00 46.30           O  
+ATOM   3698  CB  MET A 474      54.298  37.505  20.356  1.00 42.63           C  
+ATOM   3699  CG  MET A 474      54.854  38.558  19.417  1.00 44.79           C  
+ATOM   3700  SD  MET A 474      54.754  40.197  20.167  1.00 49.04           S  
+ATOM   3701  CE  MET A 474      53.080  40.397  20.209  1.00 48.00           C  
+ATOM   3702  N   LYS A 475      54.233  35.531  22.836  1.00 46.17           N  
+ATOM   3703  CA  LYS A 475      53.455  34.616  23.651  1.00 45.10           C  
+ATOM   3704  C   LYS A 475      53.334  35.197  25.052  1.00 43.92           C  
+ATOM   3705  O   LYS A 475      52.237  35.302  25.605  1.00 41.98           O  
+ATOM   3706  CB  LYS A 475      54.124  33.234  23.728  1.00 47.28           C  
+ATOM   3707  CG  LYS A 475      53.268  32.202  24.455  1.00 49.10           C  
+ATOM   3708  CD  LYS A 475      54.124  31.153  25.131  1.00 57.34           C  
+ATOM   3709  CE  LYS A 475      54.055  29.808  24.414  1.00 62.48           C  
+ATOM   3710  NZ  LYS A 475      52.719  29.149  24.584  1.00 65.79           N  
+ATOM   3711  N   LYS A 476      54.466  35.590  25.619  1.00 42.88           N  
+ATOM   3712  CA  LYS A 476      54.456  36.149  26.959  1.00 45.69           C  
+ATOM   3713  C   LYS A 476      53.724  37.490  26.991  1.00 47.26           C  
+ATOM   3714  O   LYS A 476      53.031  37.801  27.966  1.00 48.37           O  
+ATOM   3715  CB  LYS A 476      55.889  36.309  27.466  1.00 47.91           C  
+ATOM   3716  CG  LYS A 476      56.169  35.564  28.761  1.00 53.67           C  
+ATOM   3717  CD  LYS A 476      55.265  36.052  29.868  1.00 60.11           C  
+ATOM   3718  CE  LYS A 476      55.669  35.474  31.216  1.00 66.49           C  
+ATOM   3719  NZ  LYS A 476      55.607  33.969  31.228  1.00 72.96           N  
+ATOM   3720  N   TRP A 477      53.862  38.279  25.925  1.00 44.35           N  
+ATOM   3721  CA  TRP A 477      53.189  39.577  25.859  1.00 44.51           C  
+ATOM   3722  C   TRP A 477      51.686  39.398  25.999  1.00 42.44           C  
+ATOM   3723  O   TRP A 477      51.063  40.031  26.837  1.00 46.81           O  
+ATOM   3724  CB  TRP A 477      53.510  40.284  24.533  1.00 42.92           C  
+ATOM   3725  CG  TRP A 477      52.705  41.542  24.256  1.00 46.14           C  
+ATOM   3726  CD1 TRP A 477      51.644  41.666  23.400  1.00 46.38           C  
+ATOM   3727  CD2 TRP A 477      52.957  42.861  24.769  1.00 42.90           C  
+ATOM   3728  NE1 TRP A 477      51.229  42.977  23.338  1.00 45.35           N  
+ATOM   3729  CE2 TRP A 477      52.013  43.732  24.169  1.00 44.34           C  
+ATOM   3730  CE3 TRP A 477      53.889  43.390  25.671  1.00 41.56           C  
+ATOM   3731  CZ2 TRP A 477      51.971  45.113  24.445  1.00 41.17           C  
+ATOM   3732  CZ3 TRP A 477      53.851  44.764  25.950  1.00 45.06           C  
+ATOM   3733  CH2 TRP A 477      52.891  45.608  25.334  1.00 42.20           C  
+ATOM   3734  N   TRP A 478      51.097  38.529  25.184  1.00 45.64           N  
+ATOM   3735  CA  TRP A 478      49.658  38.308  25.245  1.00 42.65           C  
+ATOM   3736  C   TRP A 478      49.219  37.511  26.465  1.00 45.60           C  
+ATOM   3737  O   TRP A 478      48.081  37.634  26.909  1.00 48.15           O  
+ATOM   3738  CB  TRP A 478      49.167  37.672  23.944  1.00 44.92           C  
+ATOM   3739  CG  TRP A 478      49.126  38.726  22.868  1.00 44.30           C  
+ATOM   3740  CD1 TRP A 478      50.004  38.892  21.837  1.00 40.98           C  
+ATOM   3741  CD2 TRP A 478      48.304  39.898  22.888  1.00 37.65           C  
+ATOM   3742  NE1 TRP A 478      49.791  40.110  21.231  1.00 41.74           N  
+ATOM   3743  CE2 TRP A 478      48.751  40.743  21.863  1.00 38.54           C  
+ATOM   3744  CE3 TRP A 478      47.241  40.317  23.692  1.00 37.73           C  
+ATOM   3745  CZ2 TRP A 478      48.174  41.987  21.616  1.00 38.09           C  
+ATOM   3746  CZ3 TRP A 478      46.669  41.557  23.449  1.00 39.88           C  
+ATOM   3747  CH2 TRP A 478      47.142  42.375  22.420  1.00 37.05           C  
+ATOM   3748  N   GLU A 479      50.119  36.730  27.043  1.00 45.68           N  
+ATOM   3749  CA  GLU A 479      49.769  35.983  28.255  1.00 49.30           C  
+ATOM   3750  C   GLU A 479      49.600  37.050  29.338  1.00 47.32           C  
+ATOM   3751  O   GLU A 479      48.665  37.013  30.140  1.00 48.04           O  
+ATOM   3752  CB  GLU A 479      50.914  35.037  28.631  1.00 52.45           C  
+ATOM   3753  CG  GLU A 479      50.503  33.621  28.981  1.00 58.28           C  
+ATOM   3754  CD  GLU A 479      51.468  32.578  28.409  1.00 63.63           C  
+ATOM   3755  OE1 GLU A 479      52.659  32.567  28.812  1.00 62.00           O  
+ATOM   3756  OE2 GLU A 479      51.028  31.774  27.551  1.00 65.54           O  
+ATOM   3757  N   MET A 480      50.520  38.015  29.333  1.00 47.66           N  
+ATOM   3758  CA  MET A 480      50.508  39.119  30.286  1.00 44.59           C  
+ATOM   3759  C   MET A 480      49.366  40.125  30.044  1.00 45.90           C  
+ATOM   3760  O   MET A 480      48.793  40.675  30.998  1.00 41.60           O  
+ATOM   3761  CB  MET A 480      51.867  39.810  30.254  1.00 47.62           C  
+ATOM   3762  CG  MET A 480      52.974  38.960  30.876  1.00 41.94           C  
+ATOM   3763  SD  MET A 480      54.624  39.571  30.569  1.00 49.38           S  
+ATOM   3764  CE  MET A 480      54.647  40.968  31.754  1.00 38.25           C  
+ATOM   3765  N   LYS A 481      49.022  40.374  28.782  1.00 45.11           N  
+ATOM   3766  CA  LYS A 481      47.906  41.280  28.519  1.00 47.33           C  
+ATOM   3767  C   LYS A 481      46.633  40.683  29.145  1.00 47.81           C  
+ATOM   3768  O   LYS A 481      45.880  41.379  29.834  1.00 48.37           O  
+ATOM   3769  CB  LYS A 481      47.707  41.476  27.008  1.00 47.75           C  
+ATOM   3770  CG  LYS A 481      48.584  42.550  26.374  1.00 52.87           C  
+ATOM   3771  CD  LYS A 481      48.154  43.963  26.820  1.00 54.73           C  
+ATOM   3772  CE  LYS A 481      48.661  45.046  25.861  1.00 55.02           C  
+ATOM   3773  NZ  LYS A 481      48.128  46.411  26.220  1.00 55.49           N  
+ATOM   3774  N   ARG A 482      46.410  39.386  28.902  1.00 49.99           N  
+ATOM   3775  CA  ARG A 482      45.242  38.650  29.403  1.00 48.21           C  
+ATOM   3776  C   ARG A 482      45.171  38.581  30.926  1.00 46.79           C  
+ATOM   3777  O   ARG A 482      44.123  38.813  31.506  1.00 46.80           O  
+ATOM   3778  CB  ARG A 482      45.230  37.216  28.856  1.00 52.31           C  
+ATOM   3779  CG  ARG A 482      45.024  37.087  27.354  1.00 55.87           C  
+ATOM   3780  CD  ARG A 482      45.177  35.633  26.899  1.00 58.06           C  
+ATOM   3781  NE  ARG A 482      45.007  35.453  25.456  1.00 59.69           N  
+ATOM   3782  CZ  ARG A 482      44.137  34.599  24.911  1.00 62.34           C  
+ATOM   3783  NH1 ARG A 482      43.361  33.858  25.697  1.00 57.40           N  
+ATOM   3784  NH2 ARG A 482      44.053  34.469  23.584  1.00 56.94           N  
+ATOM   3785  N   GLU A 483      46.284  38.266  31.577  1.00 47.83           N  
+ATOM   3786  CA  GLU A 483      46.296  38.167  33.037  1.00 49.47           C  
+ATOM   3787  C   GLU A 483      46.234  39.477  33.833  1.00 45.97           C  
+ATOM   3788  O   GLU A 483      45.418  39.628  34.737  1.00 46.21           O  
+ATOM   3789  CB  GLU A 483      47.536  37.398  33.487  1.00 54.03           C  
+ATOM   3790  CG  GLU A 483      47.364  35.908  33.457  1.00 69.52           C  
+ATOM   3791  CD  GLU A 483      46.625  35.403  34.678  1.00 75.02           C  
+ATOM   3792  OE1 GLU A 483      46.269  34.203  34.703  1.00 78.21           O  
+ATOM   3793  OE2 GLU A 483      46.410  36.213  35.614  1.00 77.96           O  
+ATOM   3794  N   ILE A 484      47.119  40.407  33.507  1.00 45.48           N  
+ATOM   3795  CA  ILE A 484      47.222  41.685  34.217  1.00 43.02           C  
+ATOM   3796  C   ILE A 484      46.239  42.758  33.785  1.00 41.08           C  
+ATOM   3797  O   ILE A 484      45.611  43.407  34.616  1.00 39.94           O  
+ATOM   3798  CB  ILE A 484      48.648  42.266  34.060  1.00 44.56           C  
+ATOM   3799  CG1 ILE A 484      49.676  41.244  34.564  1.00 48.74           C  
+ATOM   3800  CG2 ILE A 484      48.757  43.586  34.806  1.00 44.62           C  
+ATOM   3801  CD1 ILE A 484      51.136  41.550  34.206  1.00 47.20           C  
+ATOM   3802  N   VAL A 485      46.092  42.925  32.476  1.00 42.63           N  
+ATOM   3803  CA  VAL A 485      45.228  43.964  31.931  1.00 41.22           C  
+ATOM   3804  C   VAL A 485      43.807  43.502  31.655  1.00 40.94           C  
+ATOM   3805  O   VAL A 485      42.882  44.308  31.621  1.00 40.27           O  
+ATOM   3806  CB  VAL A 485      45.870  44.513  30.627  1.00 41.49           C  
+ATOM   3807  CG1 VAL A 485      45.224  45.861  30.189  1.00 38.81           C  
+ATOM   3808  CG2 VAL A 485      47.365  44.660  30.847  1.00 37.80           C  
+ATOM   3809  N   GLY A 486      43.640  42.197  31.462  1.00 44.32           N  
+ATOM   3810  CA  GLY A 486      42.329  41.651  31.165  1.00 39.96           C  
+ATOM   3811  C   GLY A 486      41.921  42.072  29.763  1.00 41.67           C  
+ATOM   3812  O   GLY A 486      40.785  42.499  29.536  1.00 45.19           O  
+ATOM   3813  N   VAL A 487      42.850  41.949  28.825  1.00 39.48           N  
+ATOM   3814  CA  VAL A 487      42.628  42.341  27.436  1.00 41.11           C  
+ATOM   3815  C   VAL A 487      43.183  41.222  26.587  1.00 42.48           C  
+ATOM   3816  O   VAL A 487      44.249  40.688  26.913  1.00 44.61           O  
+ATOM   3817  CB  VAL A 487      43.397  43.662  27.109  1.00 44.27           C  
+ATOM   3818  CG1 VAL A 487      43.376  43.954  25.612  1.00 45.09           C  
+ATOM   3819  CG2 VAL A 487      42.768  44.830  27.870  1.00 43.62           C  
+ATOM   3820  N   VAL A 488      42.470  40.857  25.518  1.00 41.49           N  
+ATOM   3821  CA  VAL A 488      42.900  39.783  24.624  1.00 40.30           C  
+ATOM   3822  C   VAL A 488      43.030  40.198  23.173  1.00 42.98           C  
+ATOM   3823  O   VAL A 488      42.193  40.930  22.642  1.00 41.63           O  
+ATOM   3824  CB  VAL A 488      41.909  38.570  24.574  1.00 44.87           C  
+ATOM   3825  CG1 VAL A 488      42.351  37.480  25.503  1.00 49.07           C  
+ATOM   3826  CG2 VAL A 488      40.512  39.024  24.853  1.00 37.53           C  
+ATOM   3827  N   GLU A 489      44.054  39.658  22.526  1.00 42.34           N  
+ATOM   3828  CA  GLU A 489      44.307  39.935  21.132  1.00 45.73           C  
+ATOM   3829  C   GLU A 489      43.186  39.280  20.308  1.00 48.65           C  
+ATOM   3830  O   GLU A 489      42.803  38.146  20.570  1.00 48.76           O  
+ATOM   3831  CB  GLU A 489      45.670  39.372  20.738  1.00 43.84           C  
+ATOM   3832  CG  GLU A 489      45.738  37.857  20.638  1.00 49.32           C  
+ATOM   3833  CD  GLU A 489      45.809  37.141  21.981  1.00 54.88           C  
+ATOM   3834  OE1 GLU A 489      46.090  35.929  21.972  1.00 56.73           O  
+ATOM   3835  OE2 GLU A 489      45.583  37.767  23.038  1.00 57.25           O  
+ATOM   3836  N   PRO A 490      42.650  40.002  19.311  1.00 48.90           N  
+ATOM   3837  CA  PRO A 490      41.570  39.596  18.398  1.00 48.56           C  
+ATOM   3838  C   PRO A 490      42.008  38.502  17.450  1.00 47.24           C  
+ATOM   3839  O   PRO A 490      41.208  37.676  17.034  1.00 46.48           O  
+ATOM   3840  CB  PRO A 490      41.240  40.881  17.629  1.00 50.82           C  
+ATOM   3841  CG  PRO A 490      41.821  41.995  18.484  1.00 54.15           C  
+ATOM   3842  CD  PRO A 490      43.079  41.383  19.037  1.00 50.97           C  
+ATOM   3843  N   VAL A 491      43.292  38.527  17.116  1.00 48.89           N  
+ATOM   3844  CA  VAL A 491      43.926  37.582  16.208  1.00 48.47           C  
+ATOM   3845  C   VAL A 491      45.130  36.980  16.908  1.00 48.82           C  
+ATOM   3846  O   VAL A 491      45.758  37.634  17.728  1.00 50.18           O  
+ATOM   3847  CB  VAL A 491      44.446  38.303  14.962  1.00 48.08           C  
+ATOM   3848  CG1 VAL A 491      45.117  37.327  14.057  1.00 55.79           C  
+ATOM   3849  CG2 VAL A 491      43.308  39.003  14.246  1.00 52.55           C  
+ATOM   3850  N   PRO A 492      45.469  35.721  16.610  1.00 48.56           N  
+ATOM   3851  CA  PRO A 492      46.642  35.221  17.324  1.00 48.11           C  
+ATOM   3852  C   PRO A 492      47.907  35.728  16.640  1.00 47.99           C  
+ATOM   3853  O   PRO A 492      47.950  35.844  15.418  1.00 47.54           O  
+ATOM   3854  CB  PRO A 492      46.466  33.701  17.257  1.00 47.29           C  
+ATOM   3855  CG  PRO A 492      45.706  33.513  15.980  1.00 46.66           C  
+ATOM   3856  CD  PRO A 492      44.707  34.618  16.002  1.00 45.16           C  
+ATOM   3857  N   HIS A 493      48.927  36.038  17.435  1.00 47.45           N  
+ATOM   3858  CA  HIS A 493      50.182  36.559  16.913  1.00 49.25           C  
+ATOM   3859  C   HIS A 493      51.395  35.705  17.261  1.00 50.19           C  
+ATOM   3860  O   HIS A 493      51.686  35.483  18.428  1.00 49.66           O  
+ATOM   3861  CB  HIS A 493      50.427  37.972  17.453  1.00 47.76           C  
+ATOM   3862  CG  HIS A 493      49.515  39.008  16.878  1.00 50.23           C  
+ATOM   3863  ND1 HIS A 493      48.563  38.716  15.926  1.00 50.09           N  
+ATOM   3864  CD2 HIS A 493      49.421  40.339  17.106  1.00 47.55           C  
+ATOM   3865  CE1 HIS A 493      47.921  39.820  15.594  1.00 43.67           C  
+ATOM   3866  NE2 HIS A 493      48.424  40.820  16.296  1.00 51.10           N  
+ATOM   3867  N   ASP A 494      52.129  35.265  16.248  1.00 52.04           N  
+ATOM   3868  CA  ASP A 494      53.317  34.460  16.496  1.00 53.92           C  
+ATOM   3869  C   ASP A 494      54.539  35.371  16.716  1.00 54.55           C  
+ATOM   3870  O   ASP A 494      54.396  36.592  16.811  1.00 53.23           O  
+ATOM   3871  CB  ASP A 494      53.540  33.473  15.339  1.00 52.39           C  
+ATOM   3872  CG  ASP A 494      53.826  34.159  14.025  1.00 55.10           C  
+ATOM   3873  OD1 ASP A 494      53.901  33.453  13.005  1.00 60.68           O  
+ATOM   3874  OD2 ASP A 494      53.988  35.397  13.999  1.00 61.11           O  
+ATOM   3875  N   GLU A 495      55.733  34.787  16.792  1.00 53.82           N  
+ATOM   3876  CA  GLU A 495      56.940  35.569  17.060  1.00 54.31           C  
+ATOM   3877  C   GLU A 495      57.409  36.422  15.893  1.00 52.87           C  
+ATOM   3878  O   GLU A 495      58.446  37.083  15.949  1.00 52.53           O  
+ATOM   3879  CB  GLU A 495      58.053  34.645  17.539  1.00 51.73           C  
+ATOM   3880  CG  GLU A 495      57.642  33.871  18.787  1.00 52.97           C  
+ATOM   3881  CD  GLU A 495      57.235  34.777  19.922  1.00 54.96           C  
+ATOM   3882  OE1 GLU A 495      56.387  34.376  20.756  1.00 55.39           O  
+ATOM   3883  OE2 GLU A 495      57.779  35.894  19.991  1.00 57.82           O  
+ATOM   3884  N   THR A 496      56.612  36.417  14.842  1.00 50.78           N  
+ATOM   3885  CA  THR A 496      56.890  37.195  13.660  1.00 48.62           C  
+ATOM   3886  C   THR A 496      56.485  38.670  13.904  1.00 46.72           C  
+ATOM   3887  O   THR A 496      56.998  39.596  13.273  1.00 47.87           O  
+ATOM   3888  CB  THR A 496      56.130  36.556  12.505  1.00 50.52           C  
+ATOM   3889  OG1 THR A 496      57.062  35.842  11.668  1.00 49.86           O  
+ATOM   3890  CG2 THR A 496      55.360  37.573  11.744  1.00 46.60           C  
+ATOM   3891  N   TYR A 497      55.581  38.860  14.855  1.00 44.89           N  
+ATOM   3892  CA  TYR A 497      55.071  40.168  15.255  1.00 45.03           C  
+ATOM   3893  C   TYR A 497      55.923  40.788  16.370  1.00 45.82           C  
+ATOM   3894  O   TYR A 497      56.748  40.119  16.987  1.00 47.91           O  
+ATOM   3895  CB  TYR A 497      53.654  40.031  15.810  1.00 39.55           C  
+ATOM   3896  CG  TYR A 497      52.567  39.713  14.814  1.00 43.98           C  
+ATOM   3897  CD1 TYR A 497      51.713  40.705  14.346  1.00 39.83           C  
+ATOM   3898  CD2 TYR A 497      52.345  38.409  14.395  1.00 45.82           C  
+ATOM   3899  CE1 TYR A 497      50.669  40.409  13.503  1.00 42.28           C  
+ATOM   3900  CE2 TYR A 497      51.304  38.102  13.555  1.00 43.52           C  
+ATOM   3901  CZ  TYR A 497      50.464  39.101  13.117  1.00 48.08           C  
+ATOM   3902  OH  TYR A 497      49.367  38.767  12.354  1.00 50.06           O  
+ATOM   3903  N   CYS A 498      55.698  42.070  16.624  1.00 44.73           N  
+ATOM   3904  CA  CYS A 498      56.370  42.781  17.702  1.00 46.62           C  
+ATOM   3905  C   CYS A 498      55.380  43.825  18.146  1.00 47.06           C  
+ATOM   3906  O   CYS A 498      55.588  45.024  17.957  1.00 49.10           O  
+ATOM   3907  CB  CYS A 498      57.641  43.481  17.260  1.00 42.84           C  
+ATOM   3908  SG  CYS A 498      58.637  43.873  18.739  1.00 54.61           S  
+ATOM   3909  N   ASP A 499      54.294  43.360  18.741  1.00 45.03           N  
+ATOM   3910  CA  ASP A 499      53.234  44.252  19.165  1.00 44.76           C  
+ATOM   3911  C   ASP A 499      53.601  45.344  20.156  1.00 43.92           C  
+ATOM   3912  O   ASP A 499      53.028  46.410  20.117  1.00 45.27           O  
+ATOM   3913  CB  ASP A 499      52.068  43.410  19.644  1.00 45.21           C  
+ATOM   3914  CG  ASP A 499      51.489  42.565  18.514  1.00 46.58           C  
+ATOM   3915  OD1 ASP A 499      50.804  41.571  18.805  1.00 44.63           O  
+ATOM   3916  OD2 ASP A 499      51.726  42.913  17.332  1.00 45.56           O  
+ATOM   3917  N   PRO A 500      54.549  45.097  21.067  1.00 46.50           N  
+ATOM   3918  CA  PRO A 500      54.837  46.226  21.963  1.00 44.07           C  
+ATOM   3919  C   PRO A 500      55.510  47.385  21.214  1.00 42.42           C  
+ATOM   3920  O   PRO A 500      55.285  48.560  21.521  1.00 39.86           O  
+ATOM   3921  CB  PRO A 500      55.732  45.604  23.048  1.00 43.66           C  
+ATOM   3922  CG  PRO A 500      56.274  44.366  22.417  1.00 47.31           C  
+ATOM   3923  CD  PRO A 500      55.137  43.844  21.573  1.00 42.70           C  
+ATOM   3924  N   ALA A 501      56.301  47.044  20.202  1.00 42.80           N  
+ATOM   3925  CA  ALA A 501      57.014  48.040  19.405  1.00 42.38           C  
+ATOM   3926  C   ALA A 501      56.102  48.895  18.518  1.00 42.81           C  
+ATOM   3927  O   ALA A 501      56.541  49.914  17.967  1.00 43.48           O  
+ATOM   3928  CB  ALA A 501      58.076  47.357  18.557  1.00 41.65           C  
+ATOM   3929  N   SER A 502      54.842  48.494  18.379  1.00 42.50           N  
+ATOM   3930  CA  SER A 502      53.912  49.260  17.560  1.00 45.00           C  
+ATOM   3931  C   SER A 502      53.373  50.429  18.382  1.00 43.65           C  
+ATOM   3932  O   SER A 502      52.423  51.102  17.991  1.00 41.43           O  
+ATOM   3933  CB  SER A 502      52.748  48.386  17.094  1.00 43.80           C  
+ATOM   3934  OG  SER A 502      51.754  48.306  18.099  1.00 45.30           O  
+ATOM   3935  N   LEU A 503      53.975  50.633  19.545  1.00 44.76           N  
+ATOM   3936  CA  LEU A 503      53.607  51.726  20.437  1.00 42.27           C  
+ATOM   3937  C   LEU A 503      54.783  52.690  20.346  1.00 39.79           C  
+ATOM   3938  O   LEU A 503      55.936  52.258  20.417  1.00 38.86           O  
+ATOM   3939  CB  LEU A 503      53.491  51.222  21.881  1.00 44.89           C  
+ATOM   3940  CG  LEU A 503      52.672  52.010  22.907  1.00 46.63           C  
+ATOM   3941  CD1 LEU A 503      53.438  52.093  24.200  1.00 46.14           C  
+ATOM   3942  CD2 LEU A 503      52.356  53.391  22.400  1.00 45.89           C  
+ATOM   3943  N   PHE A 504      54.492  53.980  20.211  1.00 35.72           N  
+ATOM   3944  CA  PHE A 504      55.523  55.013  20.124  1.00 38.39           C  
+ATOM   3945  C   PHE A 504      56.699  54.904  21.126  1.00 37.05           C  
+ATOM   3946  O   PHE A 504      57.863  54.851  20.727  1.00 40.03           O  
+ATOM   3947  CB  PHE A 504      54.878  56.400  20.263  1.00 35.00           C  
+ATOM   3948  CG  PHE A 504      55.875  57.532  20.325  1.00 36.80           C  
+ATOM   3949  CD1 PHE A 504      56.446  58.030  19.175  1.00 35.35           C  
+ATOM   3950  CD2 PHE A 504      56.248  58.077  21.538  1.00 36.01           C  
+ATOM   3951  CE1 PHE A 504      57.374  59.054  19.222  1.00 37.60           C  
+ATOM   3952  CE2 PHE A 504      57.173  59.096  21.600  1.00 38.55           C  
+ATOM   3953  CZ  PHE A 504      57.741  59.590  20.443  1.00 39.72           C  
+ATOM   3954  N   HIS A 505      56.407  54.850  22.415  1.00 39.20           N  
+ATOM   3955  CA  HIS A 505      57.490  54.803  23.406  1.00 41.85           C  
+ATOM   3956  C   HIS A 505      58.397  53.581  23.312  1.00 42.30           C  
+ATOM   3957  O   HIS A 505      59.577  53.643  23.683  1.00 41.04           O  
+ATOM   3958  CB  HIS A 505      56.898  54.909  24.803  1.00 39.50           C  
+ATOM   3959  CG  HIS A 505      55.871  55.985  24.927  1.00 42.72           C  
+ATOM   3960  ND1 HIS A 505      56.047  57.098  25.722  1.00 44.41           N  
+ATOM   3961  CD2 HIS A 505      54.653  56.121  24.350  1.00 42.70           C  
+ATOM   3962  CE1 HIS A 505      54.979  57.873  25.631  1.00 43.24           C  
+ATOM   3963  NE2 HIS A 505      54.120  57.303  24.806  1.00 40.45           N  
+ATOM   3964  N   VAL A 506      57.860  52.469  22.815  1.00 39.76           N  
+ATOM   3965  CA  VAL A 506      58.682  51.277  22.687  1.00 38.89           C  
+ATOM   3966  C   VAL A 506      59.644  51.419  21.512  1.00 40.99           C  
+ATOM   3967  O   VAL A 506      60.856  51.334  21.684  1.00 40.80           O  
+ATOM   3968  CB  VAL A 506      57.803  50.007  22.514  1.00 40.44           C  
+ATOM   3969  CG1 VAL A 506      58.659  48.814  22.169  1.00 38.67           C  
+ATOM   3970  CG2 VAL A 506      57.031  49.721  23.810  1.00 38.98           C  
+ATOM   3971  N   SER A 507      59.124  51.646  20.307  1.00 41.14           N  
+ATOM   3972  CA  SER A 507      60.020  51.785  19.165  1.00 40.74           C  
+ATOM   3973  C   SER A 507      60.824  53.087  19.188  1.00 39.07           C  
+ATOM   3974  O   SER A 507      61.781  53.223  18.437  1.00 41.53           O  
+ATOM   3975  CB  SER A 507      59.235  51.682  17.845  1.00 41.10           C  
+ATOM   3976  OG  SER A 507      58.132  52.556  17.875  1.00 48.70           O  
+ATOM   3977  N   ASN A 508      60.448  54.046  20.032  1.00 39.91           N  
+ATOM   3978  CA  ASN A 508      61.208  55.300  20.105  1.00 42.89           C  
+ATOM   3979  C   ASN A 508      62.112  55.384  21.335  1.00 43.35           C  
+ATOM   3980  O   ASN A 508      62.600  56.446  21.730  1.00 41.15           O  
+ATOM   3981  CB  ASN A 508      60.256  56.509  19.974  1.00 41.76           C  
+ATOM   3982  CG  ASN A 508      59.842  56.743  18.506  1.00 47.53           C  
+ATOM   3983  OD1 ASN A 508      60.544  57.422  17.758  1.00 47.99           O  
+ATOM   3984  ND2 ASN A 508      58.735  56.129  18.083  1.00 46.84           N  
+ATOM   3985  N   ASP A 509      62.324  54.230  21.951  1.00 45.77           N  
+ATOM   3986  CA  ASP A 509      63.246  54.115  23.068  1.00 42.33           C  
+ATOM   3987  C   ASP A 509      63.078  55.046  24.284  1.00 44.17           C  
+ATOM   3988  O   ASP A 509      64.059  55.644  24.753  1.00 45.42           O  
+ATOM   3989  CB  ASP A 509      64.654  54.237  22.473  1.00 41.21           C  
+ATOM   3990  CG  ASP A 509      65.751  54.021  23.495  1.00 46.72           C  
+ATOM   3991  OD1 ASP A 509      65.651  53.044  24.265  1.00 41.75           O  
+ATOM   3992  OD2 ASP A 509      66.718  54.820  23.512  1.00 45.75           O  
+ATOM   3993  N   TYR A 510      61.851  55.160  24.800  1.00 42.60           N  
+ATOM   3994  CA  TYR A 510      61.562  55.972  25.999  1.00 40.37           C  
+ATOM   3995  C   TYR A 510      61.053  55.047  27.102  1.00 43.13           C  
+ATOM   3996  O   TYR A 510      60.267  54.129  26.843  1.00 42.19           O  
+ATOM   3997  CB  TYR A 510      60.464  57.012  25.732  1.00 40.19           C  
+ATOM   3998  CG  TYR A 510      60.909  58.189  24.888  1.00 49.96           C  
+ATOM   3999  CD1 TYR A 510      61.725  59.180  25.419  1.00 52.41           C  
+ATOM   4000  CD2 TYR A 510      60.545  58.290  23.549  1.00 49.31           C  
+ATOM   4001  CE1 TYR A 510      62.174  60.239  24.631  1.00 56.01           C  
+ATOM   4002  CE2 TYR A 510      60.984  59.340  22.759  1.00 49.78           C  
+ATOM   4003  CZ  TYR A 510      61.800  60.312  23.305  1.00 54.42           C  
+ATOM   4004  OH  TYR A 510      62.237  61.366  22.533  1.00 54.12           O  
+ATOM   4005  N   SER A 511      61.487  55.278  28.334  1.00 41.24           N  
+ATOM   4006  CA  SER A 511      61.024  54.453  29.424  1.00 41.70           C  
+ATOM   4007  C   SER A 511      59.564  54.820  29.633  1.00 40.59           C  
+ATOM   4008  O   SER A 511      59.160  55.941  29.344  1.00 39.93           O  
+ATOM   4009  CB  SER A 511      61.847  54.716  30.696  1.00 45.09           C  
+ATOM   4010  OG  SER A 511      61.683  56.048  31.126  1.00 46.67           O  
+ATOM   4011  N   PHE A 512      58.795  53.886  30.192  1.00 39.66           N  
+ATOM   4012  CA  PHE A 512      57.369  54.053  30.384  1.00 36.56           C  
+ATOM   4013  C   PHE A 512      56.859  54.088  31.823  1.00 40.07           C  
+ATOM   4014  O   PHE A 512      55.796  54.654  32.079  1.00 38.88           O  
+ATOM   4015  CB  PHE A 512      56.676  52.916  29.623  1.00 40.76           C  
+ATOM   4016  CG  PHE A 512      55.340  53.282  29.025  1.00 41.44           C  
+ATOM   4017  CD1 PHE A 512      54.168  52.679  29.486  1.00 39.88           C  
+ATOM   4018  CD2 PHE A 512      55.258  54.177  27.969  1.00 38.07           C  
+ATOM   4019  CE1 PHE A 512      52.920  52.961  28.893  1.00 39.99           C  
+ATOM   4020  CE2 PHE A 512      54.028  54.464  27.370  1.00 39.91           C  
+ATOM   4021  CZ  PHE A 512      52.853  53.852  27.834  1.00 40.25           C  
+ATOM   4022  N   ILE A 513      57.600  53.523  32.778  1.00 39.77           N  
+ATOM   4023  CA  ILE A 513      57.110  53.490  34.169  1.00 37.26           C  
+ATOM   4024  C   ILE A 513      56.768  54.855  34.788  1.00 35.36           C  
+ATOM   4025  O   ILE A 513      55.963  54.941  35.707  1.00 39.28           O  
+ATOM   4026  CB  ILE A 513      58.117  52.736  35.097  1.00 39.05           C  
+ATOM   4027  CG1 ILE A 513      57.394  52.257  36.354  1.00 39.02           C  
+ATOM   4028  CG2 ILE A 513      59.266  53.663  35.511  1.00 32.84           C  
+ATOM   4029  CD1 ILE A 513      56.231  51.298  36.091  1.00 41.72           C  
+ATOM   4030  N   ARG A 514      57.359  55.924  34.268  1.00 38.86           N  
+ATOM   4031  CA  ARG A 514      57.105  57.287  34.766  1.00 39.57           C  
+ATOM   4032  C   ARG A 514      55.629  57.657  34.742  1.00 39.39           C  
+ATOM   4033  O   ARG A 514      55.172  58.466  35.547  1.00 40.85           O  
+ATOM   4034  CB  ARG A 514      57.894  58.302  33.916  1.00 43.18           C  
+ATOM   4035  CG  ARG A 514      57.456  58.332  32.443  1.00 48.25           C  
+ATOM   4036  CD  ARG A 514      58.491  58.986  31.565  1.00 50.32           C  
+ATOM   4037  NE  ARG A 514      58.791  60.310  32.060  1.00 59.99           N  
+ATOM   4038  CZ  ARG A 514      59.871  61.005  31.729  1.00 62.26           C  
+ATOM   4039  NH1 ARG A 514      60.756  60.483  30.890  1.00 56.63           N  
+ATOM   4040  NH2 ARG A 514      60.068  62.213  32.260  1.00 61.48           N  
+ATOM   4041  N   TYR A 515      54.863  57.082  33.819  1.00 41.28           N  
+ATOM   4042  CA  TYR A 515      53.431  57.412  33.772  1.00 39.66           C  
+ATOM   4043  C   TYR A 515      52.717  56.743  34.936  1.00 37.54           C  
+ATOM   4044  O   TYR A 515      51.676  57.209  35.406  1.00 39.54           O  
+ATOM   4045  CB  TYR A 515      52.827  56.992  32.411  1.00 41.12           C  
+ATOM   4046  CG  TYR A 515      53.477  57.726  31.240  1.00 36.42           C  
+ATOM   4047  CD1 TYR A 515      53.257  59.069  31.036  1.00 37.67           C  
+ATOM   4048  CD2 TYR A 515      54.379  57.085  30.405  1.00 38.02           C  
+ATOM   4049  CE1 TYR A 515      53.920  59.764  30.032  1.00 38.05           C  
+ATOM   4050  CE2 TYR A 515      55.048  57.767  29.419  1.00 36.83           C  
+ATOM   4051  CZ  TYR A 515      54.806  59.114  29.235  1.00 38.40           C  
+ATOM   4052  OH  TYR A 515      55.437  59.791  28.222  1.00 41.18           O  
+ATOM   4053  N   TYR A 516      53.280  55.637  35.406  1.00 38.53           N  
+ATOM   4054  CA  TYR A 516      52.713  54.936  36.555  1.00 38.16           C  
+ATOM   4055  C   TYR A 516      53.030  55.759  37.810  1.00 36.03           C  
+ATOM   4056  O   TYR A 516      52.125  56.165  38.526  1.00 41.12           O  
+ATOM   4057  CB  TYR A 516      53.326  53.529  36.693  1.00 39.60           C  
+ATOM   4058  CG  TYR A 516      52.713  52.723  37.817  1.00 36.95           C  
+ATOM   4059  CD1 TYR A 516      51.573  51.955  37.606  1.00 36.95           C  
+ATOM   4060  CD2 TYR A 516      53.225  52.805  39.112  1.00 40.16           C  
+ATOM   4061  CE1 TYR A 516      50.946  51.300  38.653  1.00 40.63           C  
+ATOM   4062  CE2 TYR A 516      52.616  52.153  40.166  1.00 39.55           C  
+ATOM   4063  CZ  TYR A 516      51.477  51.406  39.938  1.00 43.00           C  
+ATOM   4064  OH  TYR A 516      50.858  50.781  41.000  1.00 45.32           O  
+ATOM   4065  N   THR A 517      54.306  56.059  38.047  1.00 36.62           N  
+ATOM   4066  CA  THR A 517      54.670  56.813  39.251  1.00 39.96           C  
+ATOM   4067  C   THR A 517      54.109  58.235  39.352  1.00 40.49           C  
+ATOM   4068  O   THR A 517      53.679  58.673  40.424  1.00 38.52           O  
+ATOM   4069  CB  THR A 517      56.196  56.879  39.430  1.00 38.19           C  
+ATOM   4070  OG1 THR A 517      56.793  57.489  38.281  1.00 40.33           O  
+ATOM   4071  CG2 THR A 517      56.767  55.461  39.624  1.00 38.02           C  
+ATOM   4072  N   ARG A 518      54.102  58.955  38.236  1.00 44.50           N  
+ATOM   4073  CA  ARG A 518      53.589  60.328  38.214  1.00 40.54           C  
+ATOM   4074  C   ARG A 518      52.120  60.358  38.639  1.00 40.32           C  
+ATOM   4075  O   ARG A 518      51.693  61.226  39.417  1.00 37.86           O  
+ATOM   4076  CB  ARG A 518      53.796  60.890  36.814  1.00 46.56           C  
+ATOM   4077  CG  ARG A 518      53.136  62.223  36.522  1.00 47.64           C  
+ATOM   4078  CD  ARG A 518      52.414  62.094  35.201  1.00 57.39           C  
+ATOM   4079  NE  ARG A 518      50.980  61.959  35.394  1.00 60.13           N  
+ATOM   4080  CZ  ARG A 518      50.122  61.610  34.440  1.00 63.16           C  
+ATOM   4081  NH1 ARG A 518      48.824  61.524  34.731  1.00 59.91           N  
+ATOM   4082  NH2 ARG A 518      50.561  61.324  33.215  1.00 54.75           N  
+ATOM   4083  N   THR A 519      51.358  59.373  38.159  1.00 40.55           N  
+ATOM   4084  CA  THR A 519      49.947  59.236  38.502  1.00 40.62           C  
+ATOM   4085  C   THR A 519      49.797  59.030  40.011  1.00 42.50           C  
+ATOM   4086  O   THR A 519      48.955  59.661  40.653  1.00 42.60           O  
+ATOM   4087  CB  THR A 519      49.286  58.009  37.823  1.00 43.38           C  
+ATOM   4088  OG1 THR A 519      49.456  58.079  36.403  1.00 39.87           O  
+ATOM   4089  CG2 THR A 519      47.814  57.960  38.183  1.00 38.13           C  
+ATOM   4090  N   LEU A 520      50.571  58.121  40.591  1.00 42.65           N  
+ATOM   4091  CA  LEU A 520      50.444  57.976  42.039  1.00 44.84           C  
+ATOM   4092  C   LEU A 520      50.953  59.255  42.729  1.00 43.52           C  
+ATOM   4093  O   LEU A 520      50.372  59.677  43.720  1.00 47.09           O  
+ATOM   4094  CB  LEU A 520      51.182  56.728  42.573  1.00 38.33           C  
+ATOM   4095  CG  LEU A 520      50.411  55.381  42.573  1.00 46.06           C  
+ATOM   4096  CD1 LEU A 520      50.049  54.984  41.111  1.00 41.82           C  
+ATOM   4097  CD2 LEU A 520      51.269  54.241  43.221  1.00 35.55           C  
+ATOM   4098  N   TYR A 521      52.004  59.898  42.215  1.00 42.18           N  
+ATOM   4099  CA  TYR A 521      52.472  61.122  42.893  1.00 41.29           C  
+ATOM   4100  C   TYR A 521      51.443  62.229  42.857  1.00 40.35           C  
+ATOM   4101  O   TYR A 521      51.172  62.869  43.882  1.00 42.14           O  
+ATOM   4102  CB  TYR A 521      53.750  61.702  42.282  1.00 38.25           C  
+ATOM   4103  CG  TYR A 521      54.940  60.817  42.304  1.00 40.64           C  
+ATOM   4104  CD1 TYR A 521      55.102  59.848  43.292  1.00 39.73           C  
+ATOM   4105  CD2 TYR A 521      55.934  60.956  41.344  1.00 38.69           C  
+ATOM   4106  CE1 TYR A 521      56.222  59.054  43.312  1.00 38.25           C  
+ATOM   4107  CE2 TYR A 521      57.044  60.165  41.366  1.00 39.22           C  
+ATOM   4108  CZ  TYR A 521      57.187  59.220  42.352  1.00 39.14           C  
+ATOM   4109  OH  TYR A 521      58.336  58.464  42.375  1.00 44.18           O  
+ATOM   4110  N   GLN A 522      50.846  62.458  41.689  1.00 40.80           N  
+ATOM   4111  CA  GLN A 522      49.875  63.537  41.602  1.00 40.88           C  
+ATOM   4112  C   GLN A 522      48.774  63.465  42.642  1.00 41.57           C  
+ATOM   4113  O   GLN A 522      48.336  64.495  43.170  1.00 43.32           O  
+ATOM   4114  CB  GLN A 522      49.277  63.647  40.186  1.00 40.84           C  
+ATOM   4115  CG  GLN A 522      48.144  62.722  39.814  1.00 44.84           C  
+ATOM   4116  CD  GLN A 522      47.740  62.910  38.350  1.00 47.64           C  
+ATOM   4117  OE1 GLN A 522      48.512  62.613  37.450  1.00 47.16           O  
+ATOM   4118  NE2 GLN A 522      46.537  63.442  38.117  1.00 49.80           N  
+ATOM   4119  N   PHE A 523      48.300  62.269  42.967  1.00 41.06           N  
+ATOM   4120  CA  PHE A 523      47.238  62.239  43.960  1.00 42.57           C  
+ATOM   4121  C   PHE A 523      47.765  62.382  45.390  1.00 39.24           C  
+ATOM   4122  O   PHE A 523      47.051  62.857  46.268  1.00 38.83           O  
+ATOM   4123  CB  PHE A 523      46.345  60.999  43.753  1.00 44.99           C  
+ATOM   4124  CG  PHE A 523      45.503  61.081  42.491  1.00 43.08           C  
+ATOM   4125  CD1 PHE A 523      44.504  62.034  42.376  1.00 41.33           C  
+ATOM   4126  CD2 PHE A 523      45.756  60.249  41.405  1.00 45.92           C  
+ATOM   4127  CE1 PHE A 523      43.763  62.172  41.197  1.00 43.92           C  
+ATOM   4128  CE2 PHE A 523      45.020  60.379  40.222  1.00 49.12           C  
+ATOM   4129  CZ  PHE A 523      44.017  61.352  40.126  1.00 44.02           C  
+ATOM   4130  N   GLN A 524      49.021  62.012  45.610  1.00 41.76           N  
+ATOM   4131  CA  GLN A 524      49.633  62.172  46.939  1.00 44.00           C  
+ATOM   4132  C   GLN A 524      49.790  63.685  47.161  1.00 43.12           C  
+ATOM   4133  O   GLN A 524      49.417  64.210  48.202  1.00 43.47           O  
+ATOM   4134  CB  GLN A 524      51.001  61.467  46.996  1.00 42.14           C  
+ATOM   4135  CG  GLN A 524      50.895  59.939  46.947  1.00 44.92           C  
+ATOM   4136  CD  GLN A 524      52.243  59.245  47.060  1.00 48.60           C  
+ATOM   4137  OE1 GLN A 524      52.935  59.372  48.070  1.00 53.07           O  
+ATOM   4138  NE2 GLN A 524      52.622  58.511  46.026  1.00 41.42           N  
+ATOM   4139  N   PHE A 525      50.312  64.378  46.149  1.00 44.61           N  
+ATOM   4140  CA  PHE A 525      50.475  65.815  46.217  1.00 39.76           C  
+ATOM   4141  C   PHE A 525      49.131  66.454  46.460  1.00 44.28           C  
+ATOM   4142  O   PHE A 525      48.981  67.278  47.376  1.00 48.75           O  
+ATOM   4143  CB  PHE A 525      51.012  66.403  44.906  1.00 39.24           C  
+ATOM   4144  CG  PHE A 525      52.391  65.988  44.569  1.00 39.94           C  
+ATOM   4145  CD1 PHE A 525      53.177  65.319  45.491  1.00 39.14           C  
+ATOM   4146  CD2 PHE A 525      52.911  66.251  43.315  1.00 41.28           C  
+ATOM   4147  CE1 PHE A 525      54.462  64.914  45.163  1.00 39.26           C  
+ATOM   4148  CE2 PHE A 525      54.190  65.851  42.982  1.00 42.53           C  
+ATOM   4149  CZ  PHE A 525      54.969  65.174  43.917  1.00 42.12           C  
+ATOM   4150  N   GLN A 526      48.146  66.095  45.634  1.00 44.91           N  
+ATOM   4151  CA  GLN A 526      46.818  66.704  45.757  1.00 42.43           C  
+ATOM   4152  C   GLN A 526      46.150  66.434  47.091  1.00 39.51           C  
+ATOM   4153  O   GLN A 526      45.497  67.328  47.641  1.00 40.89           O  
+ATOM   4154  CB  GLN A 526      45.894  66.252  44.613  1.00 45.33           C  
+ATOM   4155  CG  GLN A 526      44.534  66.977  44.559  1.00 43.44           C  
+ATOM   4156  CD  GLN A 526      44.662  68.461  44.176  1.00 46.12           C  
+ATOM   4157  OE1 GLN A 526      43.664  69.148  43.919  1.00 50.15           O  
+ATOM   4158  NE2 GLN A 526      45.886  68.949  44.138  1.00 45.40           N  
+ATOM   4159  N   GLU A 527      46.275  65.215  47.609  1.00 39.17           N  
+ATOM   4160  CA  GLU A 527      45.665  64.933  48.911  1.00 42.57           C  
+ATOM   4161  C   GLU A 527      46.388  65.804  49.951  1.00 44.49           C  
+ATOM   4162  O   GLU A 527      45.749  66.449  50.787  1.00 46.60           O  
+ATOM   4163  CB  GLU A 527      45.785  63.452  49.296  1.00 43.81           C  
+ATOM   4164  CG  GLU A 527      44.940  63.097  50.523  1.00 48.81           C  
+ATOM   4165  CD  GLU A 527      44.843  61.601  50.785  1.00 56.67           C  
+ATOM   4166  OE1 GLU A 527      45.802  61.025  51.349  1.00 61.35           O  
+ATOM   4167  OE2 GLU A 527      43.803  60.994  50.423  1.00 58.93           O  
+ATOM   4168  N   ALA A 528      47.714  65.866  49.850  1.00 43.11           N  
+ATOM   4169  CA  ALA A 528      48.501  66.667  50.777  1.00 46.06           C  
+ATOM   4170  C   ALA A 528      48.151  68.149  50.722  1.00 47.90           C  
+ATOM   4171  O   ALA A 528      47.879  68.770  51.752  1.00 49.98           O  
+ATOM   4172  CB  ALA A 528      49.985  66.468  50.507  1.00 45.59           C  
+ATOM   4173  N   LEU A 529      48.155  68.735  49.528  1.00 50.33           N  
+ATOM   4174  CA  LEU A 529      47.835  70.151  49.410  1.00 48.41           C  
+ATOM   4175  C   LEU A 529      46.434  70.464  49.879  1.00 47.07           C  
+ATOM   4176  O   LEU A 529      46.206  71.477  50.512  1.00 50.21           O  
+ATOM   4177  CB  LEU A 529      48.018  70.639  47.969  1.00 50.22           C  
+ATOM   4178  CG  LEU A 529      49.445  71.001  47.529  1.00 51.23           C  
+ATOM   4179  CD1 LEU A 529      50.414  70.925  48.708  1.00 50.84           C  
+ATOM   4180  CD2 LEU A 529      49.889  70.062  46.441  1.00 52.81           C  
+ATOM   4181  N   CYS A 530      45.485  69.592  49.578  1.00 51.62           N  
+ATOM   4182  CA  CYS A 530      44.108  69.819  49.992  1.00 51.41           C  
+ATOM   4183  C   CYS A 530      43.916  69.699  51.507  1.00 50.11           C  
+ATOM   4184  O   CYS A 530      43.069  70.382  52.090  1.00 47.85           O  
+ATOM   4185  CB  CYS A 530      43.185  68.864  49.228  1.00 55.57           C  
+ATOM   4186  SG  CYS A 530      43.164  69.357  47.473  1.00 67.05           S  
+ATOM   4187  N   GLN A 531      44.667  68.818  52.151  1.00 48.89           N  
+ATOM   4188  CA  GLN A 531      44.547  68.734  53.594  1.00 54.61           C  
+ATOM   4189  C   GLN A 531      45.114  70.043  54.140  1.00 57.14           C  
+ATOM   4190  O   GLN A 531      44.587  70.593  55.100  1.00 57.27           O  
+ATOM   4191  CB  GLN A 531      45.310  67.523  54.153  1.00 58.79           C  
+ATOM   4192  CG  GLN A 531      44.616  66.185  53.805  1.00 70.39           C  
+ATOM   4193  CD  GLN A 531      45.078  64.994  54.649  1.00 73.73           C  
+ATOM   4194  OE1 GLN A 531      44.521  63.894  54.540  1.00 70.32           O  
+ATOM   4195  NE2 GLN A 531      46.095  65.210  55.488  1.00 74.58           N  
+ATOM   4196  N   ALA A 532      46.163  70.558  53.498  1.00 56.76           N  
+ATOM   4197  CA  ALA A 532      46.780  71.804  53.928  1.00 57.48           C  
+ATOM   4198  C   ALA A 532      45.901  72.983  53.592  1.00 59.00           C  
+ATOM   4199  O   ALA A 532      46.151  74.096  54.052  1.00 62.93           O  
+ATOM   4200  CB  ALA A 532      48.132  71.980  53.274  1.00 56.88           C  
+ATOM   4201  N   ALA A 533      44.875  72.747  52.781  1.00 56.82           N  
+ATOM   4202  CA  ALA A 533      43.964  73.813  52.403  1.00 54.81           C  
+ATOM   4203  C   ALA A 533      42.667  73.702  53.200  1.00 55.22           C  
+ATOM   4204  O   ALA A 533      41.714  74.460  52.990  1.00 53.49           O  
+ATOM   4205  CB  ALA A 533      43.685  73.748  50.916  1.00 54.92           C  
+ATOM   4206  N   LYS A 534      42.638  72.747  54.122  1.00 56.56           N  
+ATOM   4207  CA  LYS A 534      41.465  72.525  54.964  1.00 57.72           C  
+ATOM   4208  C   LYS A 534      40.233  72.160  54.117  1.00 58.05           C  
+ATOM   4209  O   LYS A 534      39.111  72.577  54.430  1.00 53.36           O  
+ATOM   4210  CB  LYS A 534      41.167  73.785  55.794  1.00 61.07           C  
+ATOM   4211  CG  LYS A 534      42.398  74.640  56.131  1.00 66.38           C  
+ATOM   4212  CD  LYS A 534      43.215  74.076  57.289  1.00 72.54           C  
+ATOM   4213  CE  LYS A 534      42.679  74.559  58.640  1.00 76.04           C  
+ATOM   4214  NZ  LYS A 534      41.251  74.183  58.886  1.00 79.30           N  
+ATOM   4215  N   HIS A 535      40.442  71.393  53.043  1.00 56.61           N  
+ATOM   4216  CA  HIS A 535      39.327  70.976  52.191  1.00 55.57           C  
+ATOM   4217  C   HIS A 535      38.428  70.024  52.970  1.00 56.73           C  
+ATOM   4218  O   HIS A 535      38.920  69.117  53.636  1.00 54.92           O  
+ATOM   4219  CB  HIS A 535      39.832  70.265  50.939  1.00 54.43           C  
+ATOM   4220  CG  HIS A 535      38.735  69.734  50.075  1.00 51.18           C  
+ATOM   4221  ND1 HIS A 535      37.775  70.548  49.512  1.00 47.53           N  
+ATOM   4222  CD2 HIS A 535      38.426  68.470  49.699  1.00 49.23           C  
+ATOM   4223  CE1 HIS A 535      36.923  69.809  48.825  1.00 48.54           C  
+ATOM   4224  NE2 HIS A 535      37.295  68.544  48.922  1.00 48.42           N  
+ATOM   4225  N   GLU A 536      37.114  70.206  52.859  1.00 60.54           N  
+ATOM   4226  CA  GLU A 536      36.177  69.375  53.609  1.00 63.97           C  
+ATOM   4227  C   GLU A 536      35.621  68.094  52.979  1.00 64.96           C  
+ATOM   4228  O   GLU A 536      35.797  67.003  53.537  1.00 68.89           O  
+ATOM   4229  CB  GLU A 536      34.992  70.224  54.099  1.00 66.60           C  
+ATOM   4230  CG  GLU A 536      35.376  71.459  54.909  1.00 74.65           C  
+ATOM   4231  CD  GLU A 536      35.402  72.731  54.063  1.00 83.24           C  
+ATOM   4232  OE1 GLU A 536      36.149  72.762  53.054  1.00 86.07           O  
+ATOM   4233  OE2 GLU A 536      34.672  73.696  54.403  1.00 84.28           O  
+ATOM   4234  N   GLY A 537      34.936  68.198  51.846  1.00 58.67           N  
+ATOM   4235  CA  GLY A 537      34.361  66.988  51.273  1.00 57.68           C  
+ATOM   4236  C   GLY A 537      35.285  66.042  50.516  1.00 55.35           C  
+ATOM   4237  O   GLY A 537      36.480  65.953  50.803  1.00 55.05           O  
+ATOM   4238  N   PRO A 538      34.742  65.321  49.527  1.00 51.36           N  
+ATOM   4239  CA  PRO A 538      35.468  64.363  48.685  1.00 49.09           C  
+ATOM   4240  C   PRO A 538      36.681  65.026  48.011  1.00 48.18           C  
+ATOM   4241  O   PRO A 538      36.596  66.150  47.511  1.00 44.86           O  
+ATOM   4242  CB  PRO A 538      34.412  63.935  47.659  1.00 50.54           C  
+ATOM   4243  CG  PRO A 538      33.120  64.134  48.376  1.00 52.52           C  
+ATOM   4244  CD  PRO A 538      33.337  65.438  49.099  1.00 52.45           C  
+ATOM   4245  N   LEU A 539      37.802  64.320  47.986  1.00 44.65           N  
+ATOM   4246  CA  LEU A 539      39.013  64.852  47.392  1.00 45.92           C  
+ATOM   4247  C   LEU A 539      38.838  65.409  45.974  1.00 46.94           C  
+ATOM   4248  O   LEU A 539      39.433  66.443  45.652  1.00 44.13           O  
+ATOM   4249  CB  LEU A 539      40.107  63.774  47.408  1.00 42.31           C  
+ATOM   4250  CG  LEU A 539      41.479  64.076  46.830  1.00 45.59           C  
+ATOM   4251  CD1 LEU A 539      42.130  65.237  47.585  1.00 38.94           C  
+ATOM   4252  CD2 LEU A 539      42.343  62.811  46.920  1.00 47.79           C  
+ATOM   4253  N   HIS A 540      38.017  64.781  45.126  1.00 45.97           N  
+ATOM   4254  CA  HIS A 540      37.904  65.298  43.752  1.00 47.16           C  
+ATOM   4255  C   HIS A 540      37.279  66.670  43.588  1.00 46.49           C  
+ATOM   4256  O   HIS A 540      37.349  67.240  42.509  1.00 52.46           O  
+ATOM   4257  CB  HIS A 540      37.196  64.300  42.809  1.00 44.10           C  
+ATOM   4258  CG  HIS A 540      35.709  64.279  42.931  1.00 43.40           C  
+ATOM   4259  ND1 HIS A 540      35.047  63.595  43.933  1.00 45.98           N  
+ATOM   4260  CD2 HIS A 540      34.748  64.845  42.163  1.00 44.25           C  
+ATOM   4261  CE1 HIS A 540      33.743  63.740  43.773  1.00 45.42           C  
+ATOM   4262  NE2 HIS A 540      33.535  64.494  42.707  1.00 45.90           N  
+ATOM   4263  N   LYS A 541      36.703  67.220  44.650  1.00 48.51           N  
+ATOM   4264  CA  LYS A 541      36.061  68.533  44.572  1.00 51.06           C  
+ATOM   4265  C   LYS A 541      36.982  69.647  45.059  1.00 53.19           C  
+ATOM   4266  O   LYS A 541      36.614  70.817  45.057  1.00 51.84           O  
+ATOM   4267  CB  LYS A 541      34.797  68.544  45.434  1.00 51.24           C  
+ATOM   4268  CG  LYS A 541      33.939  67.309  45.263  1.00 55.27           C  
+ATOM   4269  CD  LYS A 541      32.536  67.666  44.853  1.00 59.38           C  
+ATOM   4270  CE  LYS A 541      31.833  68.440  45.936  1.00 58.91           C  
+ATOM   4271  NZ  LYS A 541      30.414  68.702  45.578  1.00 63.15           N  
+ATOM   4272  N   CYS A 542      38.186  69.276  45.470  1.00 54.75           N  
+ATOM   4273  CA  CYS A 542      39.117  70.245  46.014  1.00 56.00           C  
+ATOM   4274  C   CYS A 542      39.697  71.277  45.058  1.00 57.58           C  
+ATOM   4275  O   CYS A 542      39.944  71.018  43.876  1.00 56.52           O  
+ATOM   4276  CB  CYS A 542      40.249  69.511  46.735  1.00 57.21           C  
+ATOM   4277  SG  CYS A 542      41.567  70.603  47.348  1.00 61.18           S  
+ATOM   4278  N   ASP A 543      39.910  72.465  45.603  1.00 55.45           N  
+ATOM   4279  CA  ASP A 543      40.493  73.572  44.863  1.00 55.34           C  
+ATOM   4280  C   ASP A 543      41.520  74.167  45.829  1.00 53.14           C  
+ATOM   4281  O   ASP A 543      41.173  74.532  46.949  1.00 54.77           O  
+ATOM   4282  CB  ASP A 543      39.405  74.589  44.526  1.00 55.00           C  
+ATOM   4283  CG  ASP A 543      39.917  75.731  43.673  1.00 58.54           C  
+ATOM   4284  OD1 ASP A 543      41.102  75.690  43.258  1.00 57.09           O  
+ATOM   4285  OD2 ASP A 543      39.127  76.667  43.414  1.00 58.07           O  
+ATOM   4286  N   ILE A 544      42.781  74.257  45.432  1.00 52.36           N  
+ATOM   4287  CA  ILE A 544      43.761  74.794  46.367  1.00 54.83           C  
+ATOM   4288  C   ILE A 544      43.934  76.308  46.379  1.00 57.08           C  
+ATOM   4289  O   ILE A 544      44.799  76.812  47.104  1.00 58.00           O  
+ATOM   4290  CB  ILE A 544      45.147  74.173  46.162  1.00 52.64           C  
+ATOM   4291  CG1 ILE A 544      45.727  74.590  44.816  1.00 50.82           C  
+ATOM   4292  CG2 ILE A 544      45.044  72.679  46.256  1.00 55.60           C  
+ATOM   4293  CD1 ILE A 544      47.171  74.146  44.621  1.00 49.72           C  
+ATOM   4294  N   SER A 545      43.120  77.023  45.596  1.00 56.05           N  
+ATOM   4295  CA  SER A 545      43.185  78.487  45.514  1.00 57.98           C  
+ATOM   4296  C   SER A 545      43.037  79.140  46.877  1.00 59.00           C  
+ATOM   4297  O   SER A 545      42.267  78.671  47.696  1.00 57.95           O  
+ATOM   4298  CB  SER A 545      42.072  79.027  44.616  1.00 55.89           C  
+ATOM   4299  OG  SER A 545      42.162  78.504  43.312  1.00 56.83           O  
+ATOM   4300  N   ASN A 546      43.762  80.236  47.094  1.00 62.68           N  
+ATOM   4301  CA  ASN A 546      43.715  80.986  48.351  1.00 63.80           C  
+ATOM   4302  C   ASN A 546      44.548  80.362  49.454  1.00 63.03           C  
+ATOM   4303  O   ASN A 546      44.780  80.991  50.482  1.00 64.16           O  
+ATOM   4304  CB  ASN A 546      42.295  81.087  48.902  1.00 68.62           C  
+ATOM   4305  CG  ASN A 546      41.433  82.098  48.187  1.00 75.80           C  
+ATOM   4306  OD1 ASN A 546      40.362  82.436  48.705  1.00 79.22           O  
+ATOM   4307  ND2 ASN A 546      41.844  82.583  47.020  1.00 78.46           N  
+ATOM   4308  N   SER A 547      44.983  79.126  49.277  1.00 58.68           N  
+ATOM   4309  CA  SER A 547      45.749  78.502  50.340  1.00 57.77           C  
+ATOM   4310  C   SER A 547      47.258  78.694  50.241  1.00 59.94           C  
+ATOM   4311  O   SER A 547      47.931  77.972  49.507  1.00 62.23           O  
+ATOM   4312  CB  SER A 547      45.421  77.013  50.412  1.00 54.33           C  
+ATOM   4313  OG  SER A 547      46.085  76.395  51.493  1.00 52.33           O  
+ATOM   4314  N   THR A 548      47.787  79.665  50.985  1.00 58.86           N  
+ATOM   4315  CA  THR A 548      49.228  79.908  50.993  1.00 60.36           C  
+ATOM   4316  C   THR A 548      49.880  78.767  51.776  1.00 60.38           C  
+ATOM   4317  O   THR A 548      51.071  78.491  51.635  1.00 61.87           O  
+ATOM   4318  CB  THR A 548      49.601  81.267  51.665  1.00 59.47           C  
+ATOM   4319  OG1 THR A 548      49.018  81.332  52.963  1.00 60.16           O  
+ATOM   4320  CG2 THR A 548      49.093  82.444  50.843  1.00 62.16           C  
+ATOM   4321  N   GLU A 549      49.099  78.087  52.599  1.00 58.69           N  
+ATOM   4322  CA  GLU A 549      49.663  76.978  53.344  1.00 62.33           C  
+ATOM   4323  C   GLU A 549      49.932  75.836  52.350  1.00 60.39           C  
+ATOM   4324  O   GLU A 549      50.895  75.082  52.487  1.00 59.03           O  
+ATOM   4325  CB  GLU A 549      48.690  76.529  54.438  1.00 68.96           C  
+ATOM   4326  CG  GLU A 549      49.390  75.917  55.637  1.00 79.45           C  
+ATOM   4327  CD  GLU A 549      50.340  76.900  56.315  1.00 85.16           C  
+ATOM   4328  OE1 GLU A 549      49.852  77.926  56.843  1.00 87.99           O  
+ATOM   4329  OE2 GLU A 549      51.569  76.652  56.314  1.00 87.59           O  
+ATOM   4330  N   ALA A 550      49.074  75.726  51.341  1.00 58.48           N  
+ATOM   4331  CA  ALA A 550      49.223  74.699  50.321  1.00 57.12           C  
+ATOM   4332  C   ALA A 550      50.406  75.058  49.437  1.00 54.87           C  
+ATOM   4333  O   ALA A 550      51.285  74.230  49.187  1.00 55.90           O  
+ATOM   4334  CB  ALA A 550      47.950  74.602  49.486  1.00 57.90           C  
+ATOM   4335  N   GLY A 551      50.424  76.307  48.977  1.00 55.39           N  
+ATOM   4336  CA  GLY A 551      51.504  76.787  48.130  1.00 51.72           C  
+ATOM   4337  C   GLY A 551      52.867  76.750  48.807  1.00 53.96           C  
+ATOM   4338  O   GLY A 551      53.896  76.630  48.138  1.00 54.08           O  
+ATOM   4339  N   GLN A 552      52.892  76.854  50.132  1.00 52.93           N  
+ATOM   4340  CA  GLN A 552      54.164  76.814  50.848  1.00 55.84           C  
+ATOM   4341  C   GLN A 552      54.692  75.386  50.854  1.00 55.57           C  
+ATOM   4342  O   GLN A 552      55.865  75.152  50.560  1.00 55.43           O  
+ATOM   4343  CB  GLN A 552      54.006  77.297  52.291  1.00 56.12           C  
+ATOM   4344  CG  GLN A 552      55.300  77.180  53.094  1.00 60.75           C  
+ATOM   4345  CD  GLN A 552      56.421  78.053  52.535  1.00 64.43           C  
+ATOM   4346  OE1 GLN A 552      56.290  79.280  52.472  1.00 67.54           O  
+ATOM   4347  NE2 GLN A 552      57.526  77.425  52.123  1.00 61.23           N  
+ATOM   4348  N   LYS A 553      53.821  74.437  51.202  1.00 55.80           N  
+ATOM   4349  CA  LYS A 553      54.208  73.033  51.214  1.00 55.95           C  
+ATOM   4350  C   LYS A 553      54.669  72.627  49.816  1.00 55.02           C  
+ATOM   4351  O   LYS A 553      55.657  71.914  49.667  1.00 52.99           O  
+ATOM   4352  CB  LYS A 553      53.034  72.142  51.644  1.00 59.84           C  
+ATOM   4353  CG  LYS A 553      52.674  72.246  53.119  1.00 66.43           C  
+ATOM   4354  CD  LYS A 553      51.879  71.032  53.556  1.00 68.82           C  
+ATOM   4355  CE  LYS A 553      52.670  69.772  53.268  1.00 70.10           C  
+ATOM   4356  NZ  LYS A 553      53.925  69.719  54.082  1.00 72.71           N  
+ATOM   4357  N   LEU A 554      53.955  73.085  48.790  1.00 52.89           N  
+ATOM   4358  CA  LEU A 554      54.321  72.749  47.424  1.00 53.02           C  
+ATOM   4359  C   LEU A 554      55.709  73.311  47.122  1.00 51.95           C  
+ATOM   4360  O   LEU A 554      56.601  72.602  46.639  1.00 51.27           O  
+ATOM   4361  CB  LEU A 554      53.287  73.322  46.448  1.00 52.11           C  
+ATOM   4362  CG  LEU A 554      53.443  73.047  44.948  1.00 54.18           C  
+ATOM   4363  CD1 LEU A 554      53.624  71.569  44.668  1.00 48.68           C  
+ATOM   4364  CD2 LEU A 554      52.216  73.555  44.243  1.00 52.00           C  
+ATOM   4365  N   PHE A 555      55.896  74.584  47.438  1.00 51.50           N  
+ATOM   4366  CA  PHE A 555      57.168  75.250  47.177  1.00 53.64           C  
+ATOM   4367  C   PHE A 555      58.397  74.671  47.890  1.00 54.07           C  
+ATOM   4368  O   PHE A 555      59.510  74.800  47.400  1.00 56.89           O  
+ATOM   4369  CB  PHE A 555      57.038  76.743  47.490  1.00 53.16           C  
+ATOM   4370  CG  PHE A 555      58.267  77.538  47.171  1.00 54.89           C  
+ATOM   4371  CD1 PHE A 555      59.305  77.647  48.094  1.00 54.25           C  
+ATOM   4372  CD2 PHE A 555      58.386  78.188  45.948  1.00 53.87           C  
+ATOM   4373  CE1 PHE A 555      60.432  78.394  47.801  1.00 55.78           C  
+ATOM   4374  CE2 PHE A 555      59.513  78.936  45.648  1.00 54.19           C  
+ATOM   4375  CZ  PHE A 555      60.538  79.042  46.575  1.00 52.72           C  
+ATOM   4376  N   ASN A 556      58.208  74.040  49.041  1.00 56.71           N  
+ATOM   4377  CA  ASN A 556      59.340  73.462  49.767  1.00 56.23           C  
+ATOM   4378  C   ASN A 556      60.015  72.353  48.972  1.00 54.88           C  
+ATOM   4379  O   ASN A 556      61.221  72.136  49.107  1.00 55.83           O  
+ATOM   4380  CB  ASN A 556      58.893  72.914  51.128  1.00 58.84           C  
+ATOM   4381  CG  ASN A 556      58.552  74.017  52.118  1.00 63.17           C  
+ATOM   4382  OD1 ASN A 556      57.989  73.758  53.194  1.00 61.68           O  
+ATOM   4383  ND2 ASN A 556      58.896  75.258  51.763  1.00 59.08           N  
+ATOM   4384  N   MET A 557      59.252  71.629  48.155  1.00 52.24           N  
+ATOM   4385  CA  MET A 557      59.871  70.578  47.355  1.00 48.30           C  
+ATOM   4386  C   MET A 557      60.223  71.104  45.965  1.00 44.96           C  
+ATOM   4387  O   MET A 557      61.180  70.650  45.339  1.00 45.48           O  
+ATOM   4388  CB  MET A 557      58.955  69.359  47.254  1.00 47.90           C  
+ATOM   4389  CG  MET A 557      57.891  69.481  46.239  1.00 56.75           C  
+ATOM   4390  SD  MET A 557      58.402  68.991  44.574  1.00 54.16           S  
+ATOM   4391  CE  MET A 557      56.770  68.899  43.867  1.00 48.24           C  
+ATOM   4392  N   LEU A 558      59.453  72.075  45.493  1.00 45.72           N  
+ATOM   4393  CA  LEU A 558      59.672  72.681  44.183  1.00 45.76           C  
+ATOM   4394  C   LEU A 558      61.078  73.336  44.059  1.00 47.96           C  
+ATOM   4395  O   LEU A 558      61.806  73.112  43.082  1.00 42.81           O  
+ATOM   4396  CB  LEU A 558      58.573  73.727  43.948  1.00 46.09           C  
+ATOM   4397  CG  LEU A 558      57.546  73.625  42.815  1.00 47.84           C  
+ATOM   4398  CD1 LEU A 558      56.950  72.244  42.715  1.00 43.83           C  
+ATOM   4399  CD2 LEU A 558      56.455  74.627  43.048  1.00 43.68           C  
+ATOM   4400  N   ARG A 559      61.476  74.128  45.056  1.00 49.09           N  
+ATOM   4401  CA  ARG A 559      62.777  74.802  44.989  1.00 50.39           C  
+ATOM   4402  C   ARG A 559      63.958  73.846  45.103  1.00 47.39           C  
+ATOM   4403  O   ARG A 559      65.086  74.210  44.806  1.00 46.88           O  
+ATOM   4404  CB  ARG A 559      62.886  75.899  46.063  1.00 53.66           C  
+ATOM   4405  CG  ARG A 559      62.940  75.374  47.476  1.00 60.10           C  
+ATOM   4406  CD  ARG A 559      63.543  76.391  48.449  1.00 64.36           C  
+ATOM   4407  NE  ARG A 559      64.195  75.673  49.542  1.00 71.76           N  
+ATOM   4408  CZ  ARG A 559      65.454  75.231  49.522  1.00 72.58           C  
+ATOM   4409  NH1 ARG A 559      66.237  75.447  48.473  1.00 71.53           N  
+ATOM   4410  NH2 ARG A 559      65.920  74.520  50.541  1.00 75.90           N  
+ATOM   4411  N   LEU A 560      63.698  72.612  45.508  1.00 46.14           N  
+ATOM   4412  CA  LEU A 560      64.761  71.621  45.641  1.00 44.69           C  
+ATOM   4413  C   LEU A 560      65.329  71.171  44.293  1.00 46.07           C  
+ATOM   4414  O   LEU A 560      66.509  70.776  44.186  1.00 46.07           O  
+ATOM   4415  CB  LEU A 560      64.214  70.394  46.375  1.00 48.09           C  
+ATOM   4416  CG  LEU A 560      64.383  70.192  47.898  1.00 54.69           C  
+ATOM   4417  CD1 LEU A 560      64.996  71.414  48.590  1.00 49.53           C  
+ATOM   4418  CD2 LEU A 560      63.044  69.842  48.476  1.00 48.80           C  
+ATOM   4419  N   GLY A 561      64.498  71.219  43.253  1.00 39.45           N  
+ATOM   4420  CA  GLY A 561      64.971  70.723  41.987  1.00 37.94           C  
+ATOM   4421  C   GLY A 561      65.333  69.273  42.252  1.00 37.45           C  
+ATOM   4422  O   GLY A 561      64.569  68.532  42.858  1.00 36.98           O  
+ATOM   4423  N   LYS A 562      66.490  68.854  41.781  1.00 38.19           N  
+ATOM   4424  CA  LYS A 562      66.941  67.495  42.017  1.00 44.34           C  
+ATOM   4425  C   LYS A 562      68.141  67.499  43.002  1.00 42.75           C  
+ATOM   4426  O   LYS A 562      68.981  66.608  42.950  1.00 41.94           O  
+ATOM   4427  CB  LYS A 562      67.371  66.840  40.690  1.00 46.28           C  
+ATOM   4428  CG  LYS A 562      66.774  65.461  40.480  1.00 54.51           C  
+ATOM   4429  CD  LYS A 562      67.676  64.521  39.651  1.00 62.53           C  
+ATOM   4430  CE  LYS A 562      68.064  65.121  38.309  1.00 64.31           C  
+ATOM   4431  NZ  LYS A 562      68.938  66.313  38.475  1.00 61.62           N  
+ATOM   4432  N   SER A 563      68.218  68.500  43.878  1.00 44.44           N  
+ATOM   4433  CA  SER A 563      69.325  68.583  44.848  1.00 50.31           C  
+ATOM   4434  C   SER A 563      69.152  67.634  46.043  1.00 52.33           C  
+ATOM   4435  O   SER A 563      70.096  67.389  46.785  1.00 54.37           O  
+ATOM   4436  CB  SER A 563      69.477  70.011  45.383  1.00 45.95           C  
+ATOM   4437  OG  SER A 563      68.396  70.356  46.231  1.00 48.58           O  
+ATOM   4438  N   GLU A 564      67.947  67.107  46.232  1.00 53.69           N  
+ATOM   4439  CA  GLU A 564      67.689  66.190  47.330  1.00 54.39           C  
+ATOM   4440  C   GLU A 564      67.147  64.883  46.786  1.00 55.43           C  
+ATOM   4441  O   GLU A 564      66.742  64.812  45.636  1.00 57.97           O  
+ATOM   4442  CB  GLU A 564      66.681  66.809  48.303  1.00 52.85           C  
+ATOM   4443  CG  GLU A 564      67.224  68.027  49.046  1.00 58.57           C  
+ATOM   4444  CD  GLU A 564      68.500  67.691  49.843  1.00 62.00           C  
+ATOM   4445  OE1 GLU A 564      68.418  66.881  50.790  1.00 58.98           O  
+ATOM   4446  OE2 GLU A 564      69.583  68.222  49.509  1.00 64.60           O  
+ATOM   4447  N   PRO A 565      67.166  63.817  47.597  1.00 54.94           N  
+ATOM   4448  CA  PRO A 565      66.638  62.542  47.107  1.00 50.19           C  
+ATOM   4449  C   PRO A 565      65.157  62.793  46.840  1.00 47.21           C  
+ATOM   4450  O   PRO A 565      64.525  63.575  47.565  1.00 42.02           O  
+ATOM   4451  CB  PRO A 565      66.854  61.594  48.292  1.00 51.75           C  
+ATOM   4452  CG  PRO A 565      68.063  62.178  48.979  1.00 54.61           C  
+ATOM   4453  CD  PRO A 565      67.802  63.664  48.918  1.00 53.80           C  
+ATOM   4454  N   TRP A 566      64.598  62.151  45.811  1.00 46.90           N  
+ATOM   4455  CA  TRP A 566      63.181  62.362  45.498  1.00 42.32           C  
+ATOM   4456  C   TRP A 566      62.342  61.915  46.693  1.00 43.44           C  
+ATOM   4457  O   TRP A 566      61.276  62.483  46.976  1.00 43.55           O  
+ATOM   4458  CB  TRP A 566      62.767  61.583  44.235  1.00 41.14           C  
+ATOM   4459  CG  TRP A 566      62.838  60.090  44.356  1.00 30.89           C  
+ATOM   4460  CD1 TRP A 566      63.866  59.297  43.980  1.00 30.32           C  
+ATOM   4461  CD2 TRP A 566      61.811  59.219  44.858  1.00 27.06           C  
+ATOM   4462  NE1 TRP A 566      63.549  57.978  44.211  1.00 35.74           N  
+ATOM   4463  CE2 TRP A 566      62.289  57.908  44.747  1.00 32.96           C  
+ATOM   4464  CE3 TRP A 566      60.537  59.428  45.388  1.00 33.45           C  
+ATOM   4465  CZ2 TRP A 566      61.531  56.795  45.135  1.00 34.22           C  
+ATOM   4466  CZ3 TRP A 566      59.784  58.319  45.779  1.00 35.95           C  
+ATOM   4467  CH2 TRP A 566      60.289  57.024  45.647  1.00 33.51           C  
+ATOM   4468  N   THR A 567      62.831  60.902  47.399  1.00 42.59           N  
+ATOM   4469  CA  THR A 567      62.143  60.405  48.593  1.00 45.49           C  
+ATOM   4470  C   THR A 567      61.969  61.517  49.641  1.00 44.88           C  
+ATOM   4471  O   THR A 567      61.018  61.521  50.401  1.00 48.47           O  
+ATOM   4472  CB  THR A 567      62.936  59.253  49.247  1.00 45.91           C  
+ATOM   4473  OG1 THR A 567      64.284  59.682  49.499  1.00 49.11           O  
+ATOM   4474  CG2 THR A 567      62.950  58.054  48.339  1.00 46.07           C  
+ATOM   4475  N   LEU A 568      62.900  62.456  49.676  1.00 47.32           N  
+ATOM   4476  CA  LEU A 568      62.828  63.565  50.615  1.00 47.97           C  
+ATOM   4477  C   LEU A 568      61.940  64.683  50.054  1.00 47.88           C  
+ATOM   4478  O   LEU A 568      61.179  65.317  50.795  1.00 48.40           O  
+ATOM   4479  CB  LEU A 568      64.246  64.097  50.894  1.00 49.82           C  
+ATOM   4480  CG  LEU A 568      64.416  65.125  52.019  1.00 54.93           C  
+ATOM   4481  CD1 LEU A 568      65.911  65.277  52.328  1.00 55.24           C  
+ATOM   4482  CD2 LEU A 568      63.805  66.471  51.616  1.00 53.63           C  
+ATOM   4483  N   ALA A 569      62.051  64.948  48.751  1.00 47.27           N  
+ATOM   4484  CA  ALA A 569      61.211  65.977  48.135  1.00 43.99           C  
+ATOM   4485  C   ALA A 569      59.760  65.569  48.313  1.00 39.35           C  
+ATOM   4486  O   ALA A 569      58.915  66.380  48.618  1.00 41.07           O  
+ATOM   4487  CB  ALA A 569      61.547  66.123  46.663  1.00 46.66           C  
+ATOM   4488  N   LEU A 570      59.463  64.292  48.136  1.00 43.24           N  
+ATOM   4489  CA  LEU A 570      58.091  63.812  48.327  1.00 43.46           C  
+ATOM   4490  C   LEU A 570      57.677  64.094  49.763  1.00 45.23           C  
+ATOM   4491  O   LEU A 570      56.610  64.672  50.040  1.00 43.74           O  
+ATOM   4492  CB  LEU A 570      58.034  62.296  48.112  1.00 44.70           C  
+ATOM   4493  CG  LEU A 570      56.842  61.659  47.403  1.00 46.03           C  
+ATOM   4494  CD1 LEU A 570      56.776  60.207  47.819  1.00 45.12           C  
+ATOM   4495  CD2 LEU A 570      55.565  62.376  47.727  1.00 43.25           C  
+ATOM   4496  N   GLU A 571      58.530  63.648  50.686  1.00 48.36           N  
+ATOM   4497  CA  GLU A 571      58.272  63.822  52.117  1.00 52.89           C  
+ATOM   4498  C   GLU A 571      57.994  65.271  52.475  1.00 50.30           C  
+ATOM   4499  O   GLU A 571      57.086  65.558  53.242  1.00 50.92           O  
+ATOM   4500  CB  GLU A 571      59.452  63.305  52.955  1.00 56.16           C  
+ATOM   4501  CG  GLU A 571      59.181  63.332  54.468  1.00 61.98           C  
+ATOM   4502  CD  GLU A 571      60.382  62.880  55.290  1.00 63.85           C  
+ATOM   4503  OE1 GLU A 571      61.405  63.598  55.309  1.00 63.45           O  
+ATOM   4504  OE2 GLU A 571      60.305  61.797  55.906  1.00 65.65           O  
+ATOM   4505  N   ASN A 572      58.766  66.192  51.913  1.00 53.64           N  
+ATOM   4506  CA  ASN A 572      58.541  67.598  52.209  1.00 56.41           C  
+ATOM   4507  C   ASN A 572      57.120  68.023  51.859  1.00 57.68           C  
+ATOM   4508  O   ASN A 572      56.606  68.998  52.405  1.00 60.58           O  
+ATOM   4509  CB  ASN A 572      59.540  68.459  51.446  1.00 61.19           C  
+ATOM   4510  CG  ASN A 572      60.958  68.277  51.947  1.00 62.06           C  
+ATOM   4511  OD1 ASN A 572      61.228  67.396  52.763  1.00 65.65           O  
+ATOM   4512  ND2 ASN A 572      61.872  69.107  51.461  1.00 61.56           N  
+ATOM   4513  N   VAL A 573      56.479  67.291  50.953  1.00 57.01           N  
+ATOM   4514  CA  VAL A 573      55.118  67.627  50.546  1.00 54.87           C  
+ATOM   4515  C   VAL A 573      54.025  66.750  51.141  1.00 52.74           C  
+ATOM   4516  O   VAL A 573      53.011  67.255  51.611  1.00 50.66           O  
+ATOM   4517  CB  VAL A 573      54.966  67.584  48.999  1.00 54.92           C  
+ATOM   4518  CG1 VAL A 573      53.497  67.671  48.600  1.00 54.11           C  
+ATOM   4519  CG2 VAL A 573      55.699  68.727  48.400  1.00 55.65           C  
+ATOM   4520  N   VAL A 574      54.211  65.439  51.126  1.00 52.58           N  
+ATOM   4521  CA  VAL A 574      53.145  64.597  51.637  1.00 54.02           C  
+ATOM   4522  C   VAL A 574      53.348  63.975  53.010  1.00 57.87           C  
+ATOM   4523  O   VAL A 574      52.441  63.312  53.513  1.00 56.67           O  
+ATOM   4524  CB  VAL A 574      52.790  63.479  50.614  1.00 52.34           C  
+ATOM   4525  CG1 VAL A 574      52.546  64.105  49.236  1.00 51.03           C  
+ATOM   4526  CG2 VAL A 574      53.889  62.448  50.557  1.00 38.84           C  
+ATOM   4527  N   GLY A 575      54.526  64.185  53.610  1.00 61.44           N  
+ATOM   4528  CA  GLY A 575      54.805  63.644  54.936  1.00 60.57           C  
+ATOM   4529  C   GLY A 575      55.196  62.174  54.974  1.00 62.14           C  
+ATOM   4530  O   GLY A 575      55.123  61.535  56.020  1.00 64.05           O  
+ATOM   4531  N   ALA A 576      55.614  61.634  53.837  1.00 61.36           N  
+ATOM   4532  CA  ALA A 576      56.014  60.238  53.747  1.00 57.12           C  
+ATOM   4533  C   ALA A 576      57.082  60.160  52.673  1.00 56.99           C  
+ATOM   4534  O   ALA A 576      57.119  60.995  51.774  1.00 52.79           O  
+ATOM   4535  CB  ALA A 576      54.825  59.375  53.377  1.00 59.19           C  
+ATOM   4536  N   LYS A 577      57.947  59.157  52.754  1.00 56.22           N  
+ATOM   4537  CA  LYS A 577      59.025  59.047  51.790  1.00 56.04           C  
+ATOM   4538  C   LYS A 577      58.790  58.057  50.668  1.00 54.79           C  
+ATOM   4539  O   LYS A 577      59.694  57.768  49.885  1.00 52.18           O  
+ATOM   4540  CB  LYS A 577      60.338  58.725  52.507  1.00 56.08           C  
+ATOM   4541  CG  LYS A 577      60.346  57.432  53.267  1.00 60.69           C  
+ATOM   4542  CD  LYS A 577      61.603  57.328  54.151  1.00 65.56           C  
+ATOM   4543  CE  LYS A 577      61.686  58.491  55.144  1.00 68.69           C  
+ATOM   4544  NZ  LYS A 577      62.769  58.307  56.160  1.00 70.17           N  
+ATOM   4545  N   ASN A 578      57.596  57.501  50.579  1.00 52.84           N  
+ATOM   4546  CA  ASN A 578      57.409  56.610  49.467  1.00 54.20           C  
+ATOM   4547  C   ASN A 578      56.126  56.770  48.684  1.00 49.29           C  
+ATOM   4548  O   ASN A 578      55.185  57.449  49.101  1.00 47.69           O  
+ATOM   4549  CB  ASN A 578      57.577  55.156  49.882  1.00 58.45           C  
+ATOM   4550  CG  ASN A 578      58.305  54.347  48.811  1.00 66.98           C  
+ATOM   4551  OD1 ASN A 578      58.189  54.634  47.608  1.00 61.54           O  
+ATOM   4552  ND2 ASN A 578      59.059  53.334  49.240  1.00 71.58           N  
+ATOM   4553  N   MET A 579      56.141  56.165  47.507  1.00 49.23           N  
+ATOM   4554  CA  MET A 579      55.011  56.162  46.605  1.00 49.39           C  
+ATOM   4555  C   MET A 579      53.924  55.360  47.315  1.00 50.77           C  
+ATOM   4556  O   MET A 579      54.165  54.263  47.814  1.00 52.36           O  
+ATOM   4557  CB  MET A 579      55.419  55.500  45.286  1.00 48.72           C  
+ATOM   4558  CG  MET A 579      54.307  55.381  44.249  1.00 52.03           C  
+ATOM   4559  SD  MET A 579      54.911  54.746  42.650  1.00 51.48           S  
+ATOM   4560  CE  MET A 579      55.497  53.078  43.119  1.00 49.10           C  
+ATOM   4561  N   ASN A 580      52.733  55.935  47.369  1.00 51.36           N  
+ATOM   4562  CA  ASN A 580      51.597  55.325  48.018  1.00 48.50           C  
+ATOM   4563  C   ASN A 580      50.352  55.485  47.132  1.00 48.29           C  
+ATOM   4564  O   ASN A 580      50.100  56.566  46.590  1.00 46.05           O  
+ATOM   4565  CB  ASN A 580      51.378  56.012  49.360  1.00 52.01           C  
+ATOM   4566  CG  ASN A 580      50.165  55.506  50.070  1.00 53.79           C  
+ATOM   4567  OD1 ASN A 580      49.530  56.235  50.839  1.00 64.88           O  
+ATOM   4568  ND2 ASN A 580      49.825  54.247  49.828  1.00 57.27           N  
+ATOM   4569  N   VAL A 581      49.558  54.423  47.016  1.00 46.80           N  
+ATOM   4570  CA  VAL A 581      48.366  54.450  46.186  1.00 46.64           C  
+ATOM   4571  C   VAL A 581      47.076  54.844  46.878  1.00 47.75           C  
+ATOM   4572  O   VAL A 581      46.067  55.065  46.207  1.00 47.29           O  
+ATOM   4573  CB  VAL A 581      48.153  53.076  45.484  1.00 52.13           C  
+ATOM   4574  CG1 VAL A 581      47.515  52.090  46.451  1.00 52.75           C  
+ATOM   4575  CG2 VAL A 581      47.309  53.251  44.216  1.00 50.24           C  
+ATOM   4576  N   ARG A 582      47.086  54.962  48.203  1.00 49.20           N  
+ATOM   4577  CA  ARG A 582      45.857  55.317  48.916  1.00 51.87           C  
+ATOM   4578  C   ARG A 582      45.169  56.591  48.445  1.00 47.48           C  
+ATOM   4579  O   ARG A 582      43.945  56.651  48.357  1.00 47.28           O  
+ATOM   4580  CB  ARG A 582      46.107  55.421  50.432  1.00 56.84           C  
+ATOM   4581  CG  ARG A 582      45.829  54.117  51.189  1.00 68.59           C  
+ATOM   4582  CD  ARG A 582      47.069  53.591  51.924  1.00 72.52           C  
+ATOM   4583  NE  ARG A 582      47.517  54.516  52.965  1.00 77.65           N  
+ATOM   4584  CZ  ARG A 582      48.683  54.418  53.596  1.00 80.09           C  
+ATOM   4585  NH1 ARG A 582      49.519  53.430  53.293  1.00 79.69           N  
+ATOM   4586  NH2 ARG A 582      49.021  55.314  54.519  1.00 81.14           N  
+ATOM   4587  N   PRO A 583      45.942  57.646  48.176  1.00 46.74           N  
+ATOM   4588  CA  PRO A 583      45.307  58.886  47.719  1.00 43.67           C  
+ATOM   4589  C   PRO A 583      44.593  58.732  46.379  1.00 42.45           C  
+ATOM   4590  O   PRO A 583      43.546  59.347  46.173  1.00 44.57           O  
+ATOM   4591  CB  PRO A 583      46.475  59.855  47.647  1.00 41.91           C  
+ATOM   4592  CG  PRO A 583      47.346  59.370  48.797  1.00 43.59           C  
+ATOM   4593  CD  PRO A 583      47.347  57.886  48.543  1.00 45.54           C  
+ATOM   4594  N   LEU A 584      45.153  57.929  45.468  1.00 43.11           N  
+ATOM   4595  CA  LEU A 584      44.512  57.723  44.166  1.00 44.47           C  
+ATOM   4596  C   LEU A 584      43.161  57.088  44.468  1.00 45.87           C  
+ATOM   4597  O   LEU A 584      42.124  57.534  43.978  1.00 44.16           O  
+ATOM   4598  CB  LEU A 584      45.361  56.807  43.265  1.00 44.69           C  
+ATOM   4599  CG  LEU A 584      44.717  56.333  41.952  1.00 52.51           C  
+ATOM   4600  CD1 LEU A 584      45.757  56.104  40.870  1.00 55.57           C  
+ATOM   4601  CD2 LEU A 584      43.952  55.042  42.208  1.00 56.29           C  
+ATOM   4602  N   LEU A 585      43.186  56.073  45.323  1.00 46.35           N  
+ATOM   4603  CA  LEU A 585      41.987  55.352  45.734  1.00 47.24           C  
+ATOM   4604  C   LEU A 585      40.987  56.260  46.437  1.00 47.94           C  
+ATOM   4605  O   LEU A 585      39.771  56.117  46.266  1.00 48.83           O  
+ATOM   4606  CB  LEU A 585      42.369  54.209  46.675  1.00 46.70           C  
+ATOM   4607  CG  LEU A 585      42.577  52.802  46.133  1.00 51.04           C  
+ATOM   4608  CD1 LEU A 585      42.900  52.839  44.623  1.00 48.67           C  
+ATOM   4609  CD2 LEU A 585      43.671  52.119  46.953  1.00 47.08           C  
+ATOM   4610  N   ASN A 586      41.482  57.180  47.257  1.00 47.04           N  
+ATOM   4611  CA  ASN A 586      40.558  58.067  47.951  1.00 48.42           C  
+ATOM   4612  C   ASN A 586      39.859  58.936  46.927  1.00 42.11           C  
+ATOM   4613  O   ASN A 586      38.680  59.216  47.051  1.00 45.81           O  
+ATOM   4614  CB  ASN A 586      41.286  58.967  48.958  1.00 51.20           C  
+ATOM   4615  CG  ASN A 586      41.832  58.200  50.154  1.00 61.01           C  
+ATOM   4616  OD1 ASN A 586      42.783  58.650  50.810  1.00 66.15           O  
+ATOM   4617  ND2 ASN A 586      41.229  57.050  50.458  1.00 58.61           N  
+ATOM   4618  N   TYR A 587      40.602  59.375  45.923  1.00 44.56           N  
+ATOM   4619  CA  TYR A 587      40.046  60.235  44.878  1.00 44.77           C  
+ATOM   4620  C   TYR A 587      38.847  59.562  44.238  1.00 45.46           C  
+ATOM   4621  O   TYR A 587      37.782  60.176  44.079  1.00 44.41           O  
+ATOM   4622  CB  TYR A 587      41.100  60.508  43.796  1.00 44.28           C  
+ATOM   4623  CG  TYR A 587      40.696  61.519  42.744  1.00 45.63           C  
+ATOM   4624  CD1 TYR A 587      40.836  62.883  42.965  1.00 45.23           C  
+ATOM   4625  CD2 TYR A 587      40.187  61.105  41.513  1.00 47.35           C  
+ATOM   4626  CE1 TYR A 587      40.486  63.791  41.998  1.00 43.84           C  
+ATOM   4627  CE2 TYR A 587      39.834  62.012  40.541  1.00 43.70           C  
+ATOM   4628  CZ  TYR A 587      39.982  63.348  40.785  1.00 45.21           C  
+ATOM   4629  OH  TYR A 587      39.614  64.241  39.804  1.00 42.86           O  
+ATOM   4630  N   PHE A 588      39.018  58.283  43.916  1.00 45.77           N  
+ATOM   4631  CA  PHE A 588      37.990  57.509  43.229  1.00 46.21           C  
+ATOM   4632  C   PHE A 588      36.987  56.745  44.077  1.00 48.31           C  
+ATOM   4633  O   PHE A 588      36.085  56.090  43.532  1.00 47.49           O  
+ATOM   4634  CB  PHE A 588      38.662  56.546  42.240  1.00 44.11           C  
+ATOM   4635  CG  PHE A 588      39.258  57.229  41.043  1.00 40.37           C  
+ATOM   4636  CD1 PHE A 588      40.633  57.326  40.886  1.00 39.19           C  
+ATOM   4637  CD2 PHE A 588      38.429  57.784  40.065  1.00 43.52           C  
+ATOM   4638  CE1 PHE A 588      41.183  57.966  39.772  1.00 43.04           C  
+ATOM   4639  CE2 PHE A 588      38.962  58.426  38.948  1.00 38.63           C  
+ATOM   4640  CZ  PHE A 588      40.337  58.521  38.795  1.00 39.75           C  
+ATOM   4641  N   GLU A 589      37.121  56.825  45.398  1.00 49.35           N  
+ATOM   4642  CA  GLU A 589      36.200  56.116  46.281  1.00 51.43           C  
+ATOM   4643  C   GLU A 589      34.713  56.262  45.949  1.00 50.63           C  
+ATOM   4644  O   GLU A 589      33.971  55.289  46.000  1.00 48.09           O  
+ATOM   4645  CB  GLU A 589      36.436  56.515  47.735  1.00 54.95           C  
+ATOM   4646  CG  GLU A 589      37.500  55.664  48.386  1.00 64.62           C  
+ATOM   4647  CD  GLU A 589      37.096  54.191  48.478  1.00 69.57           C  
+ATOM   4648  OE1 GLU A 589      37.878  53.326  48.027  1.00 69.37           O  
+ATOM   4649  OE2 GLU A 589      36.000  53.897  49.007  1.00 70.52           O  
+ATOM   4650  N   PRO A 590      34.253  57.485  45.639  1.00 50.07           N  
+ATOM   4651  CA  PRO A 590      32.829  57.650  45.314  1.00 47.14           C  
+ATOM   4652  C   PRO A 590      32.407  56.779  44.120  1.00 48.97           C  
+ATOM   4653  O   PRO A 590      31.328  56.177  44.130  1.00 48.02           O  
+ATOM   4654  CB  PRO A 590      32.721  59.135  45.011  1.00 46.33           C  
+ATOM   4655  CG  PRO A 590      33.801  59.743  45.915  1.00 46.88           C  
+ATOM   4656  CD  PRO A 590      34.943  58.788  45.720  1.00 46.99           C  
+ATOM   4657  N   LEU A 591      33.264  56.717  43.100  1.00 47.70           N  
+ATOM   4658  CA  LEU A 591      32.994  55.925  41.911  1.00 48.31           C  
+ATOM   4659  C   LEU A 591      33.138  54.438  42.233  1.00 51.55           C  
+ATOM   4660  O   LEU A 591      32.416  53.597  41.700  1.00 53.05           O  
+ATOM   4661  CB  LEU A 591      33.970  56.293  40.791  1.00 44.76           C  
+ATOM   4662  CG  LEU A 591      33.874  55.395  39.547  1.00 46.05           C  
+ATOM   4663  CD1 LEU A 591      32.563  55.674  38.836  1.00 39.19           C  
+ATOM   4664  CD2 LEU A 591      35.028  55.635  38.594  1.00 37.33           C  
+ATOM   4665  N   PHE A 592      34.066  54.124  43.126  1.00 53.21           N  
+ATOM   4666  CA  PHE A 592      34.328  52.748  43.496  1.00 54.19           C  
+ATOM   4667  C   PHE A 592      33.154  52.087  44.196  1.00 57.73           C  
+ATOM   4668  O   PHE A 592      32.885  50.899  43.987  1.00 58.68           O  
+ATOM   4669  CB  PHE A 592      35.568  52.680  44.379  1.00 53.52           C  
+ATOM   4670  CG  PHE A 592      35.954  51.293  44.768  1.00 49.50           C  
+ATOM   4671  CD1 PHE A 592      36.017  50.293  43.826  1.00 53.22           C  
+ATOM   4672  CD2 PHE A 592      36.287  50.995  46.073  1.00 51.79           C  
+ATOM   4673  CE1 PHE A 592      36.411  49.015  44.177  1.00 54.52           C  
+ATOM   4674  CE2 PHE A 592      36.682  49.725  46.432  1.00 51.06           C  
+ATOM   4675  CZ  PHE A 592      36.744  48.732  45.479  1.00 51.82           C  
+ATOM   4676  N   THR A 593      32.446  52.844  45.021  1.00 58.06           N  
+ATOM   4677  CA  THR A 593      31.299  52.290  45.733  1.00 61.51           C  
+ATOM   4678  C   THR A 593      30.103  52.152  44.787  1.00 59.60           C  
+ATOM   4679  O   THR A 593      29.299  51.233  44.906  1.00 59.66           O  
+ATOM   4680  CB  THR A 593      30.927  53.176  46.928  1.00 63.01           C  
+ATOM   4681  OG1 THR A 593      30.663  54.507  46.464  1.00 67.77           O  
+ATOM   4682  CG2 THR A 593      32.078  53.215  47.923  1.00 60.36           C  
+ATOM   4683  N   TRP A 594      30.004  53.073  43.841  1.00 58.06           N  
+ATOM   4684  CA  TRP A 594      28.940  53.047  42.851  1.00 58.01           C  
+ATOM   4685  C   TRP A 594      29.180  51.858  41.920  1.00 59.56           C  
+ATOM   4686  O   TRP A 594      28.256  51.123  41.579  1.00 61.22           O  
+ATOM   4687  CB  TRP A 594      28.973  54.328  42.036  1.00 52.55           C  
+ATOM   4688  CG  TRP A 594      27.906  54.414  41.009  1.00 52.93           C  
+ATOM   4689  CD1 TRP A 594      26.619  54.809  41.204  1.00 52.17           C  
+ATOM   4690  CD2 TRP A 594      28.047  54.186  39.601  1.00 51.09           C  
+ATOM   4691  NE1 TRP A 594      25.948  54.855  40.009  1.00 50.28           N  
+ATOM   4692  CE2 TRP A 594      26.801  54.475  39.006  1.00 53.14           C  
+ATOM   4693  CE3 TRP A 594      29.104  53.773  38.788  1.00 50.48           C  
+ATOM   4694  CZ2 TRP A 594      26.580  54.365  37.628  1.00 51.04           C  
+ATOM   4695  CZ3 TRP A 594      28.888  53.665  37.420  1.00 54.19           C  
+ATOM   4696  CH2 TRP A 594      27.631  53.963  36.853  1.00 53.98           C  
+ATOM   4697  N   LEU A 595      30.433  51.687  41.509  1.00 58.33           N  
+ATOM   4698  CA  LEU A 595      30.812  50.595  40.618  1.00 58.15           C  
+ATOM   4699  C   LEU A 595      30.423  49.239  41.232  1.00 58.39           C  
+ATOM   4700  O   LEU A 595      29.738  48.439  40.593  1.00 58.13           O  
+ATOM   4701  CB  LEU A 595      32.320  50.661  40.337  1.00 54.49           C  
+ATOM   4702  CG  LEU A 595      32.803  51.072  38.936  1.00 58.25           C  
+ATOM   4703  CD1 LEU A 595      31.783  51.942  38.259  1.00 56.97           C  
+ATOM   4704  CD2 LEU A 595      34.152  51.789  39.034  1.00 51.54           C  
+ATOM   4705  N   LYS A 596      30.853  48.990  42.469  1.00 58.15           N  
+ATOM   4706  CA  LYS A 596      30.529  47.747  43.165  1.00 57.20           C  
+ATOM   4707  C   LYS A 596      29.036  47.440  43.087  1.00 58.98           C  
+ATOM   4708  O   LYS A 596      28.646  46.334  42.712  1.00 58.31           O  
+ATOM   4709  CB  LYS A 596      30.972  47.835  44.625  1.00 56.77           C  
+ATOM   4710  CG  LYS A 596      32.442  47.485  44.836  1.00 59.18           C  
+ATOM   4711  CD  LYS A 596      33.096  48.304  45.956  1.00 62.91           C  
+ATOM   4712  CE  LYS A 596      32.327  48.238  47.268  1.00 66.40           C  
+ATOM   4713  NZ  LYS A 596      33.180  48.682  48.422  1.00 68.19           N  
+ATOM   4714  N   ASP A 597      28.207  48.425  43.428  1.00 58.82           N  
+ATOM   4715  CA  ASP A 597      26.753  48.273  43.383  1.00 62.50           C  
+ATOM   4716  C   ASP A 597      26.252  48.014  41.949  1.00 61.62           C  
+ATOM   4717  O   ASP A 597      25.291  47.272  41.746  1.00 60.93           O  
+ATOM   4718  CB  ASP A 597      26.070  49.527  43.958  1.00 64.10           C  
+ATOM   4719  CG  ASP A 597      24.551  49.407  43.988  1.00 67.03           C  
+ATOM   4720  OD1 ASP A 597      24.040  48.487  44.665  1.00 70.69           O  
+ATOM   4721  OD2 ASP A 597      23.866  50.231  43.340  1.00 67.90           O  
+ATOM   4722  N   GLN A 598      26.890  48.634  40.962  1.00 59.82           N  
+ATOM   4723  CA  GLN A 598      26.508  48.420  39.570  1.00 59.59           C  
+ATOM   4724  C   GLN A 598      26.857  46.995  39.149  1.00 59.27           C  
+ATOM   4725  O   GLN A 598      26.159  46.390  38.344  1.00 58.64           O  
+ATOM   4726  CB  GLN A 598      27.246  49.388  38.643  1.00 60.78           C  
+ATOM   4727  CG  GLN A 598      26.710  50.820  38.616  1.00 64.55           C  
+ATOM   4728  CD  GLN A 598      25.314  50.917  38.020  1.00 64.45           C  
+ATOM   4729  OE1 GLN A 598      25.037  50.354  36.961  1.00 62.42           O  
+ATOM   4730  NE2 GLN A 598      24.434  51.642  38.697  1.00 63.52           N  
+ATOM   4731  N   ASN A 599      27.948  46.470  39.693  1.00 58.76           N  
+ATOM   4732  CA  ASN A 599      28.407  45.128  39.368  1.00 58.21           C  
+ATOM   4733  C   ASN A 599      27.818  44.081  40.322  1.00 61.25           C  
+ATOM   4734  O   ASN A 599      28.326  42.959  40.413  1.00 60.45           O  
+ATOM   4735  CB  ASN A 599      29.933  45.070  39.463  1.00 55.30           C  
+ATOM   4736  CG  ASN A 599      30.627  45.974  38.464  1.00 52.29           C  
+ATOM   4737  OD1 ASN A 599      31.837  46.187  38.556  1.00 55.83           O  
+ATOM   4738  ND2 ASN A 599      29.883  46.494  37.503  1.00 43.47           N  
+ATOM   4739  N   LYS A 600      26.755  44.451  41.027  1.00 63.06           N  
+ATOM   4740  CA  LYS A 600      26.119  43.562  42.003  1.00 67.91           C  
+ATOM   4741  C   LYS A 600      25.808  42.189  41.414  1.00 68.58           C  
+ATOM   4742  O   LYS A 600      25.999  41.154  42.058  1.00 67.97           O  
+ATOM   4743  CB  LYS A 600      24.824  44.209  42.515  1.00 73.40           C  
+ATOM   4744  CG  LYS A 600      24.299  43.669  43.842  1.00 78.19           C  
+ATOM   4745  CD  LYS A 600      25.193  44.057  45.026  1.00 82.63           C  
+ATOM   4746  CE  LYS A 600      24.647  43.495  46.345  1.00 82.24           C  
+ATOM   4747  NZ  LYS A 600      25.452  43.904  47.534  1.00 82.48           N  
+ATOM   4748  N   ASN A 601      25.352  42.192  40.172  1.00 69.07           N  
+ATOM   4749  CA  ASN A 601      24.984  40.967  39.482  1.00 71.54           C  
+ATOM   4750  C   ASN A 601      25.971  40.532  38.391  1.00 71.21           C  
+ATOM   4751  O   ASN A 601      25.807  39.461  37.793  1.00 74.46           O  
+ATOM   4752  CB  ASN A 601      23.607  41.175  38.862  1.00 74.84           C  
+ATOM   4753  CG  ASN A 601      23.582  42.371  37.919  1.00 79.14           C  
+ATOM   4754  OD1 ASN A 601      24.352  43.335  38.091  1.00 76.22           O  
+ATOM   4755  ND2 ASN A 601      22.694  42.324  36.923  1.00 79.09           N  
+ATOM   4756  N   SER A 602      26.986  41.350  38.122  1.00 67.58           N  
+ATOM   4757  CA  SER A 602      27.959  41.027  37.079  1.00 61.75           C  
+ATOM   4758  C   SER A 602      29.099  40.138  37.538  1.00 59.39           C  
+ATOM   4759  O   SER A 602      29.279  39.903  38.728  1.00 59.07           O  
+ATOM   4760  CB  SER A 602      28.556  42.313  36.504  1.00 60.16           C  
+ATOM   4761  OG  SER A 602      27.583  43.070  35.814  1.00 59.30           O  
+ATOM   4762  N   PHE A 603      29.861  39.626  36.578  1.00 57.60           N  
+ATOM   4763  CA  PHE A 603      31.027  38.821  36.903  1.00 58.44           C  
+ATOM   4764  C   PHE A 603      32.155  39.845  37.012  1.00 58.13           C  
+ATOM   4765  O   PHE A 603      32.364  40.640  36.097  1.00 58.12           O  
+ATOM   4766  CB  PHE A 603      31.344  37.809  35.794  1.00 57.35           C  
+ATOM   4767  CG  PHE A 603      32.518  36.897  36.111  1.00 55.59           C  
+ATOM   4768  CD1 PHE A 603      33.797  37.203  35.674  1.00 53.93           C  
+ATOM   4769  CD2 PHE A 603      32.338  35.752  36.864  1.00 55.69           C  
+ATOM   4770  CE1 PHE A 603      34.879  36.386  35.983  1.00 50.09           C  
+ATOM   4771  CE2 PHE A 603      33.411  34.927  37.179  1.00 55.82           C  
+ATOM   4772  CZ  PHE A 603      34.686  35.249  36.736  1.00 55.39           C  
+ATOM   4773  N   VAL A 604      32.844  39.858  38.145  1.00 56.64           N  
+ATOM   4774  CA  VAL A 604      33.942  40.786  38.343  1.00 56.35           C  
+ATOM   4775  C   VAL A 604      35.256  40.034  38.136  1.00 57.51           C  
+ATOM   4776  O   VAL A 604      35.566  39.078  38.863  1.00 57.19           O  
+ATOM   4777  CB  VAL A 604      33.910  41.402  39.761  1.00 57.11           C  
+ATOM   4778  CG1 VAL A 604      34.977  42.498  39.877  1.00 55.27           C  
+ATOM   4779  CG2 VAL A 604      32.526  41.965  40.046  1.00 54.15           C  
+ATOM   4780  N   GLY A 605      36.026  40.462  37.137  1.00 53.73           N  
+ATOM   4781  CA  GLY A 605      37.281  39.794  36.854  1.00 50.80           C  
+ATOM   4782  C   GLY A 605      37.193  39.145  35.487  1.00 49.56           C  
+ATOM   4783  O   GLY A 605      36.258  39.394  34.739  1.00 47.41           O  
+ATOM   4784  N   TRP A 606      38.134  38.282  35.149  1.00 48.37           N  
+ATOM   4785  CA  TRP A 606      38.081  37.699  33.828  1.00 51.52           C  
+ATOM   4786  C   TRP A 606      38.762  36.369  33.720  1.00 51.66           C  
+ATOM   4787  O   TRP A 606      39.607  36.024  34.536  1.00 49.34           O  
+ATOM   4788  CB  TRP A 606      38.721  38.672  32.831  1.00 51.03           C  
+ATOM   4789  CG  TRP A 606      40.098  39.125  33.267  1.00 49.26           C  
+ATOM   4790  CD1 TRP A 606      41.282  38.458  33.087  1.00 49.47           C  
+ATOM   4791  CD2 TRP A 606      40.422  40.327  33.973  1.00 44.98           C  
+ATOM   4792  NE1 TRP A 606      42.314  39.173  33.631  1.00 45.64           N  
+ATOM   4793  CE2 TRP A 606      41.816  40.324  34.184  1.00 46.19           C  
+ATOM   4794  CE3 TRP A 606      39.670  41.405  34.445  1.00 45.15           C  
+ATOM   4795  CZ2 TRP A 606      42.477  41.364  34.848  1.00 43.44           C  
+ATOM   4796  CZ3 TRP A 606      40.328  42.438  35.102  1.00 43.42           C  
+ATOM   4797  CH2 TRP A 606      41.715  42.410  35.296  1.00 39.43           C  
+ATOM   4798  N   SER A 607      38.384  35.631  32.685  1.00 55.74           N  
+ATOM   4799  CA  SER A 607      38.970  34.324  32.391  1.00 56.90           C  
+ATOM   4800  C   SER A 607      39.984  34.589  31.292  1.00 53.61           C  
+ATOM   4801  O   SER A 607      39.690  35.338  30.367  1.00 54.10           O  
+ATOM   4802  CB  SER A 607      37.882  33.369  31.882  1.00 61.82           C  
+ATOM   4803  OG  SER A 607      38.402  32.425  30.955  1.00 66.09           O  
+ATOM   4804  N   THR A 608      41.169  33.994  31.376  1.00 53.83           N  
+ATOM   4805  CA  THR A 608      42.176  34.226  30.346  1.00 56.90           C  
+ATOM   4806  C   THR A 608      42.088  33.250  29.168  1.00 59.18           C  
+ATOM   4807  O   THR A 608      42.886  33.317  28.234  1.00 59.67           O  
+ATOM   4808  CB  THR A 608      43.595  34.164  30.933  1.00 59.61           C  
+ATOM   4809  OG1 THR A 608      43.874  32.836  31.407  1.00 54.94           O  
+ATOM   4810  CG2 THR A 608      43.729  35.167  32.074  1.00 57.30           C  
+ATOM   4811  N   ASP A 609      41.100  32.361  29.205  1.00 61.41           N  
+ATOM   4812  CA  ASP A 609      40.920  31.357  28.160  1.00 60.66           C  
+ATOM   4813  C   ASP A 609      40.170  31.879  26.956  1.00 58.50           C  
+ATOM   4814  O   ASP A 609      40.520  31.581  25.817  1.00 60.39           O  
+ATOM   4815  CB  ASP A 609      40.152  30.155  28.706  1.00 63.79           C  
+ATOM   4816  CG  ASP A 609      40.897  29.435  29.802  1.00 68.98           C  
+ATOM   4817  OD1 ASP A 609      40.285  28.548  30.434  1.00 74.57           O  
+ATOM   4818  OD2 ASP A 609      42.088  29.743  30.031  1.00 70.74           O  
+ATOM   4819  N   TRP A 610      39.131  32.657  27.205  1.00 55.66           N  
+ATOM   4820  CA  TRP A 610      38.327  33.166  26.115  1.00 56.39           C  
+ATOM   4821  C   TRP A 610      39.074  34.065  25.133  1.00 58.39           C  
+ATOM   4822  O   TRP A 610      39.997  34.802  25.505  1.00 57.97           O  
+ATOM   4823  CB  TRP A 610      37.122  33.920  26.668  1.00 53.55           C  
+ATOM   4824  CG  TRP A 610      36.201  34.380  25.587  1.00 55.11           C  
+ATOM   4825  CD1 TRP A 610      35.225  33.650  24.981  1.00 51.97           C  
+ATOM   4826  CD2 TRP A 610      36.189  35.676  24.956  1.00 52.68           C  
+ATOM   4827  NE1 TRP A 610      34.604  34.407  24.013  1.00 53.21           N  
+ATOM   4828  CE2 TRP A 610      35.175  35.653  23.979  1.00 51.97           C  
+ATOM   4829  CE3 TRP A 610      36.938  36.846  25.123  1.00 53.63           C  
+ATOM   4830  CZ2 TRP A 610      34.884  36.759  23.174  1.00 51.45           C  
+ATOM   4831  CZ3 TRP A 610      36.648  37.952  24.314  1.00 49.12           C  
+ATOM   4832  CH2 TRP A 610      35.633  37.896  23.360  1.00 52.56           C  
+ATOM   4833  N   SER A 611      38.679  33.979  23.867  1.00 58.19           N  
+ATOM   4834  CA  SER A 611      39.261  34.813  22.825  1.00 60.20           C  
+ATOM   4835  C   SER A 611      38.226  34.922  21.722  1.00 60.17           C  
+ATOM   4836  O   SER A 611      37.387  34.038  21.562  1.00 61.37           O  
+ATOM   4837  CB  SER A 611      40.570  34.213  22.287  1.00 58.84           C  
+ATOM   4838  OG  SER A 611      40.351  32.980  21.641  1.00 58.77           O  
+ATOM   4839  N   PRO A 612      38.262  36.019  20.954  1.00 60.45           N  
+ATOM   4840  CA  PRO A 612      37.324  36.267  19.856  1.00 59.12           C  
+ATOM   4841  C   PRO A 612      37.290  35.137  18.825  1.00 59.65           C  
+ATOM   4842  O   PRO A 612      36.270  34.899  18.174  1.00 58.08           O  
+ATOM   4843  CB  PRO A 612      37.844  37.579  19.249  1.00 53.90           C  
+ATOM   4844  CG  PRO A 612      38.479  38.259  20.408  1.00 57.17           C  
+ATOM   4845  CD  PRO A 612      39.224  37.127  21.072  1.00 58.47           C  
+ATOM   4846  N   TYR A 613      38.408  34.438  18.687  1.00 60.58           N  
+ATOM   4847  CA  TYR A 613      38.516  33.370  17.700  1.00 63.69           C  
+ATOM   4848  C   TYR A 613      38.443  31.942  18.251  1.00 66.93           C  
+ATOM   4849  O   TYR A 613      38.584  30.982  17.498  1.00 64.80           O  
+ATOM   4850  CB  TYR A 613      39.829  33.559  16.927  1.00 59.71           C  
+ATOM   4851  CG  TYR A 613      41.059  33.619  17.817  1.00 57.04           C  
+ATOM   4852  CD1 TYR A 613      41.692  32.459  18.244  1.00 53.28           C  
+ATOM   4853  CD2 TYR A 613      41.568  34.843  18.265  1.00 56.90           C  
+ATOM   4854  CE1 TYR A 613      42.792  32.509  19.089  1.00 53.24           C  
+ATOM   4855  CE2 TYR A 613      42.676  34.898  19.122  1.00 48.81           C  
+ATOM   4856  CZ  TYR A 613      43.277  33.732  19.524  1.00 51.41           C  
+ATOM   4857  OH  TYR A 613      44.375  33.772  20.356  1.00 57.07           O  
+ATOM   4858  N   ALA A 614      38.222  31.800  19.553  1.00 70.32           N  
+ATOM   4859  CA  ALA A 614      38.167  30.478  20.167  1.00 75.58           C  
+ATOM   4860  C   ALA A 614      37.195  29.530  19.464  1.00 79.72           C  
+ATOM   4861  O   ALA A 614      37.281  28.309  19.629  1.00 78.60           O  
+ATOM   4862  CB  ALA A 614      37.803  30.601  21.643  1.00 76.48           C  
+ATOM   4863  N   ASP A 615      36.279  30.091  18.678  1.00 83.14           N  
+ATOM   4864  CA  ASP A 615      35.298  29.286  17.954  1.00 86.68           C  
+ATOM   4865  C   ASP A 615      35.267  29.560  16.436  1.00 88.09           C  
+ATOM   4866  O   ASP A 615      34.267  30.121  15.930  1.00 88.57           O  
+ATOM   4867  CB  ASP A 615      33.907  29.487  18.575  1.00 87.40           C  
+ATOM   4868  CG  ASP A 615      33.457  30.934  18.554  1.00 88.22           C  
+ATOM   4869  OD1 ASP A 615      32.381  31.227  19.121  1.00 88.15           O  
+ATOM   4870  OD2 ASP A 615      34.171  31.777  17.969  1.00 89.57           O  
+ATOM   4871  OXT ASP A 615      36.257  29.204  15.756  1.00 89.04           O  
+TER    4872      ASP A 615                                                      
+ATOM   4873  N   UNK B 901      37.483  27.352  14.778  1.00 67.99           N  
+ATOM   4874  CA  UNK B 901      38.856  26.820  14.989  1.00 71.22           C  
+ATOM   4875  C   UNK B 901      38.853  25.310  15.274  1.00 72.26           C  
+ATOM   4876  O   UNK B 901      38.080  24.834  16.103  1.00 74.09           O  
+ATOM   4877  CB  UNK B 901      39.537  27.581  16.143  1.00 68.58           C  
+ATOM   4878  N   UNK B 902      39.711  24.567  14.574  1.00 73.73           N  
+ATOM   4879  CA  UNK B 902      39.831  23.117  14.749  1.00 74.30           C  
+ATOM   4880  C   UNK B 902      41.186  22.845  15.405  1.00 75.13           C  
+ATOM   4881  O   UNK B 902      42.184  23.452  15.030  1.00 75.79           O  
+ATOM   4882  CB  UNK B 902      39.737  22.418  13.390  1.00 74.12           C  
+ATOM   4883  N   UNK B 903      41.232  21.939  16.376  1.00 77.47           N  
+ATOM   4884  CA  UNK B 903      42.482  21.664  17.086  1.00 79.68           C  
+ATOM   4885  C   UNK B 903      43.408  20.611  16.458  1.00 82.33           C  
+ATOM   4886  O   UNK B 903      43.046  19.943  15.485  1.00 81.30           O  
+ATOM   4887  CB  UNK B 903      42.173  21.297  18.536  1.00 78.88           C  
+ATOM   4888  N   UNK B 904      44.612  20.490  17.022  1.00 82.61           N  
+ATOM   4889  CA  UNK B 904      45.621  19.540  16.551  1.00 84.52           C  
+ATOM   4890  C   UNK B 904      46.739  19.423  17.589  1.00 86.88           C  
+ATOM   4891  O   UNK B 904      47.181  20.428  18.150  1.00 88.47           O  
+ATOM   4892  CB  UNK B 904      46.196  19.999  15.214  1.00 81.41           C  
+ATOM   4893  N   UNK B 905      47.198  18.199  17.841  1.00 89.33           N  
+ATOM   4894  CA  UNK B 905      48.255  17.970  18.831  1.00 91.58           C  
+ATOM   4895  C   UNK B 905      49.671  18.111  18.262  1.00 92.32           C  
+ATOM   4896  O   UNK B 905      49.991  19.111  17.617  1.00 92.54           O  
+ATOM   4897  CB  UNK B 905      48.080  16.584  19.481  1.00 90.31           C  
+ATOM   4898  N   UNK B 906      50.512  17.108  18.513  1.00 92.71           N  
+ATOM   4899  CA  UNK B 906      51.896  17.122  18.050  1.00 92.94           C  
+ATOM   4900  C   UNK B 906      52.694  18.177  18.819  1.00 91.28           C  
+ATOM   4901  O   UNK B 906      53.783  17.843  19.318  1.00 90.44           O  
+ATOM   4902  CB  UNK B 906      51.953  17.400  16.540  1.00 93.51           C  
+ATOM   4903  OXT UNK B 906      52.222  19.328  18.915  1.00 91.49           O  
+TER    4904      UNK B 906                                                      
+ATOM   4905  N   UNK C 907      50.376  21.063  20.432  1.00 99.98           N  
+ATOM   4906  CA  UNK C 907      49.084  21.807  20.330  1.00100.13           C  
+ATOM   4907  C   UNK C 907      49.081  22.705  19.097  1.00 98.97           C  
+ATOM   4908  O   UNK C 907      50.132  23.184  18.675  1.00 99.51           O  
+ATOM   4909  CB  UNK C 907      48.864  22.650  21.587  1.00 99.23           C  
+ATOM   4910  N   UNK C 908      47.900  22.927  18.525  1.00 96.97           N  
+ATOM   4911  CA  UNK C 908      47.771  23.779  17.349  1.00 95.76           C  
+ATOM   4912  C   UNK C 908      46.314  23.983  16.939  1.00 94.78           C  
+ATOM   4913  O   UNK C 908      45.631  23.038  16.533  1.00 94.56           O  
+ATOM   4914  CB  UNK C 908      48.570  23.193  16.175  1.00 95.52           C  
+ATOM   4915  N   UNK C 909      45.848  25.226  17.052  1.00 91.88           N  
+ATOM   4916  CA  UNK C 909      44.484  25.588  16.676  1.00 87.19           C  
+ATOM   4917  C   UNK C 909      44.595  26.431  15.408  1.00 84.04           C  
+ATOM   4918  O   UNK C 909      45.649  27.014  15.157  1.00 82.90           O  
+ATOM   4919  CB  UNK C 909      43.828  26.391  17.796  1.00 86.63           C  
+ATOM   4920  N   UNK C 910      43.525  26.499  14.615  1.00 80.08           N  
+ATOM   4921  CA  UNK C 910      43.558  27.276  13.375  1.00 77.81           C  
+ATOM   4922  C   UNK C 910      42.198  27.823  12.904  1.00 75.71           C  
+ATOM   4923  O   UNK C 910      41.150  27.409  13.388  1.00 76.87           O  
+ATOM   4924  CB  UNK C 910      44.191  26.430  12.261  1.00 78.50           C  
+ATOM   4925  N   UNK C 911      42.237  28.756  11.952  1.00 72.39           N  
+ATOM   4926  CA  UNK C 911      41.036  29.370  11.380  1.00 68.60           C  
+ATOM   4927  C   UNK C 911      41.415  29.916  10.004  1.00 67.68           C  
+ATOM   4928  O   UNK C 911      42.582  29.857   9.626  1.00 67.39           O  
+ATOM   4929  CB  UNK C 911      40.529  30.500  12.287  1.00 70.84           C  
+ATOM   4930  N   UNK C 912      40.452  30.452   9.258  1.00 65.66           N  
+ATOM   4931  CA  UNK C 912      40.746  30.974   7.922  1.00 67.45           C  
+ATOM   4932  C   UNK C 912      40.033  32.289   7.643  1.00 66.75           C  
+ATOM   4933  O   UNK C 912      38.931  32.500   8.110  1.00 67.79           O  
+ATOM   4934  CB  UNK C 912      40.371  29.928   6.854  1.00 64.96           C  
+ATOM   4935  N   UNK C 913      40.655  33.162   6.858  1.00 67.90           N  
+ATOM   4936  CA  UNK C 913      40.076  34.460   6.563  1.00 71.25           C  
+ATOM   4937  C   UNK C 913      39.729  34.601   5.083  1.00 74.36           C  
+ATOM   4938  O   UNK C 913      38.909  33.844   4.578  1.00 76.18           O  
+ATOM   4939  CB  UNK C 913      41.049  35.577   7.010  1.00 70.01           C  
+ATOM   4940  N   UNK C 914      40.339  35.561   4.386  1.00 77.67           N  
+ATOM   4941  CA  UNK C 914      40.043  35.744   2.965  1.00 80.41           C  
+ATOM   4942  C   UNK C 914      40.822  36.865   2.299  1.00 82.83           C  
+ATOM   4943  O   UNK C 914      40.453  37.310   1.219  1.00 83.73           O  
+ATOM   4944  CB  UNK C 914      38.558  36.003   2.786  1.00 80.55           C  
+ATOM   4945  N   UNK C 915      41.900  37.315   2.921  1.00 85.02           N  
+ATOM   4946  CA  UNK C 915      42.666  38.417   2.354  1.00 87.50           C  
+ATOM   4947  C   UNK C 915      41.787  39.648   2.536  1.00 90.19           C  
+ATOM   4948  O   UNK C 915      41.761  40.550   1.696  1.00 89.41           O  
+ATOM   4949  CB  UNK C 915      42.934  38.175   0.887  1.00 88.01           C  
+ATOM   4950  N   UNK C 916      41.054  39.636   3.650  1.00 91.86           N  
+ATOM   4951  CA  UNK C 916      40.135  40.691   4.069  1.00 92.24           C  
+ATOM   4952  C   UNK C 916      39.705  40.296   5.489  1.00 93.58           C  
+ATOM   4953  O   UNK C 916      38.534  40.016   5.752  1.00 93.58           O  
+ATOM   4954  CB  UNK C 916      38.930  40.748   3.143  1.00 93.79           C  
+ATOM   4955  N   UNK C 917      40.703  40.278   6.375  1.00 94.15           N  
+ATOM   4956  CA  UNK C 917      40.628  39.922   7.799  1.00 93.87           C  
+ATOM   4957  C   UNK C 917      39.302  39.900   8.562  1.00 94.96           C  
+ATOM   4958  O   UNK C 917      39.276  39.458   9.714  1.00 92.77           O  
+ATOM   4959  CB  UNK C 917      41.632  40.770   8.573  1.00 93.51           C  
+ATOM   4960  N   UNK C 918      38.217  40.370   7.948  1.00 95.91           N  
+ATOM   4961  CA  UNK C 918      36.898  40.379   8.584  1.00 94.64           C  
+ATOM   4962  C   UNK C 918      36.633  39.092   9.376  1.00 94.04           C  
+ATOM   4963  O   UNK C 918      36.472  39.134  10.595  1.00 92.54           O  
+ATOM   4964  CB  UNK C 918      35.818  40.569   7.520  1.00 97.06           C  
+ATOM   4965  N   UNK C 919      36.589  37.960   8.669  1.00 93.46           N  
+ATOM   4966  CA  UNK C 919      36.354  36.634   9.262  1.00 92.65           C  
+ATOM   4967  C   UNK C 919      36.079  35.640   8.133  1.00 91.55           C  
+ATOM   4968  O   UNK C 919      36.385  35.933   6.980  1.00 90.51           O  
+ATOM   4969  CB  UNK C 919      35.164  36.683  10.216  1.00 93.51           C  
+ATOM   4970  N   UNK C 920      35.510  34.478   8.459  1.00 91.96           N  
+ATOM   4971  CA  UNK C 920      35.178  33.467   7.441  1.00 93.03           C  
+ATOM   4972  C   UNK C 920      34.564  32.194   8.016  1.00 93.57           C  
+ATOM   4973  O   UNK C 920      35.254  31.423   8.683  1.00 92.80           O  
+ATOM   4974  CB  UNK C 920      36.409  33.108   6.633  1.00 93.76           C  
+ATOM   4975  N   UNK C 921      33.279  31.972   7.721  1.00 94.47           N  
+ATOM   4976  CA  UNK C 921      32.516  30.806   8.200  1.00 94.89           C  
+ATOM   4977  C   UNK C 921      33.368  29.635   8.698  1.00 95.29           C  
+ATOM   4978  O   UNK C 921      34.288  29.185   8.013  1.00 95.98           O  
+ATOM   4979  CB  UNK C 921      31.563  30.329   7.112  1.00 92.96           C  
+ATOM   4980  N   UNK C 922      33.043  29.146   9.893  1.00 96.69           N  
+ATOM   4981  CA  UNK C 922      33.770  28.043  10.527  1.00 97.45           C  
+ATOM   4982  C   UNK C 922      33.380  26.674   9.995  1.00 98.21           C  
+ATOM   4983  O   UNK C 922      32.990  26.534   8.836  1.00 97.21           O  
+ATOM   4984  CB  UNK C 922      33.559  28.080  12.038  1.00 97.85           C  
+ATOM   4985  N   UNK C 923      33.482  25.669  10.862  1.00100.21           N  
+ATOM   4986  CA  UNK C 923      33.157  24.291  10.495  1.00102.48           C  
+ATOM   4987  C   UNK C 923      33.940  23.924   9.239  1.00103.99           C  
+ATOM   4988  O   UNK C 923      35.103  23.520   9.325  1.00104.38           O  
+ATOM   4989  CB  UNK C 923      31.652  24.143  10.245  1.00102.11           C  
+ATOM   4990  N   UNK C 924      33.298  24.083   8.080  1.00104.24           N  
+ATOM   4991  CA  UNK C 924      33.915  23.787   6.792  1.00103.41           C  
+ATOM   4992  C   UNK C 924      35.101  22.850   6.956  1.00104.02           C  
+ATOM   4993  O   UNK C 924      36.235  23.206   6.641  1.00101.35           O  
+ATOM   4994  CB  UNK C 924      34.356  25.078   6.114  1.00101.55           C  
+ATOM   4995  N   UNK C 925      34.827  21.660   7.483  1.00106.85           N  
+ATOM   4996  CA  UNK C 925      35.855  20.646   7.687  1.00109.27           C  
+ATOM   4997  C   UNK C 925      35.914  19.829   6.404  1.00110.85           C  
+ATOM   4998  O   UNK C 925      36.900  19.144   6.124  1.00111.39           O  
+ATOM   4999  CB  UNK C 925      35.494  19.753   8.875  1.00107.44           C  
+ATOM   5000  N   UNK C 926      34.842  19.927   5.624  1.00113.20           N  
+ATOM   5001  CA  UNK C 926      34.735  19.227   4.351  1.00115.53           C  
+ATOM   5002  C   UNK C 926      35.884  19.640   3.433  1.00116.81           C  
+ATOM   5003  O   UNK C 926      36.588  18.735   2.931  1.00117.85           O  
+ATOM   5004  CB  UNK C 926      33.390  19.545   3.691  1.00115.52           C  
+ATOM   5005  OXT UNK C 926      36.066  20.861   3.226  1.00116.85           O  
+TER    5006      UNK C 926                                                      
+ATOM   5007  N   UNK D 927      59.698  24.750  11.451  1.00 82.60           N  
+ATOM   5008  CA  UNK D 927      58.839  25.869  10.946  1.00 84.82           C  
+ATOM   5009  C   UNK D 927      58.432  25.674   9.478  1.00 84.55           C  
+ATOM   5010  O   UNK D 927      57.341  26.077   9.075  1.00 84.97           O  
+ATOM   5011  CB  UNK D 927      59.562  27.208  11.118  1.00 82.35           C  
+ATOM   5012  N   UNK D 928      59.299  25.055   8.681  1.00 84.53           N  
+ATOM   5013  CA  UNK D 928      58.982  24.821   7.277  1.00 84.78           C  
+ATOM   5014  C   UNK D 928      57.858  23.790   7.163  1.00 85.53           C  
+ATOM   5015  O   UNK D 928      57.224  23.653   6.113  1.00 86.31           O  
+ATOM   5016  CB  UNK D 928      60.227  24.348   6.518  1.00 84.86           C  
+ATOM   5017  N   UNK D 929      57.616  23.059   8.247  1.00 85.64           N  
+ATOM   5018  CA  UNK D 929      56.548  22.063   8.264  1.00 84.00           C  
+ATOM   5019  C   UNK D 929      55.228  22.827   8.404  1.00 83.41           C  
+ATOM   5020  O   UNK D 929      54.207  22.464   7.803  1.00 83.13           O  
+ATOM   5021  CB  UNK D 929      56.742  21.103   9.437  1.00 84.92           C  
+ATOM   5022  N   UNK D 930      55.268  23.900   9.192  1.00 81.54           N  
+ATOM   5023  CA  UNK D 930      54.103  24.752   9.402  1.00 80.04           C  
+ATOM   5024  C   UNK D 930      53.631  25.316   8.065  1.00 78.71           C  
+ATOM   5025  O   UNK D 930      52.457  25.187   7.717  1.00 77.32           O  
+ATOM   5026  CB  UNK D 930      54.452  25.894  10.353  1.00 81.36           C  
+ATOM   5027  N   UNK D 931      54.552  25.933   7.321  1.00 76.51           N  
+ATOM   5028  CA  UNK D 931      54.228  26.519   6.019  1.00 76.19           C  
+ATOM   5029  C   UNK D 931      53.492  25.500   5.181  1.00 76.40           C  
+ATOM   5030  O   UNK D 931      52.507  25.827   4.508  1.00 76.82           O  
+ATOM   5031  CB  UNK D 931      55.506  26.974   5.283  1.00 73.50           C  
+ATOM   5032  N   UNK D 932      53.982  24.262   5.235  1.00 76.77           N  
+ATOM   5033  CA  UNK D 932      53.402  23.153   4.487  1.00 75.21           C  
+ATOM   5034  C   UNK D 932      51.957  22.937   4.909  1.00 73.83           C  
+ATOM   5035  O   UNK D 932      51.034  22.961   4.080  1.00 72.16           O  
+ATOM   5036  CB  UNK D 932      54.219  21.885   4.724  1.00 76.29           C  
+ATOM   5037  N   UNK D 933      51.758  22.730   6.205  1.00 72.12           N  
+ATOM   5038  CA  UNK D 933      50.409  22.517   6.710  1.00 73.31           C  
+ATOM   5039  C   UNK D 933      49.507  23.654   6.258  1.00 73.38           C  
+ATOM   5040  O   UNK D 933      48.476  23.418   5.629  1.00 73.75           O  
+ATOM   5041  CB  UNK D 933      50.414  22.429   8.236  1.00 72.46           C  
+ATOM   5042  N   UNK D 934      49.911  24.887   6.569  1.00 72.02           N  
+ATOM   5043  CA  UNK D 934      49.124  26.064   6.216  1.00 69.67           C  
+ATOM   5044  C   UNK D 934      48.923  26.154   4.721  1.00 68.49           C  
+ATOM   5045  O   UNK D 934      47.840  26.509   4.255  1.00 67.72           O  
+ATOM   5046  CB  UNK D 934      49.800  27.337   6.737  1.00 70.29           C  
+ATOM   5047  N   UNK D 935      49.967  25.828   3.967  1.00 68.60           N  
+ATOM   5048  CA  UNK D 935      49.882  25.881   2.512  1.00 70.57           C  
+ATOM   5049  C   UNK D 935      48.903  24.827   1.995  1.00 71.14           C  
+ATOM   5050  O   UNK D 935      48.180  25.064   1.027  1.00 70.39           O  
+ATOM   5051  CB  UNK D 935      51.259  25.679   1.897  1.00 67.16           C  
+ATOM   5052  N   UNK D 936      48.877  23.667   2.648  1.00 74.13           N  
+ATOM   5053  CA  UNK D 936      47.973  22.584   2.254  1.00 77.37           C  
+ATOM   5054  C   UNK D 936      46.537  22.881   2.698  1.00 79.21           C  
+ATOM   5055  O   UNK D 936      45.602  22.804   1.889  1.00 80.68           O  
+ATOM   5056  CB  UNK D 936      48.442  21.265   2.853  1.00 78.68           C  
+ATOM   5057  N   UNK D 937      46.361  23.216   3.978  1.00 78.33           N  
+ATOM   5058  CA  UNK D 937      45.034  23.540   4.501  1.00 78.34           C  
+ATOM   5059  C   UNK D 937      44.452  24.604   3.590  1.00 78.18           C  
+ATOM   5060  O   UNK D 937      43.275  24.565   3.244  1.00 78.82           O  
+ATOM   5061  CB  UNK D 937      45.129  24.067   5.932  1.00 79.11           C  
+ATOM   5062  N   UNK D 938      45.297  25.549   3.191  1.00 78.46           N  
+ATOM   5063  CA  UNK D 938      44.878  26.619   2.298  1.00 78.08           C  
+ATOM   5064  C   UNK D 938      44.435  25.999   0.984  1.00 79.57           C  
+ATOM   5065  O   UNK D 938      43.433  26.413   0.399  1.00 78.05           O  
+ATOM   5066  CB  UNK D 938      46.025  27.580   2.063  1.00 75.23           C  
+ATOM   5067  N   UNK D 939      45.194  25.007   0.519  1.00 82.90           N  
+ATOM   5068  CA  UNK D 939      44.864  24.315  -0.723  1.00 83.98           C  
+ATOM   5069  C   UNK D 939      43.409  23.885  -0.611  1.00 85.16           C  
+ATOM   5070  O   UNK D 939      42.598  24.129  -1.512  1.00 84.70           O  
+ATOM   5071  CB  UNK D 939      45.766  23.097  -0.906  1.00 84.12           C  
+ATOM   5072  N   UNK D 940      43.078  23.265   0.518  1.00 85.77           N  
+ATOM   5073  CA  UNK D 940      41.715  22.811   0.757  1.00 87.17           C  
+ATOM   5074  C   UNK D 940      40.724  23.960   0.580  1.00 88.61           C  
+ATOM   5075  O   UNK D 940      39.749  23.842  -0.163  1.00 91.19           O  
+ATOM   5076  CB  UNK D 940      41.599  22.230   2.153  1.00 85.13           C  
+ATOM   5077  N   UNK D 941      40.977  25.077   1.252  1.00 88.63           N  
+ATOM   5078  CA  UNK D 941      40.081  26.219   1.153  1.00 88.94           C  
+ATOM   5079  C   UNK D 941      39.730  26.503  -0.299  1.00 88.81           C  
+ATOM   5080  O   UNK D 941      38.560  26.464  -0.678  1.00 88.37           O  
+ATOM   5081  CB  UNK D 941      40.717  27.449   1.792  1.00 88.32           C  
+ATOM   5082  N   UNK D 942      40.748  26.779  -1.110  1.00 90.14           N  
+ATOM   5083  CA  UNK D 942      40.546  27.082  -2.525  1.00 91.10           C  
+ATOM   5084  C   UNK D 942      39.773  25.964  -3.226  1.00 92.33           C  
+ATOM   5085  O   UNK D 942      39.028  26.218  -4.177  1.00 91.35           O  
+ATOM   5086  CB  UNK D 942      41.894  27.307  -3.211  1.00 89.85           C  
+ATOM   5087  N   UNK D 943      39.951  24.734  -2.744  1.00 92.61           N  
+ATOM   5088  CA  UNK D 943      39.272  23.567  -3.311  1.00 95.01           C  
+ATOM   5089  C   UNK D 943      37.809  23.507  -2.854  1.00 95.39           C  
+ATOM   5090  O   UNK D 943      37.378  22.528  -2.234  1.00 94.88           O  
+ATOM   5091  CB  UNK D 943      40.005  22.286  -2.898  1.00 94.56           C  
+ATOM   5092  N   UNK D 944      37.057  24.560  -3.167  1.00 93.90           N  
+ATOM   5093  CA  UNK D 944      35.653  24.661  -2.789  1.00 92.96           C  
+ATOM   5094  C   UNK D 944      35.060  25.877  -3.477  1.00 92.93           C  
+ATOM   5095  O   UNK D 944      34.830  26.880  -2.779  1.00 93.95           O  
+ATOM   5096  CB  UNK D 944      35.518  24.801  -1.270  1.00 90.78           C  
+ATOM   5097  OXT UNK D 944      34.855  25.825  -4.705  1.00 95.03           O  
+TER    5098      UNK D 944                                                      
+ATOM   5099  N   UNK E 945      36.533  31.112  -6.771  1.00 90.48           N  
+ATOM   5100  CA  UNK E 945      37.522  32.204  -7.026  1.00 90.75           C  
+ATOM   5101  C   UNK E 945      38.328  32.557  -5.774  1.00 89.53           C  
+ATOM   5102  O   UNK E 945      39.419  33.120  -5.872  1.00 90.07           O  
+ATOM   5103  CB  UNK E 945      36.803  33.455  -7.549  1.00 91.31           C  
+ATOM   5104  N   UNK E 946      37.790  32.225  -4.602  1.00 87.54           N  
+ATOM   5105  CA  UNK E 946      38.462  32.516  -3.333  1.00 85.03           C  
+ATOM   5106  C   UNK E 946      39.888  31.955  -3.298  1.00 81.81           C  
+ATOM   5107  O   UNK E 946      40.094  30.750  -3.137  1.00 79.58           O  
+ATOM   5108  CB  UNK E 946      37.641  31.959  -2.155  1.00 83.55           C  
+ATOM   5109  N   UNK E 947      40.866  32.847  -3.438  1.00 77.79           N  
+ATOM   5110  CA  UNK E 947      42.274  32.468  -3.439  1.00 74.24           C  
+ATOM   5111  C   UNK E 947      42.915  32.454  -2.040  1.00 72.16           C  
+ATOM   5112  O   UNK E 947      43.781  33.268  -1.741  1.00 69.88           O  
+ATOM   5113  CB  UNK E 947      43.045  33.408  -4.365  1.00 72.30           C  
+ATOM   5114  N   UNK E 948      42.492  31.522  -1.192  1.00 70.53           N  
+ATOM   5115  CA  UNK E 948      43.036  31.413   0.156  1.00 70.89           C  
+ATOM   5116  C   UNK E 948      44.560  31.309   0.086  1.00 72.38           C  
+ATOM   5117  O   UNK E 948      45.130  31.182  -1.003  1.00 74.78           O  
+ATOM   5118  CB  UNK E 948      42.450  30.192   0.857  1.00 71.12           C  
+ATOM   5119  N   UNK E 949      45.224  31.359   1.237  1.00 69.01           N  
+ATOM   5120  CA  UNK E 949      46.676  31.276   1.249  1.00 66.97           C  
+ATOM   5121  C   UNK E 949      47.254  30.936   2.617  1.00 66.91           C  
+ATOM   5122  O   UNK E 949      46.556  30.961   3.626  1.00 68.70           O  
+ATOM   5123  CB  UNK E 949      47.247  32.568   0.753  1.00 70.69           C  
+ATOM   5124  N   UNK E 950      48.535  30.603   2.644  1.00 66.15           N  
+ATOM   5125  CA  UNK E 950      49.203  30.253   3.893  1.00 68.76           C  
+ATOM   5126  C   UNK E 950      48.985  31.343   4.948  1.00 67.02           C  
+ATOM   5127  O   UNK E 950      48.725  31.059   6.122  1.00 64.89           O  
+ATOM   5128  CB  UNK E 950      50.711  30.055   3.644  1.00 69.50           C  
+ATOM   5129  N   UNK E 951      49.093  32.592   4.509  1.00 67.00           N  
+ATOM   5130  CA  UNK E 951      48.928  33.741   5.388  1.00 68.25           C  
+ATOM   5131  C   UNK E 951      47.469  33.943   5.773  1.00 66.65           C  
+ATOM   5132  O   UNK E 951      47.165  34.692   6.698  1.00 66.83           O  
+ATOM   5133  CB  UNK E 951      49.486  35.005   4.710  1.00 69.00           C  
+ATOM   5134  N   UNK E 952      46.565  33.275   5.065  1.00 67.00           N  
+ATOM   5135  CA  UNK E 952      45.142  33.392   5.372  1.00 65.90           C  
+ATOM   5136  C   UNK E 952      44.684  32.256   6.293  1.00 65.75           C  
+ATOM   5137  O   UNK E 952      43.496  32.102   6.555  1.00 65.77           O  
+ATOM   5138  CB  UNK E 952      44.321  33.411   4.087  1.00 63.51           C  
+ATOM   5139  N   UNK E 953      45.641  31.469   6.783  1.00 67.42           N  
+ATOM   5140  CA  UNK E 953      45.370  30.355   7.701  1.00 68.23           C  
+ATOM   5141  C   UNK E 953      46.118  30.668   8.993  1.00 67.32           C  
+ATOM   5142  O   UNK E 953      47.333  30.521   9.064  1.00 68.39           O  
+ATOM   5143  CB  UNK E 953      45.864  29.011   7.095  1.00 65.90           C  
+ATOM   5144  N   UNK E 954      45.380  31.085  10.017  1.00 69.33           N  
+ATOM   5145  CA  UNK E 954      45.963  31.491  11.295  1.00 68.74           C  
+ATOM   5146  C   UNK E 954      46.068  30.433  12.387  1.00 69.58           C  
+ATOM   5147  O   UNK E 954      45.060  29.941  12.885  1.00 69.95           O  
+ATOM   5148  CB  UNK E 954      45.195  32.710  11.822  1.00 67.26           C  
+ATOM   5149  N   UNK E 955      47.301  30.118  12.780  1.00 71.26           N  
+ATOM   5150  CA  UNK E 955      47.571  29.119  13.813  1.00 72.29           C  
+ATOM   5151  C   UNK E 955      47.803  29.749  15.187  1.00 73.85           C  
+ATOM   5152  O   UNK E 955      48.558  30.703  15.316  1.00 75.73           O  
+ATOM   5153  CB  UNK E 955      48.785  28.275  13.411  1.00 68.28           C  
+ATOM   5154  N   UNK E 956      47.156  29.204  16.214  1.00 77.16           N  
+ATOM   5155  CA  UNK E 956      47.291  29.717  17.576  1.00 79.64           C  
+ATOM   5156  C   UNK E 956      47.730  28.616  18.544  1.00 82.78           C  
+ATOM   5157  O   UNK E 956      47.971  27.478  18.133  1.00 83.20           O  
+ATOM   5158  CB  UNK E 956      45.968  30.320  18.037  1.00 78.39           C  
+ATOM   5159  N   UNK E 957      47.815  28.957  19.829  1.00 85.48           N  
+ATOM   5160  CA  UNK E 957      48.237  28.003  20.855  1.00 88.38           C  
+ATOM   5161  C   UNK E 957      49.596  27.448  20.437  1.00 91.05           C  
+ATOM   5162  O   UNK E 957      50.442  28.197  19.943  1.00 94.05           O  
+ATOM   5163  CB  UNK E 957      47.217  26.880  20.987  1.00 86.24           C  
+ATOM   5164  N   UNK E 958      49.817  26.151  20.630  1.00 90.93           N  
+ATOM   5165  CA  UNK E 958      51.090  25.542  20.242  1.00 91.66           C  
+ATOM   5166  C   UNK E 958      52.277  26.076  21.052  1.00 92.07           C  
+ATOM   5167  O   UNK E 958      52.072  26.979  21.889  1.00 93.64           O  
+ATOM   5168  CB  UNK E 958      51.337  25.770  18.746  1.00 89.41           C  
+ATOM   5169  OXT UNK E 958      53.408  25.588  20.836  1.00 91.33           O  
+TER    5170      UNK E 958                                                      
+HETATM 5171  C1  NAG A 800      78.943  71.316  49.196  1.00 90.12           C  
+HETATM 5172  C2  NAG A 800      78.474  71.698  50.620  1.00 92.58           C  
+HETATM 5173  C3  NAG A 800      77.751  73.065  50.645  1.00 91.62           C  
+HETATM 5174  C4  NAG A 800      78.564  74.122  49.918  1.00 90.73           C  
+HETATM 5175  C5  NAG A 800      78.848  73.625  48.506  1.00 91.32           C  
+HETATM 5176  C6  NAG A 800      79.629  74.628  47.682  1.00 90.42           C  
+HETATM 5177  C7  NAG A 800      77.684  70.198  52.347  1.00 95.56           C  
+HETATM 5178  C8  NAG A 800      76.774  70.809  53.404  1.00 96.16           C  
+HETATM 5179  N2  NAG A 800      77.573  70.667  51.107  1.00 95.17           N  
+HETATM 5180  O3  NAG A 800      77.541  73.485  51.985  1.00 91.12           O  
+HETATM 5181  O4  NAG A 800      77.841  75.343  49.879  1.00 90.70           O  
+HETATM 5182  O5  NAG A 800      79.634  72.411  48.568  1.00 91.35           O  
+HETATM 5183  O6  NAG A 800      80.677  73.992  46.967  1.00 91.24           O  
+HETATM 5184  O7  NAG A 800      78.474  69.304  52.656  1.00 95.15           O  
+HETATM 5185  C1  NAG A 801      83.514  55.932  30.937  1.00 88.71           C  
+HETATM 5186  C2  NAG A 801      83.685  55.430  32.377  1.00 89.54           C  
+HETATM 5187  C3  NAG A 801      85.132  55.644  32.848  1.00 89.73           C  
+HETATM 5188  C4  NAG A 801      86.134  55.083  31.825  1.00 89.86           C  
+HETATM 5189  C5  NAG A 801      85.828  55.629  30.427  1.00 88.99           C  
+HETATM 5190  C6  NAG A 801      86.742  55.055  29.358  1.00 88.49           C  
+HETATM 5191  C7  NAG A 801      82.206  55.542  34.284  1.00 89.64           C  
+HETATM 5192  C8  NAG A 801      82.777  55.837  35.661  1.00 89.22           C  
+HETATM 5193  N2  NAG A 801      82.772  56.151  33.247  1.00 89.80           N  
+HETATM 5194  O3  NAG A 801      85.320  54.997  34.096  1.00 88.45           O  
+HETATM 5195  O4  NAG A 801      87.460  55.436  32.197  1.00 90.73           O  
+HETATM 5196  O5  NAG A 801      84.466  55.305  30.063  1.00 89.07           O  
+HETATM 5197  O6  NAG A 801      86.058  54.130  28.528  1.00 88.59           O  
+HETATM 5198  O7  NAG A 801      81.254  54.769  34.169  1.00 91.19           O  
+HETATM 5199  C1  NAG A 802      41.035  83.603  46.375  1.00 84.59           C  
+HETATM 5200  C2  NAG A 802      39.562  83.151  46.358  1.00 85.39           C  
+HETATM 5201  C3  NAG A 802      38.677  84.242  45.754  1.00 87.96           C  
+HETATM 5202  C4  NAG A 802      38.860  85.530  46.562  1.00 88.16           C  
+HETATM 5203  C5  NAG A 802      40.350  85.919  46.549  1.00 89.39           C  
+HETATM 5204  C6  NAG A 802      40.660  87.167  47.363  1.00 88.39           C  
+HETATM 5205  C7  NAG A 802      38.588  80.966  46.090  1.00 85.51           C  
+HETATM 5206  C8  NAG A 802      37.467  80.519  45.176  1.00 85.61           C  
+HETATM 5207  N2  NAG A 802      39.409  81.906  45.627  1.00 86.30           N  
+HETATM 5208  O3  NAG A 802      37.313  83.835  45.774  1.00 88.19           O  
+HETATM 5209  O4  NAG A 802      38.074  86.571  45.997  1.00 87.85           O  
+HETATM 5210  O5  NAG A 802      41.157  84.846  47.097  1.00 88.31           O  
+HETATM 5211  O6  NAG A 802      39.627  87.446  48.299  1.00 88.55           O  
+HETATM 5212  O7  NAG A 802      38.697  80.467  47.212  1.00 83.01           O  
+HETATM 5213 CL    CL A 803      49.529  45.396  21.465  1.00 44.38          CL  
+HETATM 5214 ZN    ZN A 804      53.141  68.638  31.204  1.00 53.98          ZN  
+HETATM 5215  O   HOH A 805      46.427  59.279   7.270  1.00 29.12           O  
+HETATM 5216  O   HOH A 806      45.583  47.126  26.107  1.00 37.45           O  
+HETATM 5217  O   HOH A 807      53.516  43.492  15.547  1.00 42.05           O  
+HETATM 5218  O   HOH A 808      39.191  66.754  40.315  1.00 45.84           O  
+HETATM 5219  O   HOH A 809      57.485  64.702  34.642  1.00 44.94           O  
+HETATM 5220  O   HOH A 810      49.129  35.309  20.824  1.00 53.86           O  
+HETATM 5221  O   HOH A 811      38.406  72.879  48.630  1.00 53.87           O  
+HETATM 5222  O   HOH A 812      65.187  44.876  33.767  1.00 41.67           O  
+HETATM 5223  O   HOH A 813      61.712  51.520  33.680  1.00 45.00           O  
+HETATM 5224  O   HOH A 814      44.150  48.447  28.184  1.00 36.84           O  
+HETATM 5225  O   HOH A 815      52.053  57.417  18.687  1.00 48.28           O  
+HETATM 5226  O   HOH A 816      46.811  57.042  23.060  1.00 45.86           O  
+HETATM 5227  O   HOH A 817      67.709  76.273  33.108  1.00 49.87           O  
+HETATM 5228  O   HOH A 818      62.401  54.471  34.646  1.00 63.30           O  
+HETATM 5229  O   HOH A 819      65.285  76.813  36.259  1.00 46.22           O  
+HETATM 5230  O   HOH A 820      39.400  36.056  27.899  1.00 50.50           O  
+HETATM 5231  O   HOH A 821      50.030  55.414  30.198  1.00 43.81           O  
+HETATM 5232  O   HOH A 822      64.037  56.271  33.062  1.00 46.66           O  
+HETATM 5233  O   HOH A 823      53.968  69.268  28.974  1.00 54.00           O  
+HETATM 5234  O   HOH A 824      40.763  55.766  24.298  1.00 42.41           O  
+HETATM 5235  O   HOH A 825      58.529  57.509  15.421  1.00 48.49           O  
+HETATM 5236  O   HOH A 826      60.252  65.397  36.463  1.00 42.00           O  
+HETATM 5237  O   HOH A 827      61.675  50.228  24.063  1.00 36.17           O  
+HETATM 5238  O   HOH A 828      61.619  47.525   6.969  1.00 45.54           O  
+HETATM 5239  O   HOH A 829      39.076  68.346  38.399  1.00 41.27           O  
+HETATM 5240  O   HOH A 830      48.410  57.940  45.028  1.00 43.84           O  
+HETATM 5241  O   HOH A 831      60.795  42.215  36.550  1.00 48.19           O  
+HETATM 5242  O   HOH A 832      51.146  60.031  50.728  1.00 49.84           O  
+HETATM 5243  O   HOH A 833      45.493  55.535  18.816  1.00 46.43           O  
+HETATM 5244  O   HOH A 834      62.739  73.451  50.996  1.00 59.25           O  
+HETATM 5245  O   HOH A 835      46.054  46.484  21.897  1.00 47.01           O  
+HETATM 5246  O   HOH A 836      72.503  42.511  29.970  1.00 49.04           O  
+HETATM 5247  O   HOH A 837      36.361  42.670  35.606  1.00 48.78           O  
+HETATM 5248  O   HOH A 838      52.680  74.632  55.180  1.00 68.93           O  
+HETATM 5249  O   HOH A 839      67.553  43.946  36.128  1.00 58.00           O  
+HETATM 5250  O   HOH A 840      49.415  57.242  23.284  1.00 46.80           O  
+HETATM 5251  O   HOH A 841      37.085  62.030  45.451  1.00 45.44           O  
+HETATM 5252  O   HOH A 842      29.670  41.237  41.389  1.00 65.76           O  
+HETATM 5253  O   HOH A 843      50.978  43.111  41.925  1.00 60.71           O  
+HETATM 5254  O   HOH A 844      43.332  56.801  18.673  1.00 50.85           O  
+HETATM 5255  O   HOH A 845      49.381  62.019  50.474  1.00 52.61           O  
+HETATM 5256  O   HOH A 846      63.742  57.328  28.457  1.00 45.04           O  
+HETATM 5257  O   HOH A 847      66.623  61.400  43.610  1.00 44.20           O  
+HETATM 5258  O   HOH A 848      45.188  43.363  37.331  1.00 56.92           O  
+HETATM 5259  O   HOH A 849      57.677  79.123  41.446  1.00 48.60           O  
+HETATM 5260  O   HOH A 850      41.602  49.493  20.769  1.00 43.00           O  
+HETATM 5261  O   HOH A 851      31.108  62.223  24.659  1.00 63.18           O  
+HETATM 5262  O   HOH A 852      55.958  49.154  49.452  1.00 63.09           O  
+HETATM 5263  O   HOH A 853      51.992  90.121  43.237  1.00 67.71           O  
+HETATM 5264  O   HOH A 854      58.061  55.853  42.823  1.00 41.26           O  
+HETATM 5265  O   HOH A 855      27.203  50.846  25.687  1.00 55.12           O  
+HETATM 5266  O   HOH A 856      65.292  67.117  45.484  1.00 39.40           O  
+HETATM 5267  O   HOH A 857      77.976  73.460  41.335  1.00 59.05           O  
+HETATM 5268  O   HOH A 858      32.465  67.418  39.268  1.00 64.57           O  
+HETATM 5269  O   HOH A 859      62.948  46.804  48.244  1.00 64.08           O  
+HETATM 5270  O   HOH A 860      58.964  40.174  11.606  1.00 47.52           O  
+HETATM 5271  O   HOH A 861      51.025  64.806  31.954  1.00 64.71           O  
+HETATM 5272  O   HOH A 862      71.028  84.058  40.600  1.00 69.62           O  
+HETATM 5273  O   HOH A 863      57.818  33.879  32.426  1.00 61.41           O  
+HETATM 5274  O   HOH A 864      79.336  83.044  24.661  1.00 58.27           O  
+HETATM 5275  O   HOH A 865      72.083  57.975  14.125  1.00 70.42           O  
+HETATM 5276  O   HOH A 866      73.599  42.076  25.339  1.00 51.32           O  
+HETATM 5277  O   HOH A 867      47.432  39.740   9.535  1.00 50.94           O  
+HETATM 5278  O   HOH A 868      35.253  48.180   0.779  1.00 67.94           O  
+HETATM 5279  O   HOH A 869      69.840  46.496  40.474  1.00 53.11           O  
+HETATM 5280  O   HOH A 870      57.624  83.246  34.377  1.00 49.23           O  
+HETATM 5281  O   HOH A 871      52.131  62.704  30.718  1.00 59.71           O  
+HETATM 5282  O   HOH A 872      42.981  85.434  22.253  1.00 56.29           O  
+HETATM 5283  O   HOH A 873      62.473  45.978   9.035  1.00 52.63           O  
+HETATM 5284  O   HOH A 874      40.477  57.432   9.124  1.00 52.59           O  
+HETATM 5285  O   HOH A 875      65.482  56.557  26.918  1.00 66.55           O  
+HETATM 5286  O   HOH A 876      86.652  72.650  26.529  1.00 66.76           O  
+HETATM 5287  O   HOH A 877      62.406  88.484  33.068  1.00 49.37           O  
+HETATM 5288  O   HOH A 878      68.760  73.523  48.231  1.00 68.54           O  
+HETATM 5289  O   HOH A 879      29.151  41.288  23.217  1.00 61.04           O  
+HETATM 5290  O   HOH A 880      52.680  30.782  11.827  1.00 69.35           O  
+HETATM 5291  O   HOH A 881      38.005  52.171   6.725  1.00 60.85           O  
+HETATM 5292  O   HOH A 882      76.259  64.586  23.858  1.00 63.19           O  
+HETATM 5293  O   HOH A 883      43.563  61.775  15.725  1.00 83.88           O  
+HETATM 5294  O   HOH A 884      53.653  48.167   4.815  1.00 65.85           O  
+HETATM 5295  O   HOH A 885      31.158  38.245  40.124  1.00 69.85           O  
+HETATM 5296  O   HOH A 886      51.949  83.443  38.965  1.00 53.29           O  
+HETATM 5297  O   HOH A 887      70.218  41.427  33.670  1.00 56.13           O  
+HETATM 5298  O   HOH A 888      74.471  76.831  37.665  1.00 57.92           O  
+HETATM 5299  O   HOH A 889      36.973  61.058  47.983  1.00 55.75           O  
+HETATM 5300  O   HOH A 890      52.538  60.414  26.557  1.00 44.86           O  
+HETATM 5301  O   HOH A 891      52.702  55.777  10.540  1.00 36.15           O  
+HETATM 5302  O   HOH A 892      67.025  74.478  31.778  1.00 64.60           O  
+HETATM 5303  O   HOH A 893      46.243  36.749  10.372  1.00 60.58           O  
+HETATM 5304  O   HOH A 894      58.317  70.388  30.873  1.00 58.51           O  
+HETATM 5305  O   HOH A 895      51.910  58.349  11.624  1.00 46.20           O  
+HETATM 5306  O   HOH A 896      59.920  56.034  32.851  1.00 49.23           O  
+HETATM 5307  O   HOH A 897      49.262  47.591  23.856  1.00 47.06           O  
+HETATM 5308  O   HOH A 898      62.048  84.702  17.709  1.00 73.85           O  
+HETATM 5309  O   HOH A 899      43.430  60.483  26.645  1.00 50.72           O  
+HETATM 5310  O   HOH A 900      58.455  61.188  25.253  1.00 59.98           O  
+HETATM 5311  O   HOH A 901      52.160  67.110  28.748  1.00 62.27           O  
+HETATM 5312  O   HOH A 902      55.998  71.225  28.760  1.00 50.79           O  
+HETATM 5313  O   HOH A 903      49.153  32.812  21.106  1.00 70.17           O  
+HETATM 5314  O   HOH A 904      20.792  59.881  45.093  1.00 66.78           O  
+HETATM 5315  O   HOH A 905      63.308  49.737   6.585  1.00 59.98           O  
+HETATM 5316  O   HOH A 906      46.334  57.977  20.531  1.00 51.38           O  
+HETATM 5317  O   HOH A 907      56.192  61.841  24.819  1.00 78.39           O  
+HETATM 5318  O   HOH A 908      45.873  61.154  27.726  1.00 56.76           O  
+HETATM 5319  O   HOH A 909      89.776  54.411  31.431  1.00 77.25           O  
+HETATM 5320  O   HOH A 910      39.472  53.665   5.468  1.00 68.41           O  
+HETATM 5321  O   HOH A 911      60.819  85.485  19.603  1.00 77.71           O  
+HETATM 5322  O   HOH A 912      53.070  81.486  40.542  1.00 94.34           O  
+HETATM 5323  O   HOH A 913      47.443  34.694  25.223  1.00 67.12           O  
+HETATM 5324  O   HOH A 914      61.413  85.298  29.320  1.00 54.36           O  
+HETATM 5325  O   HOH A 915      34.374  40.506  34.854  1.00 56.45           O  
+HETATM 5326  O   HOH A 916      62.160  69.102  43.440  1.00 45.80           O  
+HETATM 5327  O   HOH A 917      60.988  48.139  48.614  1.00 63.47           O  
+HETATM 5328  O   HOH A 918      27.944  74.665  28.338  1.00 65.44           O  
+HETATM 5329  O   HOH A 919      67.062  59.347  41.996  1.00 45.92           O  
+HETATM 5330  O   HOH A 920     101.681  64.857  50.865  1.00 57.67           O  
+HETATM 5331  O   HOH A 921      47.006  35.588  12.691  1.00 54.45           O  
+HETATM 5332  O   HOH A 922      46.380  59.651  23.546  1.00 55.32           O  
+HETATM 5333  O   HOH A 923      70.374  58.821  15.622  1.00 74.26           O  
+HETATM 5334  O   HOH A 924      63.939  54.956  18.200  1.00 45.43           O  
+HETATM 5335  O   HOH A 925      23.515  50.555  29.935  1.00 66.43           O  
+HETATM 5336  O   HOH A 926      70.276  49.629  43.232  1.00 63.19           O  
+HETATM 5337  O   HOH A 927      63.379  79.614  44.454  1.00 68.49           O  
+HETATM 5338  O   HOH A 928      69.633  61.684  44.279  1.00 49.19           O  
+HETATM 5339  O   HOH A 929      74.750  75.811  21.949  1.00 57.62           O  
+HETATM 5340  O   HOH A 930      67.380  79.082  15.149  1.00 68.72           O  
+HETATM 5341  O   HOH A 931      28.421  37.672  42.947  1.00 79.87           O  
+HETATM 5342  O   HOH A 932      46.337  63.565  31.344  1.00 63.68           O  
+HETATM 5343  O   HOH A 933      70.409  40.525  31.062  1.00 58.87           O  
+HETATM 5344  O   HOH A 934      27.759  78.087  33.557  1.00 73.66           O  
+HETATM 5345  O   HOH A 935      81.845  46.767  16.779  1.00 65.82           O  
+HETATM 5346  O   HOH A 936      84.988  58.177  38.671  1.00 74.50           O  
+HETATM 5347  O   HOH A 937      62.773  36.041  15.905  1.00 59.46           O  
+HETATM 5348  O   HOH A 938      70.344  52.169  47.319  1.00 49.65           O  
+HETATM 5349  O   HOH A 939      41.857  79.849  37.071  1.00 49.80           O  
+HETATM 5350  O   HOH A 940      24.994  57.929  43.441  1.00 60.80           O  
+HETATM 5351  O   HOH A 941      50.113  60.220  53.016  1.00 63.07           O  
+HETATM 5352  O   HOH A 942      46.239  56.972   0.492  1.00 59.99           O  
+HETATM 5353  O   HOH A 943      39.879  55.067  49.704  1.00 73.28           O  
+HETATM 5354  O   HOH A 944      26.111  54.449  28.752  1.00 57.03           O  
+HETATM 5355  O   HOH A 945      54.775  56.967   4.340  1.00 61.74           O  
+HETATM 5356  O   HOH A 946      72.153  60.342  46.275  1.00 66.08           O  
+HETATM 5357  O   HOH A 947      53.134  57.736  13.991  1.00 48.19           O  
+HETATM 5358  O   HOH A 948      49.555  68.790  53.922  1.00 72.55           O  
+HETATM 5359  O   HOH A 949      51.739  88.259  26.259  1.00 79.98           O  
+HETATM 5360  O   HOH A 950      52.213  34.081  31.430  1.00 63.84           O  
+HETATM 5361  O   HOH A 951      65.844  48.256   7.346  1.00 71.09           O  
+HETATM 5362  O   HOH A 952      64.863  75.198  26.799  1.00 66.85           O  
+HETATM 5363  O   HOH A 953      31.492  53.903  13.012  1.00 58.28           O  
+HETATM 5364  O   HOH A 954      24.461  50.613  27.207  1.00 59.76           O  
+HETATM 5365  O   HOH A 955      27.007  77.806  43.094  1.00 70.99           O  
+HETATM 5366  O   HOH A 956      41.868  53.284  -6.602  1.00 57.98           O  
+HETATM 5367  O   HOH A 957      58.040  62.627  23.195  1.00 64.39           O  
+HETATM 5368  O   HOH A 958      65.016  46.682   9.036  1.00 66.25           O  
+HETATM 5369  O   HOH A 959      70.529  59.644  43.463  1.00 53.55           O  
+HETATM 5370  O   HOH A 960      71.269  40.701  25.519  1.00 59.46           O  
+HETATM 5371  O   HOH A 961      49.902  34.171  24.421  1.00 61.07           O  
+HETATM 5372  O   HOH A 962      50.667  60.933  28.224  1.00 78.35           O  
+HETATM 5373  O   HOH A 963      51.329  57.974  21.458  1.00 70.98           O  
+HETATM 5374  O   HOH A 964      52.486  60.730  10.855  1.00 61.69           O  
+HETATM 5375  O   HOH A 965      64.842  45.025  47.712  1.00 65.36           O  
+HETATM 5376  O   HOH A 966      59.347  68.279  31.632  1.00 84.08           O  
+HETATM 5377  O   HOH A 967      61.101  65.479  33.734  1.00 61.87           O  
+HETATM 5378  O   HOH A 968      65.074  57.108  19.054  1.00 50.02           O  
+HETATM 5379  O   HOH A 969      78.228  85.212  23.471  1.00 69.92           O  
+HETATM 5380  O   HOH A 970      30.920  42.782  33.024  1.00 54.44           O  
+HETATM 5381  O   HOH A 971      77.831  77.058  47.710  1.00 58.48           O  
+HETATM 5382  O   HOH A 972      44.478  40.324  37.445  1.00 85.49           O  
+HETATM 5383  O   HOH A 973      32.451  68.440  37.089  1.00 72.35           O  
+HETATM 5384  O   HOH A 974      21.636  58.266  43.064  1.00 73.94           O  
+HETATM 5385  O   HOH A 975      73.304  58.653  44.870  1.00 54.41           O  
+HETATM 5386  O   HOH A 976      44.331  48.636  30.917  1.00 46.41           O  
+HETATM 5387  O   HOH A 977      68.246  73.633  33.453  1.00 61.30           O  
+HETATM 5388  O   HOH A 978      64.697  57.922  30.829  1.00 55.82           O  
+HETATM 5389  O   HOH A 979      69.129  64.105  42.774  1.00 59.06           O  
+HETATM 5390  O   HOH A 980      30.144  68.298  39.068  1.00 91.36           O  
+HETATM 5391  O   HOH A 981      65.973  50.540   4.905  1.00 83.51           O  
+HETATM 5392  O   HOH A 982      63.255  82.147  39.889  1.00 58.93           O  
+HETATM 5393  O   HOH A 983      45.550  58.314  51.691  1.00 74.27           O  
+HETATM 5394  O   HOH A 984      62.018  85.619  11.305  1.00 71.76           O  
+HETATM 5395  O   HOH A 985      54.690  55.423   2.307  1.00 66.27           O  
+HETATM 5396  O   HOH A 986      60.357  86.512  12.731  1.00 62.54           O  
+HETATM 5397  O   HOH A 987      24.308  77.573  34.760  1.00 72.86           O  
+HETATM 5398  O   HOH A 988      64.856  58.312  22.698  1.00 57.82           O  
+HETATM 5399  O   HOH A 989      36.595  69.273  38.401  1.00 59.92           O  
+HETATM 5400  O   HOH A 990      65.220  35.544  15.787  1.00 65.55           O  
+HETATM 5401  O   HOH A 991      87.132  75.793  27.808  1.00 66.73           O  
+HETATM 5402  O   HOH A 992      61.720  64.570  31.403  1.00 75.12           O  
+HETATM 5403  O   HOH A 993      47.724  58.952   3.967  1.00 59.78           O  
+HETATM 5404  O   HOH A 994      77.652  78.309  50.014  1.00 59.28           O  
+HETATM 5405  O   HOH A 995      56.347  62.044  27.559  1.00 73.36           O  
+HETATM 5406  O   HOH A 996      60.842  36.174  14.318  1.00 65.60           O  
+HETATM 5407  O   HOH A 997      41.877  82.798  38.557  1.00 61.93           O  
+HETATM 5408  O   HOH A 998      59.302  34.198  30.587  1.00 63.04           O  
+HETATM 5409  O   HOH A 999      66.796  61.022  39.326  1.00 60.57           O  
+HETATM 5410  O   HOH A1000      34.923  60.352  49.350  1.00 55.44           O  
+HETATM 5411  O   HOH A1001      63.501  86.884  30.694  1.00 63.55           O  
+HETATM 5412  O   HOH A1002      81.083  81.037  40.126  1.00 67.67           O  
+HETATM 5413  O   HOH A1003      41.382  49.075  44.316  1.00 49.22           O  
+HETATM 5414  O   HOH A1004      40.145  68.938  42.405  1.00 54.35           O  
+HETATM 5415  O   HOH A1005      35.042  51.223  21.065  1.00 50.47           O  
+HETATM 5416  O   HOH A1006      20.849  50.902  29.218  1.00 68.64           O  
+HETATM 5417  O   HOH A1007      88.516  74.027  26.129  1.00 69.15           O  
+HETATM 5418  O   HOH A1008      70.171  39.507  28.876  1.00 83.15           O  
+HETATM 5419  O   HOH A1009      56.158  68.918  55.561  1.00 74.77           O  
+HETATM 5420  O   HOH A1010      58.619  53.560  44.474  1.00 46.94           O  
+HETATM 5421  O   HOH A1011      71.140  80.911  19.205  1.00 68.19           O  
+HETATM 5422  O   HOH A1012      71.171  54.774  22.374  1.00 56.66           O  
+HETATM 5423  O   HOH A1013      51.139  66.969  54.223  1.00 62.23           O  
+HETATM 5424  O   HOH A1014      82.385  45.940  19.910  1.00 87.37           O  
+HETATM 5425  O   HOH A1015      67.018  71.043  51.645  1.00 61.76           O  
+HETATM 5426  O   HOH A1016      84.537  72.320  33.393  1.00 54.10           O  
+HETATM 5427  O   HOH A1017      39.903  74.318  50.458  1.00 64.07           O  
+HETATM 5428  O   HOH A1018      75.016  77.437  12.620  1.00 79.40           O  
+HETATM 5429  O   HOH A1019      80.554  47.024  22.859  1.00 78.45           O  
+HETATM 5430  O   HOH A1020      47.108  34.476  30.620  1.00 54.70           O  
+HETATM 5431  O   HOH A1021      22.781  50.543  24.772  1.00 79.88           O  
+HETATM 5432  O   HOH A1022      42.967  83.252  20.945  1.00 61.38           O  
+HETATM 5433  O   HOH A1023      48.562  46.622   4.328  1.00 69.07           O  
+HETATM 5434  O   HOH A1024      49.981  62.811   8.853  1.00 56.61           O  
+HETATM 5435  O   HOH A1025      29.783  62.538  22.483  1.00 69.69           O  
+HETATM 5436  O   HOH A1026      28.143  73.750  31.414  1.00 73.32           O  
+HETATM 5437  O   HOH A1027      78.514  55.246  33.641  1.00 67.88           O  
+HETATM 5438  O   HOH A1028      63.429  81.933  43.894  1.00 65.22           O  
+HETATM 5439  O   HOH A1029      75.608  59.657  56.377  1.00 76.63           O  
+HETATM 5440  O   HOH A1030      64.173  64.504  36.464  1.00 61.39           O  
+HETATM 5441  O   HOH A1031      19.073  58.176  45.922  1.00 70.24           O  
+HETATM 5442  O   HOH A1032      58.371  63.971  30.280  1.00 86.31           O  
+HETATM 5443  O   HOH A1033      35.715  53.902  20.984  1.00 60.42           O  
+HETATM 5444  O   HOH A1034      69.183  60.973  38.327  1.00 77.79           O  
+HETATM 5445  O   HOH A1035      47.458  62.001  22.855  1.00 88.67           O  
+HETATM 5446  O   HOH A1036      49.002  62.021  20.498  1.00 91.95           O  
+HETATM 5447  O   HOH A1037      54.957  69.157  26.880  1.00 63.39           O  
+HETATM 5448  O   HOH A1038      25.831  51.234  22.921  1.00 63.71           O  
+HETATM 5449  O   HOH A1039      52.549  60.220  22.824  1.00 67.65           O  
+HETATM 5450  O   HOH A1040      64.801  70.333  52.358  1.00 64.23           O  
+HETATM 5451  O   HOH A1041      47.884  58.791  52.640  1.00 72.12           O  
+HETATM 5452  O   HOH A1042      41.553  66.796  42.894  1.00 69.79           O  
+HETATM 5453  O   HOH A1043      48.262  69.620  19.906  1.00 71.58           O  
+HETATM 5454  O   HOH A1044      65.495  59.414  20.419  1.00 63.83           O  
+HETATM 5455  O   HOH A1045      34.117  72.078  43.698  1.00 67.02           O  
+HETATM 5456  O   HOH A1046      46.696  60.619  32.537  1.00 62.80           O  
+HETATM 5457  O   HOH A1047      21.286  57.008  45.217  1.00 68.21           O  
+HETATM 5458  O   HOH A1048      24.370  78.200  32.372  1.00 78.20           O  
+HETATM 5459  O   HOH A1049      53.711  57.598   0.794  1.00 75.91           O  
+HETATM 5460  O   HOH A1050      64.086  73.105  33.867  1.00 50.83           O  
+HETATM 5461  O   HOH A1051      85.750  74.011  30.997  1.00 69.81           O  
+HETATM 5462  O   HOH A1052      50.130  65.143  28.336  1.00 68.61           O  
+HETATM 5463  O   HOH A1053      41.236  61.511  50.158  1.00 71.44           O  
+HETATM 5464  O   HOH A1054      71.331  40.191  35.590  1.00 76.34           O  
+HETATM 5465  O   HOH A1055      81.522  77.949  48.219  1.00 74.22           O  
+HETATM 5466  O   HOH A1056      34.219  69.586  29.172  1.00 76.89           O  
+HETATM 5467  O   HOH A1057      44.864  45.598   4.876  1.00 75.13           O  
+HETATM 5468  O   HOH A1058      62.114  28.853  25.134  1.00 59.96           O  
+HETATM 5469  O   HOH A1059      67.043  56.948  21.619  1.00 56.99           O  
+HETATM 5470  O   HOH A1060      22.894  60.015  46.558  1.00 85.20           O  
+HETATM 5471  O   HOH A1061      58.168  40.495  40.929  1.00 71.80           O  
+HETATM 5472  O   HOH A1062      86.152  56.882  37.006  1.00 91.54           O  
+HETATM 5473  O   HOH A1063      73.783  60.244  58.948  1.00 77.11           O  
+HETATM 5474  O   HOH A1064      74.313  77.417  15.187  1.00 82.96           O  
+HETATM 5475  O   HOH A1065      89.774  55.526  29.276  1.00 95.40           O  
+HETATM 5476  O   HOH A1066      27.048  38.360  40.328  1.00 97.41           O  
+HETATM 5477  O   HOH A1067      37.715  75.020  52.876  1.00 61.94           O  
+HETATM 5478  O   HOH A1068      47.137  32.593  28.242  1.00 55.58           O  
+HETATM 5479  O   HOH A1069      91.698  56.387  31.226  1.00 82.40           O  
+HETATM 5480  O   HOH A1070      49.749  58.028  31.237  1.00 60.93           O  
+HETATM 5481  O   HOH A1071      61.513  83.215  41.395  1.00 72.30           O  
+HETATM 5482  O   HOH A1072      78.126  45.325  34.785  1.00 67.08           O  
+HETATM 5483  O   HOH A1073      27.958  75.478  40.160  1.00 71.91           O  
+HETATM 5484  O   HOH A1074      74.742  37.924  28.056  1.00 90.85           O  
+HETATM 5485  O   HOH A1075      45.212  66.670  35.828  1.00 59.73           O  
+HETATM 5486  O   HOH A1076      91.840  69.250  38.497  1.00 82.85           O  
+HETATM 5487  O   HOH A1077      28.026  41.803  32.921  1.00 64.18           O  
+HETATM 5488  O   HOH A1078      73.866  80.525  18.321  1.00 81.88           O  
+HETATM 5489  O   HOH A1079      92.440  53.890  29.601  1.00 96.77           O  
+HETATM 5490  O   HOH A1080      39.065  53.570  -6.937  1.00 72.48           O  
+HETATM 5491  O   HOH A1081      66.406  34.773  23.663  1.00 65.76           O  
+HETATM 5492  O   HOH A1082      58.708  65.814  32.551  1.00 66.63           O  
+HETATM 5493  O   HOH A1083      30.692  64.896  27.635  1.00 70.58           O  
+HETATM 5494  O   HOH A1084      62.005  85.371  32.028  1.00 64.44           O  
+HETATM 5495  O   HOH A1085      54.002  61.200  20.847  1.00 74.90           O  
+HETATM 5496  O   HOH A1086      37.897  63.660  33.066  1.00 58.39           O  
+HETATM 5497  O   HOH A1087      44.860  39.542  40.569  1.00 68.12           O  
+HETATM 5498  O   HOH A1088      72.057  51.503  45.856  1.00 66.96           O  
+HETATM 5499  O   HOH A1089      77.930  72.951  43.817  1.00 64.03           O  
+HETATM 5500  O   HOH A1090      29.775  39.843  33.490  1.00 63.01           O  
+HETATM 5501  O   HOH A1091      73.124  53.371  49.495  1.00 62.82           O  
+HETATM 5502  O   HOH A1092      36.787  65.792  55.265  1.00 67.90           O  
+HETATM 5503  O   HOH A1093      66.448  64.080  43.072  1.00 66.62           O  
+HETATM 5504  O   HOH A1094      32.890  39.996  12.704  1.00 63.72           O  
+HETATM 5505  O   HOH A1095      45.812  71.489  42.965  1.00 61.37           O  
+HETATM 5506  O   HOH A1096      66.114  77.327  44.428  1.00 53.30           O  
+HETATM 5507  O   HOH A1097      35.899  55.129  10.026  1.00 68.52           O  
+HETATM 5508  O   HOH A1098      43.008  54.626  50.894  1.00 65.05           O  
+HETATM 5509  O   HOH A1099      46.778  68.598  33.536  1.00 73.55           O  
+HETATM 5510  O   HOH A1100      30.015  43.919  42.999  1.00 65.14           O  
+HETATM 5511  O   HOH A1101      33.606  59.134  23.909  1.00 63.25           O  
+HETATM 5512  O   HOH A1102      63.331  55.574  51.305  1.00 65.39           O  
+HETATM 5513  O   HOH C 288      34.040  35.595   5.900  1.00 59.04           O  
+HETATM 5514  O   HOH E 112      45.335  30.577  -3.627  1.00 70.66           O  
+HETATM 5515  O   HOH E 190      50.009  31.161   0.595  1.00 77.36           O  
+HETATM 5516  O   HOH E 235      49.599  33.863   1.879  1.00 65.45           O  
+CONECT  592 5171                                                                
+CONECT  696 5185                                                                
+CONECT  919  981                                                                
+CONECT  981  919                                                                
+CONECT 2653 2789                                                                
+CONECT 2789 2653                                                                
+CONECT 2894 5214                                                                
+CONECT 2925 5214                                                                
+CONECT 3118 5214                                                                
+CONECT 3119 5214                                                                
+CONECT 4186 4277                                                                
+CONECT 4277 4186                                                                
+CONECT 4307 5199                                                                
+CONECT 5171  592 5172 5182                                                      
+CONECT 5172 5171 5173 5179                                                      
+CONECT 5173 5172 5174 5180                                                      
+CONECT 5174 5173 5175 5181                                                      
+CONECT 5175 5174 5176 5182                                                      
+CONECT 5176 5175 5183                                                           
+CONECT 5177 5178 5179 5184                                                      
+CONECT 5178 5177                                                                
+CONECT 5179 5172 5177                                                           
+CONECT 5180 5173                                                                
+CONECT 5181 5174                                                                
+CONECT 5182 5171 5175                                                           
+CONECT 5183 5176                                                                
+CONECT 5184 5177                                                                
+CONECT 5185  696 5186 5196                                                      
+CONECT 5186 5185 5187 5193                                                      
+CONECT 5187 5186 5188 5194                                                      
+CONECT 5188 5187 5189 5195                                                      
+CONECT 5189 5188 5190 5196                                                      
+CONECT 5190 5189 5197                                                           
+CONECT 5191 5192 5193 5198                                                      
+CONECT 5192 5191                                                                
+CONECT 5193 5186 5191                                                           
+CONECT 5194 5187                                                                
+CONECT 5195 5188                                                                
+CONECT 5196 5185 5189                                                           
+CONECT 5197 5190                                                                
+CONECT 5198 5191                                                                
+CONECT 5199 4307 5200 5210                                                      
+CONECT 5200 5199 5201 5207                                                      
+CONECT 5201 5200 5202 5208                                                      
+CONECT 5202 5201 5203 5209                                                      
+CONECT 5203 5202 5204 5210                                                      
+CONECT 5204 5203 5211                                                           
+CONECT 5205 5206 5207 5212                                                      
+CONECT 5206 5205                                                                
+CONECT 5207 5200 5205                                                           
+CONECT 5208 5201                                                                
+CONECT 5209 5202                                                                
+CONECT 5210 5199 5203                                                           
+CONECT 5211 5204                                                                
+CONECT 5212 5205                                                                
+CONECT 5214 2894 2925 3118 3119                                                 
+CONECT 5214 5233                                                                
+CONECT 5233 5214                                                                
+MASTER      413    0    5   33    8    0    0    6 5511    5   58   55          
+END                                                                             

--- a/nim-skills/rfdiffusion-nim/evals/config.yml
+++ b/nim-skills/rfdiffusion-nim/evals/config.yml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  runtime_env:
+    - NGC_API_KEY
+
+grading:
+  mode: aces_default

--- a/nim-skills/rfdiffusion-nim/evals/evals.json
+++ b/nim-skills/rfdiffusion-nim/evals/evals.json
@@ -3,10 +3,15 @@
   "evals": [
     {
       "id": "1",
-      "prompt": "I want to design a de novo protein backbone with RFDiffusion. Generate a protein of around 80-120 residues from scratch with the maximum quality settings. Use the hosted NVIDIA API.",
-      "expected_output": "A Python script that calls the hosted RFDiffusion endpoint with Bearer auth, contigs set to '80-120' (or similar length range), diffusion_steps=50, passes a non-empty minimal dummy PDB string as input_pdb because live hosted validation requires input_pdb or input_pdb_asset even for de novo generation, and saves the returned PDB file.",
+      "prompt": "I want to design a de novo protein backbone with RFDiffusion. Generate a protein of around 80-120 residues from scratch with the maximum quality settings using the hosted NVIDIA API. Create and execute the request now using NGC_API_KEY from the environment, save the requested artifacts, and report values from the actual response; do not stop after writing the script.",
+      "expected_output": "A successfully executed hosted RFDiffusion request with Bearer auth, an 80-120 residue contig range, diffusion_steps=50, and the required non-empty dummy input_pdb, plus the actual returned backbone saved as a PDB artifact and summarized from the response.",
       "files": [],
       "assertions": [
+        {
+          "id": "hosted-request-executed",
+          "description": "Executes the hosted request instead of only writing code",
+          "check": "Trajectory shows successful execution of the hosted request, and the final response reports actual response-derived backbone information and the saved .pdb path"
+        },
         {
           "id": "hosted-endpoint-url",
           "description": "Uses the correct hosted RFDiffusion endpoint URL",
@@ -38,7 +43,9 @@
           "check": "Script includes an 'input_pdb' field with a minimal non-empty PDB string such as CRYST1/ATOM/END; it must not omit both input_pdb and input_pdb_asset because live hosted validation requires one of them even for de novo generation"
         }
       ]
-    },
+    }
+  ],
+  "deferred_evals": [
     {
       "id": "2",
       "prompt": "I have a protein structure (target.pdb) with a functional motif at residues 25-35 of chain A. I want to scaffold this motif — keep those residues and design a new protein structure of 50-80 residues around them. Use the hosted RFDiffusion API.",
@@ -116,6 +123,7 @@
       ]
     },
     {
+      "todo": "Waiting on local Docker setup in Harbor before enabling this eval.",
       "id": "4",
       "prompt": "Help me set up RFDiffusion locally with Docker on my GPU machine. I have an A100 and NGC_API_KEY set. Once it's running, design a de novo protein backbone of 100 residues.",
       "expected_output": "Docker setup instructions using shell env first and optional repo-root .env overrides, requiring NGC_API_KEY or NVIDIA_API_KEY fallback plus LOCAL_NIM_CACHE, with the correct image (:2 tag), single GPU flag, cache mount, health check loop, then a local no-auth prediction script targeting localhost:8000 without /v1/ prefix and passing a non-empty dummy input_pdb for de novo generation.",


### PR DESCRIPTION
Add a suite of evals for nim-skills, using the nim-hosted endpoints.

Follow-up MRs will add harbor native tasks (and i.e. corresponding local docker setups required to run the evals locally).