### PR TITLE
Aggregate Proteina-Complexa from aggregator-compat fix branch (interim)

### DIFF
--- a/components.d/proteina-complexa.yml
+++ b/components.d/proteina-complexa.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Proteina-Complexa
+repo: NVIDIA-BioNeMo/Proteina-Complexa
+# INTERIM: sourced from the `aggregator-compat` fix branch (PR #57), which carries
+# the co-located evals/ + the self-contained complexa-sweep (reference/SWEEP.md)
+# that `dev` does not have yet. Switch ref to `dev` once #57 merges — the branch
+# is deleted on merge, which would otherwise break the sync.
+ref: aggregator-compat
+skills:
+  - path: .claude/skills
+    catalog_dir: open-models-skills/proteina-complexa

--- a/open-models-skills/proteina-complexa/README.md
+++ b/open-models-skills/proteina-complexa/README.md
@@ -1,0 +1,51 @@
+# Proteina-Complexa Skills
+
+Five project-local Claude Code skills covering setup, target configuration, design, evaluation, and sweeps. Each skill picks the cheapest tool for its job — the `complexa` CLI where it adds real value (pipeline orchestration, weight downloads, Hydra-defaults validation), and direct file edits / Python module calls where the CLI would just be a thin wrapper.
+
+## The three design pipelines
+
+Complexa runs one of three pipelines. **Protein binder is the default**; the other two are extensions for ligand pockets and enzyme scaffolding. Pick the pipeline by picking the `configs/search_*_pipeline.yaml` file — each one pins its own model checkpoint, autoencoder, targets dict, reward, and refold backend, so switching pipelines is "swap the config + change the target name".
+
+| Pipeline (intent) | Config YAML | Model ckpt | Targets dict | Task-name pattern | Download flag |
+|---|---|---|---|---|---|
+| **Protein binder (default)** | `configs/search_binder_local_pipeline.yaml` | `complexa.ckpt` + `complexa_ae.ckpt` | `configs/targets/targets_dict.yaml` | `02_PDL1`, `22_DerF21`, … | `--complexa --all` |
+| Ligand binder (small-molecule pocket) | `configs/search_ligand_binder_local_pipeline.yaml` | `complexa_ligand.ckpt` + `complexa_ligand_ae.ckpt` | `configs/targets/ligand_targets_dict.yaml` | `39_7V11_LIGAND`, `41_7BKC_LIGAND`, … | `--complexa-ligand --all` |
+| AME (motif + ligand, enzyme scaffolding) | `configs/search_ame_local_pipeline.yaml` | `complexa_ame.ckpt` + `complexa_ame_ae.ckpt` | `configs/design_tasks/ame_dict_v2.yaml` | `M0024_1nzy`, `M0096_1chm`, … | `--complexa-ame --all` |
+
+**If the user doesn't specify a pipeline, default to protein binder.** Switch to one of the others only when the request explicitly names a ligand pocket / SMILES / enzyme / `M####_<pdb>` task. See [`complexa-design/SKILL.md`](./complexa-design/SKILL.md) Step 2 for the full "what changes when you switch pipeline" cheat sheet and [`complexa-design/reference/pipelines.md`](./complexa-design/reference/pipelines.md) for the deep dive (reward weights, success thresholds, LoRA, `USE_V2_COMPLEXA_ARCH`).
+
+## Skills
+
+Each skill picks the cheapest tool for the job — sometimes the `complexa` CLI,
+sometimes a direct file edit or Python module call. The "primary tool" column
+is the default the skill recommends; the alternatives are still documented
+inside each `SKILL.md` for cases where they fit better.
+
+| Skill | Primary tool | CLI / alternative paths | When to use it |
+|---|---|---|---|
+| [`complexa-setup`](./complexa-setup/) | **File-edit** for `.env` + **CLI** (`complexa download`) for weights | `complexa init` is a `cp+sed` wrapper, fine either way; `complexa validate env` and `validate design` are the recommended CLI checks | Fresh checkout, verifying an existing install, configuring `.env` |
+| [`complexa-target`](./complexa-target/) | **File-edit** of `configs/targets/{,ligand_}targets_dict.yaml` | `complexa target add/list/show` (CLI is a thin YAML-append wrapper); `complexa validate target` still has unique value (Hydra defaults traversal) | Registering a new protein or ligand design target |
+| [`complexa-design`](./complexa-design/) | **CLI** (`complexa design <pipeline>` orchestrates 4 stages with logging) | Direct `python -m proteinfoundation.{generate,filter,evaluate,analyze}` for single-stage debug | Protein binder, ligand binder, AME motif scaffolding |
+| [`complexa-evaluate-pdbs`](./complexa-evaluate-pdbs/) | **CLI** (`complexa analysis <eval_cfg>` chains evaluate→analyze) | Direct `python -m proteinfoundation.{evaluate,analyze}` for debugging | Re-folding / scoring an existing PDB directory with AF2 / RF3 / ESMFold |
+| [`complexa-sweep`](./complexa-sweep/) | **Python script** (`script_utils/generate_inference_configs.py`) + a `complexa design` loop | No CLI — `complexa design` does not accept `--sweeper`; generate configs first, then loop | Finding optimal beam_width, nsteps, reward weights, etc. |
+
+## Shared infrastructure
+
+| File | Purpose |
+|---|---|
+| [`_shared/scripts/preflight.sh`](./_shared/scripts/preflight.sh) | One-shot system probe (GPU, VRAM, disk, checkpoints, tools, `.env`). Outputs `preflight.json`. |
+| [`_shared/scripts/write_manifest.py`](./_shared/scripts/write_manifest.py) | Emits a pinned, replayable `run_manifest.json` per pipeline run. |
+| [`_shared/reference/hardware.md`](./_shared/reference/hardware.md) | Per-pipeline hardware requirements. |
+
+The skills require `complexa` (this repo's CLI), `bash`, and optionally `nvidia-smi`.
+
+## Adding a new skill
+
+These skills were authored with Anthropic's [`skill-creator`](https://github.com/anthropics/skills/tree/main/skill-creator) workflow:
+
+1. **Draft** — `SKILL.md` (≤300 lines) + progressive-disclosure `reference/*.md`. Anchor authoring to specific source files (`cli_runner.py`, `target_cli.py`, `configs/**`).
+2. **Test prompts** — a handful of realistic agent prompts per skill.
+3. **Parallel eval** — for each prompt, run a with-skill agent vs a baseline; grade against objective assertions (uses correct flag? cites real override key? runs preflight?).
+4. **Iterate** on regressions.
+
+The flagship reference is [`complexa-design`](./complexa-design/) — its SKILL.md anchors on a real scientific task (full pipeline → success rate + diversity) and shows the progressive-disclosure pattern at its widest (3 reference files).

--- a/open-models-skills/proteina-complexa/_shared/reference/hardware.md
+++ b/open-models-skills/proteina-complexa/_shared/reference/hardware.md
@@ -1,0 +1,80 @@
+# Proteina-Complexa Hardware Reference
+
+Shared hardware reference for every `complexa-*` skill. Tables only — see each
+skill's `SKILL.md` "Hardware" section for the user-facing prose. Numbers marked
+`(empirical)` are not pulled from any doc and represent conservative defaults
+based on the configs in this repo.
+
+## Per-pipeline GPU requirements
+
+| Pipeline           | Config                                            | Min VRAM (GB) | Recommended VRAM (GB) | Supported SKUs            | Single-GPU only |
+|--------------------|---------------------------------------------------|--------------:|----------------------:|---------------------------|-----------------|
+| Protein Binder     | `search_binder_local_pipeline.yaml`               |  24 (empirical) |  40 (empirical)       | H100, A100-80, L40S       | Yes             |
+| Ligand Binder      | `search_ligand_binder_local_pipeline.yaml`        |  32 (empirical) |  48 (empirical)       | H100, A100-80, L40S       | Yes             |
+| AME (motif+ligand) | `search_ame_local_pipeline.yaml`                  |  32 (empirical) |  48 (empirical)       | H100, A100-80, L40S       | Yes             |
+
+Notes:
+- All three inference pipelines are single-GPU (the `complexa generate` stage
+  is one process per `gen_njobs` slot; jobs do not shard a single design
+  across GPUs).
+- AME requires `USE_V2_COMPLEXA_ARCH=True`, set via `env_vars:` in
+  `configs/search_ame_local_pipeline.yaml` (no runtime VRAM impact).
+- Multi-GPU hosts run multiple pipelines / stages in parallel by bumping
+  `gen_njobs` / `eval_njobs` — each job takes one GPU.
+
+## Per-evaluation-backend requirements
+
+| Backend             | Min VRAM (GB) | Extra packages / env             | Wall-clock per sample      |
+|---------------------|--------------:|----------------------------------|----------------------------|
+| ColabDesign / AF2   |            16 | JAX + ColabFold; `AF2_DIR`       | ~30–60 s (empirical)       |
+| RoseTTAFold3 (rf3)  |            24 | `RF3_EXEC_PATH`, `RF3_CKPT_PATH` | ~60–180 s (empirical)      |
+| ESMFold             |            16 | `fair-esm`, internet/cache OK    | ~5–15 s (empirical)        |
+
+Selected via `++metric.binder_folding_method=colabdesign|rf3_latest|esmfold`.
+
+## Search-algorithm cost multipliers
+
+Relative to `single-pass` (= 1.0×) at fixed `nsteps` and `dataloader.batch_size`.
+
+| Algorithm    | Override key                                | Wall-clock | Peak VRAM |
+|--------------|---------------------------------------------|-----------:|----------:|
+| single-pass  | `++generation.search.algorithm=single_pass` |        1.0× |     1.0× |
+| best-of-n    | `…=best_of_n` + `n=N`                       |        N×  |     1.0× |
+| beam-search  | `…=beam_search` + `beam_width=W,n_branch=B` |     W·B× ≈ W× |  ~1.1× |
+| FK-steering  | `…=fk_steering` + `num_particles=N`         |       ~2N× |     1.2× |
+| MCTS         | `…=mcts` + `beam_width=W`                   |       ≥W×  |     1.2× |
+
+Memory is roughly constant — search algorithms reuse the same model forward;
+only beam/FK/MCTS retain extra candidate tensors per branch.
+
+## CPU / RAM / disk
+
+Defaults pulled from `configs/search_*_local_pipeline.yaml`:
+
+| Pipeline           | `ncpus_` | `gen_njobs` | `eval_njobs` | RAM (rec.) | Output disk / 100 designs |
+|--------------------|---------:|------------:|-------------:|-----------:|--------------------------:|
+| Protein Binder     |       24 |           2 |            2 |  32 GB (empirical) | ~10–20 GB (empirical) |
+| Ligand Binder      |       24 |           2 |            2 |  32 GB (empirical) | ~15–30 GB (empirical) |
+| AME                |       24 |           2 |            2 |  32 GB (empirical) | ~20–50 GB (empirical) |
+
+`keep_folding_outputs=true` (eval default) roughly doubles the output disk
+footprint — set to `false` if disk is tight.
+
+## When you hit OOM
+
+Try these in order — cheapest mitigations first:
+
+- Reduce `++generation.dataloader.batch_size` (often the biggest VRAM lever).
+- Reduce `++gen_njobs` (frees one inference process worth of memory).
+- Reduce `++generation.args.nsteps` (less VRAM tied up in trajectory buffers
+  when using search algorithms that retain steps).
+- Reduce `++generation.search.beam_search.beam_width` /
+  `++generation.search.beam_search.n_branch`.
+- Set `++metric.keep_folding_outputs=false` to free fold-stage RAM/disk
+  pressure (helps when an OOM lands during evaluation).
+- Switch fold backend: `++metric.binder_folding_method=esmfold` is the
+  cheapest; `rf3_latest` is the heaviest.
+- For AME: confirm `USE_V2_COMPLEXA_ARCH=True` matches the AME checkpoint —
+  loading the wrong arch wastes ~10–20% VRAM (empirical).
+- Multi-GPU host: set `CUDA_VISIBLE_DEVICES=<idx>` to pin the run to a single
+  card and avoid PyTorch placing tensors on a busy peer GPU.

--- a/open-models-skills/proteina-complexa/_shared/scripts/preflight.sh
+++ b/open-models-skills/proteina-complexa/_shared/scripts/preflight.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# preflight.sh — Probe local system for Proteina-Complexa readiness; emit JSON.
+#
+# Probes GPU (name/VRAM/count/driver/CUDA), disk free in $CKPT_PATH, the six
+# canonical Complexa ckpts, the six tool binaries (foldseek/mmseqs/dssp/hbplus/
+# sc/rf3), .env loadability + required-var presence, community model paths
+# (AF2_DIR/ESM_DIR/RF3_CKPT_PATH), and git SHA. Every probe degrades to
+# {available:false} / {exists:false} rather than failing.
+#
+# Usage: bash preflight.sh [--quiet] [--out PATH] [--help]
+set -euo pipefail
+
+QUIET=0; OUT="./preflight.json"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --quiet) QUIET=1; shift ;;
+        --out)   OUT="${2:-}"; shift 2 ;;
+        --help|-h) sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+json_str() {
+    local v="${1-}"
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))' "$v"
+    else
+        printf '"%s"' "$(printf '%s' "$v" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+    fi
+}
+
+# Source .env in a subshell and dump variables we care about as KEY<TAB>VALUE.
+ENV_FILE="$PWD/.env"; ENV_LOADED=false
+declare -A V=()
+if [[ -f "$ENV_FILE" ]]; then
+    ENV_LOADED=true
+    DUMP=$(bash -c '
+        set -a
+        source "'"$ENV_FILE"'" 2>/dev/null || true
+        set +a
+        for k in LOCAL_CODE_PATH LOCAL_DATA_PATH CKPT_PATH LOCAL_CHECKPOINT_PATH \
+                 COMPLEXA_RUNTIME FOLDSEEK_EXEC MMSEQS_EXEC DSSP_EXEC HBPLUS_EXEC \
+                 SC_EXEC RF3_EXEC_PATH AF2_DIR ESM_DIR RF3_CKPT_PATH; do
+            printf "%s\t%s\n" "$k" "${!k-}"
+        done' 2>/dev/null || true)
+    while IFS=$'\t' read -r k v; do [[ -n "$k" ]] && V["$k"]="$v"; done <<<"$DUMP"
+fi
+# Fall through to live env for any unset keys
+for k in LOCAL_CODE_PATH LOCAL_DATA_PATH CKPT_PATH LOCAL_CHECKPOINT_PATH \
+         COMPLEXA_RUNTIME FOLDSEEK_EXEC MMSEQS_EXEC DSSP_EXEC HBPLUS_EXEC \
+         SC_EXEC RF3_EXEC_PATH AF2_DIR ESM_DIR RF3_CKPT_PATH; do
+    [[ -z "${V[$k]:-}" ]] && V["$k"]="${!k-}"
+done
+
+# Resolve CKPT_PATH: explicit -> LOCAL_CHECKPOINT_PATH -> $LOCAL_CODE_PATH/ckpts
+if [[ -z "${V[CKPT_PATH]:-}" ]]; then
+    if   [[ -n "${V[LOCAL_CHECKPOINT_PATH]:-}" ]]; then V[CKPT_PATH]="${V[LOCAL_CHECKPOINT_PATH]}"
+    elif [[ -n "${V[LOCAL_CODE_PATH]:-}"       ]]; then V[CKPT_PATH]="${V[LOCAL_CODE_PATH]}/ckpts"
+    fi
+fi
+
+MISSING=()
+for req in LOCAL_CODE_PATH LOCAL_DATA_PATH CKPT_PATH; do
+    [[ -z "${V[$req]:-}" ]] && MISSING+=("$req")
+done
+
+# ---- GPU ----
+GPU_JSON='{"available":false}'
+if command -v nvidia-smi >/dev/null 2>&1; then
+    OUT_LINES=$(nvidia-smi --query-gpu=name,memory.total,driver_version \
+                           --format=csv,noheader,nounits 2>/dev/null || true)
+    if [[ -n "$OUT_LINES" ]]; then
+        N=$(printf '%s\n' "$OUT_LINES" | wc -l | tr -d ' ')
+        F=$(printf '%s\n' "$OUT_LINES" | head -n1)
+        NAME=$(printf '%s' "$F" | awk -F',' '{gsub(/^ +| +$/,"",$1); print $1}')
+        VRAM_MIB=$(printf '%s' "$F" | awk -F',' '{gsub(/[^0-9]/,"",$2); print $2}')
+        VRAM_GB=$(( VRAM_MIB / 1024 ))
+        DRV=$(printf '%s' "$F" | awk -F',' '{gsub(/^ +| +$/,"",$3); print $3}')
+        CUDA=$(nvidia-smi 2>/dev/null | sed -n 's/.*CUDA Version: *\([0-9.]*\).*/\1/p' | head -n1)
+        GPU_JSON=$(printf '{"available":true,"name":%s,"vram_gb":%s,"count":%s,"driver":%s,"cuda":%s}' \
+            "$(json_str "$NAME")" "$VRAM_GB" "$N" "$(json_str "$DRV")" "$(json_str "${CUDA:-unknown}")")
+    fi
+fi
+
+# ---- Disk ----
+DISK_FREE="null"; DISK_TARGET="${V[CKPT_PATH]:-}"
+if [[ -n "$DISK_TARGET" ]]; then
+    DP="$DISK_TARGET"; [[ ! -d "$DP" ]] && DP="$(dirname -- "$DP" 2>/dev/null || echo /)"
+    if [[ -d "$DP" ]]; then
+        FREE_KB=$(df -P -k -- "$DP" 2>/dev/null | awk 'NR==2{print $4}')
+        [[ -n "${FREE_KB:-}" ]] && DISK_FREE=$(( FREE_KB / 1024 / 1024 ))
+    fi
+fi
+DISK_JSON=$(printf '{"ckpt_path":%s,"free_gb":%s}' "$(json_str "$DISK_TARGET")" "$DISK_FREE")
+
+# ---- Checkpoints ----
+CKPT_ITEMS=()
+for name in complexa.ckpt complexa_ae.ckpt complexa_ligand.ckpt complexa_ligand_ae.ckpt complexa_ame.ckpt complexa_ame_ae.ckpt; do
+    p="${V[CKPT_PATH]%/}/$name"; ex=false; size="null"; sha="null"
+    if [[ -n "${V[CKPT_PATH]:-}" && -f "$p" ]]; then
+        ex=true
+        sz=$(stat -c %s -- "$p" 2>/dev/null || stat -f %z -- "$p" 2>/dev/null || echo "")
+        [[ -n "$sz" ]] && size="$sz"
+        if command -v sha256sum >/dev/null 2>&1; then
+            s=$(sha256sum -- "$p" 2>/dev/null | cut -c1-16 || echo "")
+        elif command -v shasum >/dev/null 2>&1; then
+            s=$(shasum -a 256 -- "$p" 2>/dev/null | cut -c1-16 || echo "")
+        fi
+        [[ -n "${s:-}" ]] && sha="$(json_str "$s")"
+    fi
+    CKPT_ITEMS+=("$(json_str "$name"):$(printf '{"path":%s,"exists":%s,"size":%s,"sha256":%s}' "$(json_str "$p")" "$ex" "$size" "$sha")")
+done
+CKPT_JSON="{$(IFS=,; echo "${CKPT_ITEMS[*]}")}"
+
+# ---- Tools ----
+TOOL_ITEMS=()
+for entry in "foldseek=${V[FOLDSEEK_EXEC]:-}" "mmseqs=${V[MMSEQS_EXEC]:-}" \
+             "dssp=${V[DSSP_EXEC]:-}"         "hbplus=${V[HBPLUS_EXEC]:-}" \
+             "sc=${V[SC_EXEC]:-}"             "rf3=${V[RF3_EXEC_PATH]:-}"; do
+    k="${entry%%=*}"; p="${entry#*=}"; ex=false
+    [[ -n "$p" && ( -x "$p" || -f "$p" ) ]] && ex=true
+    TOOL_ITEMS+=("$(json_str "$k"):$(printf '{"path":%s,"exists":%s}' "$(json_str "$p")" "$ex")")
+done
+TOOLS_JSON="{$(IFS=,; echo "${TOOL_ITEMS[*]}")}"
+
+# ---- Community models ----
+cm() { local k="$1" p="$2" ex=false; [[ -n "$p" && -e "$p" ]] && ex=true; printf '%s:{"path":%s,"exists":%s}' "$(json_str "$k")" "$(json_str "$p")" "$ex"; }
+COMMUNITY_JSON="{$(cm AF2_DIR "${V[AF2_DIR]:-}"),$(cm ESM_DIR "${V[ESM_DIR]:-}"),$(cm RF3_CKPT_PATH "${V[RF3_CKPT_PATH]:-}")}"
+
+# ---- Env summary ----
+MISS_JSON="[]"
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    parts=(); for m in "${MISSING[@]}"; do parts+=("$(json_str "$m")"); done
+    MISS_JSON="[$(IFS=,; echo "${parts[*]}")]"
+fi
+ENV_JSON=$(printf '{".env_loaded":%s,".env_path":%s,"missing_required":%s,"LOCAL_CODE_PATH":%s,"LOCAL_DATA_PATH":%s,"CKPT_PATH":%s}' \
+    "$ENV_LOADED" "$(json_str "$ENV_FILE")" "$MISS_JSON" \
+    "$(json_str "${V[LOCAL_CODE_PATH]:-}")" "$(json_str "${V[LOCAL_DATA_PATH]:-}")" "$(json_str "${V[CKPT_PATH]:-}")")
+
+# ---- Git SHA ----
+GIT_SHA="unknown"; GIT_DIR="${V[LOCAL_CODE_PATH]:-$PWD}"
+if command -v git >/dev/null 2>&1; then
+    c=$(git -C "$GIT_DIR" rev-parse --short HEAD 2>/dev/null || true)
+    [[ -z "$c" ]] && c=$(git rev-parse --short HEAD 2>/dev/null || true)
+    [[ -n "$c" ]] && GIT_SHA="$c"
+fi
+
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+DOC=$(printf '{"timestamp":%s,"gpu":%s,"disk":%s,"checkpoints":%s,"tools":%s,"env":%s,"community_models":%s,"complexa_runtime":%s,"git_sha":%s}' \
+    "$(json_str "$TS")" "$GPU_JSON" "$DISK_JSON" "$CKPT_JSON" "$TOOLS_JSON" "$ENV_JSON" "$COMMUNITY_JSON" \
+    "$(json_str "${V[COMPLEXA_RUNTIME]:-}")" "$(json_str "$GIT_SHA")")
+
+PRETTY="$DOC"
+if command -v jq >/dev/null 2>&1; then
+    PRETTY=$(printf '%s' "$DOC" | jq . 2>/dev/null || printf '%s' "$DOC")
+elif command -v python3 >/dev/null 2>&1; then
+    PRETTY=$(printf '%s' "$DOC" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin), indent=2))' 2>/dev/null || printf '%s' "$DOC")
+fi
+
+printf '%s\n' "$PRETTY" > "$OUT"
+[[ "$QUIET" == "1" ]] || printf '%s\n' "$PRETTY"

--- a/open-models-skills/proteina-complexa/_shared/scripts/write_manifest.py
+++ b/open-models-skills/proteina-complexa/_shared/scripts/write_manifest.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""write_manifest.py — emit run_manifest.json for a Proteina-Complexa run.
+
+This is the R8/R9 replayable-artifact emitter shared by all `complexa-*` skills.
+It captures:
+
+  * Timestamp (UTC, ISO-8601)
+  * The skill that produced the run, and the resolved `complexa …` command
+  * The Hydra-resolved config (copied inline from <output_dir>/.hydra/config.yaml)
+  * Git SHA of the repo (resolved by walking up from this file to pyproject.toml)
+  * Per-checkpoint SHA-256 over the first 4096 bytes + size  (4K truncation is
+    intentional — model files are multi-GB and full hashes are slow; the first
+    4K still detects accidental re-downloads or path mix-ups)
+  * Invocation metadata: argv, cwd, user, host
+  * Pointers to result CSVs found under <output_dir> (capped at 50)
+
+Stdlib-only on purpose: this often runs before any venv is active.
+
+Usage:
+    python3 write_manifest.py \\
+        --output-dir /path/to/inference/<run_name> \\
+        --command   "complexa design <config> ++run_name=foo …" \\
+        --skill     complexa-design \\
+        [--out ./run_manifest.json]
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CKPT_KEYS = ("ckpt_path", "ckpt_name", "autoencoder_ckpt_path")
+HASH_FIRST_N_BYTES = 4096
+MAX_CSV_POINTERS = 50
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--output-dir", required=True, help="Run output directory (contains .hydra/config.yaml)")
+    p.add_argument("--command", required=True, help="The complexa invocation that produced the run")
+    p.add_argument("--skill", required=True, help="Skill name (e.g. complexa-design)")
+    p.add_argument("--out", default="./run_manifest.json", help="Manifest path (default: ./run_manifest.json)")
+    return p.parse_args()
+
+
+def find_repo_root(start: Path) -> Path | None:
+    """Walk up from `start` looking for a pyproject.toml. Returns None if not found."""
+    for parent in [start, *start.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return None
+
+
+def git_sha(repo_root: Path | None) -> str:
+    """Best-effort `git rev-parse HEAD`. Returns 'unknown' on any failure."""
+    if repo_root is None:
+        return "unknown"
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if res.returncode == 0:
+            return res.stdout.strip() or "unknown"
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+    return "unknown"
+
+
+def read_hydra_config(output_dir: Path) -> tuple[str | None, str | None]:
+    """Return (config_text, config_path) or (None, None) if .hydra/config.yaml is absent."""
+    candidate = output_dir / ".hydra" / "config.yaml"
+    if not candidate.is_file():
+        return None, None
+    try:
+        return candidate.read_text(encoding="utf-8", errors="replace"), str(candidate)
+    except OSError:
+        return None, str(candidate)
+
+
+def scan_ckpt_keys(config_text: str) -> dict[str, str]:
+    """Pull scalar values for any of CKPT_KEYS out of a Hydra YAML dump.
+
+    Intentionally a tiny line-based parser — stdlib has no YAML module and we
+    only need three well-known keys at any depth. Treats the first scalar after
+    `<key>:` as the value. Hydra resolvers like `${oc.env:CKPT_PATH}` are
+    captured verbatim; the caller can decide whether to hash them.
+    """
+    found: dict[str, str] = {}
+    for raw in config_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        for key in CKPT_KEYS:
+            prefix = f"{key}:"
+            if line.startswith(prefix):
+                val = line[len(prefix):].strip().strip("'").strip('"')
+                # Skip block-scalar/list markers
+                if val and not val.startswith(("|", ">", "-", "[", "{")):
+                    found.setdefault(key, val)
+                break
+    return found
+
+
+def hash_first_4k(path: Path) -> dict[str, Any]:
+    """Return {path, sha256_first_4k, size_bytes, exists} for `path`."""
+    info: dict[str, Any] = {"path": str(path), "exists": False, "sha256_first_4k": None, "size_bytes": None}
+    try:
+        if not path.is_file():
+            return info
+        info["exists"] = True
+        info["size_bytes"] = path.stat().st_size
+        with path.open("rb") as fh:
+            info["sha256_first_4k"] = hashlib.sha256(fh.read(HASH_FIRST_N_BYTES)).hexdigest()
+    except (OSError, ValueError):
+        pass
+    return info
+
+
+def resolve_ckpts(ckpt_fields: dict[str, str]) -> dict[str, dict[str, Any]]:
+    """Build manifest.checkpoints from the scanned ckpt fields.
+
+    Joins `ckpt_path` + `ckpt_name` if both are scalars (no `${…}` interpolation
+    left). Always also records `autoencoder_ckpt_path` if present.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    ckpt_path = ckpt_fields.get("ckpt_path", "")
+    ckpt_name = ckpt_fields.get("ckpt_name", "")
+    ae_path = ckpt_fields.get("autoencoder_ckpt_path", "")
+
+    if ckpt_path and ckpt_name and "${" not in ckpt_path and "${" not in ckpt_name:
+        out["ckpt"] = hash_first_4k(Path(ckpt_path) / ckpt_name)
+    elif ckpt_path or ckpt_name:
+        out["ckpt"] = {"path": f"{ckpt_path}/{ckpt_name}".strip("/"), "exists": False,
+                       "sha256_first_4k": None, "size_bytes": None,
+                       "note": "unresolved Hydra interpolation; cannot hash"}
+
+    if ae_path:
+        if "${" not in ae_path:
+            out["autoencoder_ckpt"] = hash_first_4k(Path(ae_path))
+        else:
+            out["autoencoder_ckpt"] = {"path": ae_path, "exists": False,
+                                       "sha256_first_4k": None, "size_bytes": None,
+                                       "note": "unresolved Hydra interpolation; cannot hash"}
+    return out
+
+
+def collect_csv_pointers(output_dir: Path, cap: int = MAX_CSV_POINTERS) -> list[str]:
+    """Walk output_dir for *.csv files, cap at `cap`, return relative paths."""
+    if not output_dir.is_dir():
+        return []
+    found: list[str] = []
+    for p in sorted(output_dir.rglob("*.csv")):
+        try:
+            found.append(str(p.relative_to(output_dir)))
+        except ValueError:
+            found.append(str(p))
+        if len(found) >= cap:
+            break
+    return found
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    repo_root = find_repo_root(Path(__file__).resolve())
+
+    config_text, config_path = read_hydra_config(output_dir)
+    ckpt_fields = scan_ckpt_keys(config_text) if config_text else {}
+
+    manifest: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "skill": args.skill,
+        "command": args.command,
+        "output_dir": str(output_dir),
+        "git_sha": git_sha(repo_root),
+        "repo_root": str(repo_root) if repo_root else None,
+        "config_path": config_path,
+        "config": config_text,
+        "checkpoints": resolve_ckpts(ckpt_fields),
+        "invocation": {
+            "argv": sys.argv,
+            "cwd": os.getcwd(),
+            "user": getpass.getuser(),
+            "host": socket.gethostname(),
+        },
+        "pointers": {"csv_files": collect_csv_pointers(output_dir)},
+        "notes": {
+            "checkpoint_hash": f"sha256 over first {HASH_FIRST_N_BYTES} bytes (truncated for speed)",
+            "csv_pointers_cap": MAX_CSV_POINTERS,
+        },
+    }
+
+    out_path = Path(args.out).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    print(f"Wrote manifest: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/open-models-skills/proteina-complexa/complexa-design/SKILL.md
+++ b/open-models-skills/proteina-complexa/complexa-design/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: complexa-design
+description: >
+  End-to-end Proteina-Complexa design pipeline driver. Reach for this skill whenever
+  the user wants to "design a binder", "design binders for X", "run complexa
+  design", "de novo binder", "PDL1 binder", "TrkA binder", "design proteins for
+  target", "protein binder design", "ligand binder", "design a small-molecule
+  binder", "ATP-binding protein", "AME motif scaffolding", "scaffold a motif
+  near a ligand", "motif + ligand design", "enzyme scaffolding", "flow matching
+  protein design", "beam-search binder", "FK steering", "MCTS protein design",
+  "refold with AF2", "refold with RF3", or wants success rates, interface pAE,
+  scRMSD, or
+  FoldSeek diversity from a single command. This is the scientific anchor of
+  the skill set: it drives `complexa design <pipeline>` from target picking to
+  manifest emission and tells the user how many designs passed.
+compatibility: "complexa CLI installed (pip install -e .); .env populated; 1x CUDA GPU >=40GB VRAM (A100/H100/L40S); 24 CPUs; ~50GB disk"
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Complexa Design Skill
+
+Drive the full four-stage `complexa design` pipeline: generate (flow matching +
+search) -> filter (top-N by reward) -> evaluate (refold with AF2/RF3) ->
+analyze (success rate, FoldSeek/MMseqs diversity). Pick the right pipeline
+config for the design intent, validate the run upfront so the user does not
+discover a missing ckpt mid-folding, run it, and emit a replayable manifest +
+per-design success CSV.
+
+## What this skill enables
+
+- Protein binder design for protein targets (AF2 reward + ColabDesign refold).
+- Ligand binder design for small-molecule targets (RF3 reward + RF3 refold).
+- AME motif scaffolding with ligand context (motif + ligand features, RF3).
+- Search-based optimization: single-pass, best-of-n, beam-search, fk-steering, mcts.
+- Refold backends: ColabDesign (AF2), RF3, Boltz2, ESMFold (fast iteration).
+- Pass-rate + diversity analysis with per-`result_type` thresholds.
+
+## Step 1: Pre-flight
+
+Always run the shared preflight before launching a design — generation needs the
+GPU and the right checkpoint, evaluation needs AF2/RF3 weights and tool
+binaries. Bail early if the host cannot run the chosen pipeline.
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+Read `./complexa_setup/preflight.json` and bail if any of these are missing for
+the chosen pipeline:
+
+- `gpu.available: false` -> all pipelines fail.
+- `gpu.vram_gb < 40` -> generation OOMs at default `batch_size: 16`; lower to 8.
+- `ckpts.complexa[.ckpt]` -> required for protein binder.
+- `ckpts.complexa_ligand[.ckpt]` -> required for ligand binder.
+- `ckpts.complexa_ame[.ckpt]` -> required for AME.
+- `env.AF2_DIR` missing -> protein binder default eval (`colabdesign`) fails.
+- `env.RF3_CKPT_PATH` or `env.RF3_EXEC_PATH` missing -> ligand binder / AME default eval (`rf3_latest`) fails.
+
+If a ckpt is missing, point at `complexa-setup` and have the user run
+`complexa download --complexa-<variant>` first.
+
+## Step 2: Pick the pipeline
+
+Complexa has **one default pipeline (protein binder) and two extensions**
+(ligand binder, AME / enzyme). The pipeline is selected entirely
+by the `configs/search_*_pipeline.yaml` you pass to `complexa design` — each
+YAML pins its own model checkpoint, autoencoder, targets dict, default reward,
+and default refold backend. Switching pipelines is just "swap the config path
+and the target name comes from a different dict".
+
+### Default — protein binder
+
+```bash
+complexa design configs/search_binder_local_pipeline.yaml \
+    ++run_name=pdl1_v1 ++generation.task_name=02_PDL1
+```
+
+Use this when the user says "design a binder for X", "PDL1 binder",
+"de novo binder", "design proteins for a target", etc. — i.e. the target is
+a protein surface. The config pins `complexa.ckpt` + `complexa_ae.ckpt`, reads
+targets from `configs/targets/targets_dict.yaml`, rewards with AF2
+(`af2folding`), inverse-folds with SolubleMPNN, and evaluates with
+ColabDesign / AF2. **If the user did not specify, this is what they want.**
+
+### Extension A — ligand binder (small-molecule pocket)
+
+```bash
+complexa design configs/search_ligand_binder_local_pipeline.yaml \
+    ++run_name=v11_v1 ++generation.task_name=39_7V11_LIGAND \
+    ++metric.binder_folding_method=rf3_latest
+```
+
+Switch to this when the user says "ligand binder", "small-molecule pocket",
+"SMILES target", "ATP-binding protein", or names a target ending in
+`_LIGAND` / from the FAD / SAM / OQO / 7V11 / etc. families. The config
+**also activates LoRA** (`r=32`, `lora_alpha=64`) which is required for the
+released ligand checkpoint — leave the `lora:` block alone.
+
+### Extension B — AME / motif + ligand (enzyme scaffolding)
+
+```bash
+complexa design configs/search_ame_local_pipeline.yaml \
+    ++run_name=ame_chm ++generation.task_name=M0096_1chm
+```
+
+Switch to this when the user says "scaffold a motif near a ligand",
+"active-site design", "enzyme scaffolding", "AME", or names a target like
+`M0024_1nzy`, `M0096_1chm` (the `M####_<pdb>` AME task naming). The config sets
+`env_vars.USE_V2_COMPLEXA_ARCH=True` (the CLI runner injects it into the
+subprocess) and uses both `MotifFeatures` and `LigandFeatures`. Default search
+is `single-pass`; switch to `best-of-n` only if you also enable the
+`CompositeRewardModel` (commented out in `ame_generate.yaml`).
+
+### Pipeline cheat sheet — what changes when you switch
+
+| Knob | Protein binder (default) | Ligand binder | AME (enzyme) |
+|---|---|---|---|
+| **Pipeline YAML** | `configs/search_binder_local_pipeline.yaml` | `configs/search_ligand_binder_local_pipeline.yaml` | `configs/search_ame_local_pipeline.yaml` |
+| **Model ckpt** | `complexa.ckpt` | `complexa_ligand.ckpt` | `complexa_ame.ckpt` |
+| **Autoencoder ckpt** | `complexa_ae.ckpt` | `complexa_ligand_ae.ckpt` | `complexa_ame_ae.ckpt` |
+| **Targets dict** | `configs/targets/targets_dict.yaml` | `configs/targets/ligand_targets_dict.yaml` | `configs/design_tasks/ame_dict_v2.yaml` |
+| **Task-name pattern** | `<NN>_<NAME>` (e.g. `02_PDL1`, `22_DerF21`) | `<NN>_<PDB>_LIGAND` (e.g. `39_7V11_LIGAND`) | `M####_<pdb>` (e.g. `M0096_1chm`) |
+| **`USE_V2_COMPLEXA_ARCH`** | (unset → v1) | (unset → v1) | `"True"` (set in YAML) |
+| **LoRA** | (none) | required (`r=32, alpha=64`) | required |
+| **Default search algo** | `best-of-n` | `best-of-n` | `single-pass` |
+| **Reward model** | AF2 (`af2folding`) | RF3 (`rf3folding`) | `null` (no reward at default) |
+| **Inverse folder** | `soluble_mpnn` | `ligand_mpnn` | `ligand_mpnn` |
+| **Default refold backend** | `colabdesign` (AF2) | `rf3_latest` | `rf3_latest` |
+| **Analysis `result_type`** | `protein_binder` | `ligand_binder` | `motif_ligand_binder` |
+| **Required ckpts (`complexa download`)** | `--complexa --all` (AF2 in community) | `--complexa-ligand --all` (RF3 in community) | `--complexa-ame --all` (RF3 in community) |
+
+For the full per-pipeline breakdown (reward weights, success thresholds,
+analysis modes), see [reference/pipelines.md](reference/pipelines.md).
+
+## Step 3: Gather parameters
+
+Use AskUserQuestion to fill in the four parameters that vary every run. Default
+to sensible production settings if the user has no preference.
+
+- **Target name** — must be a key in the relevant dict (`targets_dict.yaml` for
+  protein binder, `ligand_targets_dict.yaml` for ligand, `ame_dict_v2.yaml` for
+  AME). If the user names a target that is not in the dict, hand off to
+  `complexa-target` to add it first.
+- **Run name** — a short identifier appended to the output dir (e.g. `pdl1_v1`).
+- **Search algorithm** — default to `beam-search` with `beam_width=8` and
+  `n_branch=4` for production. Use `single-pass` for a quick smoke test.
+- **Evaluation refold backend** — protein binder defaults to `colabdesign`
+  (AF2); ligand/AME default to `rf3_latest`. Use `esmfold` for fast iteration
+  (worse but seconds per sample).
+
+## Step 4: Validate
+
+Validate before running. This is cheap (seconds) and catches missing ckpts,
+missing env vars, unknown override keys, and missing target entries — all of
+which would otherwise abort the pipeline mid-evaluation after hours of
+generation.
+
+```bash
+complexa validate design configs/search_binder_local_pipeline.yaml \
+    ++generation.task_name=02_PDL1 \
+    ++metric.binder_folding_method=colabdesign
+```
+
+The validator returns non-zero on failure and prints a pass/fail report.
+Re-run the command with the suggested overrides until it returns clean.
+
+## Step 5: Run the pipeline
+
+`complexa design` is the right tool for the full 4-stage run — it orchestrates
+`generate → filter → evaluate → analyze` as sequential subprocesses with a
+shared run name, log dir, and multi-GPU split (see `run_design_pipeline` in
+`src/proteinfoundation/cli/cli_runner.py`). Re-implementing that manually
+loses the per-stage log routing and progress prints.
+
+Use `++` (forced) Hydra overrides; they apply to all stages. The minimal
+production protein-binder invocation:
+
+```bash
+complexa design configs/search_binder_local_pipeline.yaml \
+    ++run_name=pdl1_v1 \
+    ++generation.task_name=02_PDL1 \
+    ++generation.search.algorithm=beam-search \
+    ++generation.search.beam_search.beam_width=8 \
+    ++metric.binder_folding_method=colabdesign
+```
+
+For ligand binder / AME, swap the pipeline YAML and target name per Step 2's
+cheat sheet — every other override above is pipeline-agnostic and can be
+reused as-is.
+
+Add `--verbose` to stream logs to the terminal instead of `./logs/`. The skill
+does not poll progress — the user re-invokes if they want a status; point them
+at `complexa status` and `./logs/design_pipeline_*/`.
+
+### Direct module invocation (debug fallback)
+
+To debug a single stage without pipeline orchestration, invoke the underlying
+Hydra module directly. `complexa generate CONFIG` is just a logged subprocess
+wrapper around this:
+
+```bash
+python -m proteinfoundation.generate \
+    --config-path "$(realpath configs)" \
+    --config-name search_binder_local_pipeline \
+    ++run_name=debug_pdl1 \
+    ++generation.task_name=02_PDL1
+```
+
+Same pattern for `proteinfoundation.{filter,evaluate,analyze}`. Use this when
+you want to attach `ipdb`, run under `nsys`, or skip the pipeline log dir.
+Prefer `complexa generate/filter/evaluate/analyze` for normal one-shot runs
+(you get logging and parallel job splitting for free).
+
+**AME-specific gotcha (when running AME with RF3 refold)**: RF3 will try to
+complete missing atoms on the ligand based on its CCD code, which produces
+shape errors in RMSD calculations and the wrong structure. Before RF3 sees the
+PDB, rename the ligand residue to `L:0` so RF3 treats it as a generic ligand
+and skips atom completion. If your AME generation outputs already encode the
+ligand this way (the canonical Complexa pipeline does), no extra step is
+needed; otherwise patch each PDB with `atomworks.io`:
+
+```python
+from atomworks.io import load_any, to_pdb_file
+atom_array = load_any("my_design.pdb")[0]
+ligand_mask = atom_array.chain_id == "A"
+atom_array.res_name[ligand_mask] = "L:0"
+to_pdb_file(atom_array, "my_design_rf3_ready.pdb")
+```
+
+Same applies if you're piping AME outputs into the `complexa-evaluate-pdbs`
+skill with an RF3 backend. Skip the rename for AF2/colabdesign refold or for
+non-AME pipelines.
+
+Wall-clock at default (`nsteps=400`, `beam_width=8`, `batch_size=16`, 100
+designs, colabdesign eval) is ~30–120 minutes on a single A100/H100.
+
+## Step 6: Collect results
+
+Outputs land in two directories. Surface both:
+
+```bash
+ls ./inference/${CONFIG_STEM}_${TASK}_*${RUN_NAME}/   # generated PDBs + filter
+ls ./evaluation_results/${RUN_NAME}/                  # per-design CSV + analysis
+```
+
+Read the combined results CSV and summarize:
+
+```bash
+ls ./evaluation_results/*/binder_results_*_combined.csv
+ls ./evaluation_results/*/motif_binder_results_*_combined.csv  # AME
+ls ./evaluation_results/*/res_filter_*_pass_*.csv              # success rate
+ls ./evaluation_results/*/res_div_foldseek_*.csv               # FoldSeek diversity
+```
+
+Pull the success rate from `res_filter_binder_pass_*.csv`, the per-design
+metrics (interface pAE, pLDDT, scRMSD) from the combined CSV, and FoldSeek
+TM-score diversity from `res_div_foldseek_*.csv`. Report top-N designs by
+i_pAE (protein binder) or min_ipAE (ligand binder).
+
+## Step 7: Emit manifest
+
+Drop a JSON manifest beside the results so the run is replayable. The shared
+helper captures the command, config, git SHA, and pointers to the result CSVs.
+
+```bash
+python3 .claude/skills/_shared/scripts/write_manifest.py \
+    --output-dir ./evaluation_results/${RUN_NAME} \
+    --command "complexa design configs/search_binder_local_pipeline.yaml ++run_name=${RUN_NAME} ++generation.task_name=${TASK}" \
+    --skill complexa-design \
+    --out ./run_manifest.json
+```
+
+Surface the manifest path and the result CSV to the user.
+
+## Most-common overrides
+
+The 10 overrides that cover ~90% of runs. Full reference (every key, type,
+default) is in [reference/overrides.md](reference/overrides.md).
+
+| Override | Default | What it controls |
+|----------|---------|------------------|
+| `++generation.task_name=<name>` | (per config) | Which target / AME task to design for |
+| `++run_name=<str>` | (config stem) | Output dir suffix and CSV tag |
+| `++generation.search.algorithm=beam-search` | `best-of-n` (binder/ligand), `single-pass` (AME) | Search strategy |
+| `++generation.search.beam_search.beam_width=8` | `4` | Beam-search width (more = better designs, slower) |
+| `++generation.args.nsteps=200` | `400` | Diffusion steps (fewer = faster, lower quality) |
+| `++generation.dataloader.batch_size=8` | `16` (binder/ligand/AME) | Drop to 8 on a 40GB GPU |
+| `++generation.filter.filter_samples_limit=500` | `1000` | Top-N samples to keep after filtering |
+| `++metric.binder_folding_method=esmfold` | `colabdesign` (binder), `rf3_latest` (ligand/AME) | Evaluation refold backend |
+| `++metric.num_redesign_seqs=8` | `2` | ProteinMPNN/LigandMPNN/SolubleMPNN sequences per design |
+| `++aggregation.success_thresholds.i_pAE.threshold=10.0` | `7.0` (protein binder) | Loosen / tighten success criteria |
+
+## Hardware requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| GPU | 1x CUDA GPU, 40 GB VRAM | A100 / H100 / L40S, 80 GB VRAM |
+| CPUs | 16 | 24 (the `ncpus_` default in every pipeline config) |
+| Disk | 50 GB at `./inference/` + `./evaluation_results/` | 200 GB for sweep runs |
+| RAM | 32 GB | 64 GB+ |
+
+Typical wall-clock for 100 designs, `beam_width=8`, default `nsteps=400`:
+
+- Protein binder + colabdesign refold: ~60–120 min on 1x A100/H100.
+- Ligand binder + RF3 refold: ~90–180 min (RF3 dominates).
+- AME + RF3 refold: ~120–240 min.
+- Any pipeline + ESMFold refold: ~30–60 min (fast iteration).
+
+Bumping `gen_njobs=2` and `eval_njobs=2` halves wall-clock on a 2-GPU host. See
+`.claude/skills/_shared/reference/hardware.md` for per-pipeline VRAM tables.
+
+## Troubleshooting (common cases)
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `CUDA out of memory` in generate | `batch_size: 16` too big on 40GB GPU | `++generation.dataloader.batch_size=8` |
+| `CUDA out of memory` in evaluate | AF2 / RF3 batched too aggressively | `++eval_njobs=1` and `++metric.num_redesign_seqs=2` |
+| `InterpolationKeyError: AF2_DIR` | colabdesign eval but `.env` does not set `AF2_DIR` | Set `AF2_DIR` in `.env` or `++metric.binder_folding_method=esmfold` |
+| `InterpolationKeyError: RF3_CKPT_PATH` | RF3 eval but RF3 not installed | `complexa download --all` or switch eval backend |
+| `KeyError: 'task_name' not in target_dict_cfg` | Target not in `targets_dict.yaml` / `ligand_targets_dict.yaml` / `ame_dict_v2.yaml` | Use `complexa-target` skill to add it |
+| 0 designs pass success thresholds | Defaults too strict for this target | Loosen via `++aggregation.success_thresholds.*` |
+
+For the full list (chain-ID mismatches, hotspot residues, ligand residue
+renaming for RF3, missing inverse-folding models, etc.) see
+[reference/troubleshooting.md](reference/troubleshooting.md).
+
+---
+
+For per-pipeline details (which model, reward, inverse folding, evaluation
+backend, `result_type`, LoRA settings, `USE_V2_COMPLEXA_ARCH` toggle), see
+[reference/pipelines.md](reference/pipelines.md).
+
+For the full override reference (every `generation.*`, `metric.*`,
+`aggregation.*` key with type, default, example, and effect), see
+[reference/overrides.md](reference/overrides.md).
+
+For all troubleshooting cases (cause + fix + source), see
+[reference/troubleshooting.md](reference/troubleshooting.md).

--- a/open-models-skills/proteina-complexa/complexa-design/evals/evals.json
+++ b/open-models-skills/proteina-complexa/complexa-design/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "complexa-design",
+  "evals": [
+    {
+      "id": "complexa-design-001",
+      "prompt": "Run complexa design for a PDL1 binder using beam-search and refold with AF2. I want at least 50 designs generated.",
+      "expected_output": "The agent executed the complexa-design pipeline for a PDL1 protein binder target, running preflight checks, selecting the appropriate search_binder_local_pipeline.yaml config, launching the design with beam-search and AF2 refold, and reporting how many designs passed filtering.",
+      "assertions": [
+        "The agent ran the preflight script (bash .claude/skills/_shared/scripts/preflight.sh) and checked preflight.json for GPU availability and AF2_DIR",
+        "The agent selected configs/search_binder_local_pipeline.yaml as the pipeline config for protein binder design",
+        "The agent constructed and executed a complexa design command with beam-search parameters and the PDL1 target task_name",
+        "The agent reported the number of designs that passed and referenced success rate or per-design CSV output",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-design",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-design-002",
+      "prompt": "I have a small molecule target (ATP) and I want to design proteins that bind it tightly. Can you set up and run a de novo design campaign for this?",
+      "expected_output": "The agent recognized this as a ligand binder design task, ran preflight validation including RF3 checkpoint checks, selected the ligand binder pipeline config, executed the complexa design run for an ATP-binding protein, and reported results including pass rates.",
+      "assertions": [
+        "The agent ran the preflight script and verified RF3_CKPT_PATH and RF3_EXEC_PATH are present in the environment for ligand binder generation",
+        "The agent selected the ligand binder pipeline configuration (not the default protein binder config)",
+        "The agent executed the complexa design command with appropriate parameters for small-molecule/ligand binding",
+        "The agent summarized the design campaign results including success rate or number of passing designs",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-design",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-design-003",
+      "prompt": "We're working on an enzyme engineering project. We have a catalytic motif (AME) that needs to be scaffolded near a ligand binding site. The ligand is a substrate analog. Can you run the full design-to-evaluation pipeline and tell me the diversity of the resulting designs?",
+      "expected_output": "The agent executed the AME motif scaffolding pipeline with ligand context, validated that the complexa_ame checkpoint and RF3 dependencies were available, ran the full four-stage pipeline (generate, filter, evaluate, analyze), and reported FoldSeek/MMseqs diversity metrics alongside success rates.",
+      "assertions": [
+        "The agent ran preflight checks and confirmed availability of ckpts.complexa_ame and RF3 environment variables",
+        "The agent selected the AME/enzyme scaffolding pipeline configuration appropriate for motif + ligand design",
+        "The agent executed the complexa design command and waited for all four stages (generate, filter, evaluate, analyze) to complete",
+        "The agent reported diversity metrics (FoldSeek or MMseqs) and success rates from the analysis stage",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-design",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-design-004",
+      "prompt": "Can you help me set up a PostgreSQL database with replication across three nodes for our production environment?",
+      "expected_output": "The agent recognized this as a database administration task unrelated to protein design and did not invoke the complexa-design skill, instead providing guidance on PostgreSQL replication setup or directing the user to appropriate resources.",
+      "assertions": [
+        "The agent did not run the complexa preflight script or any complexa design commands",
+        "The agent did not reference protein binder design, flow matching, or refold pipelines",
+        "The agent addressed the PostgreSQL replication question directly or asked clarifying questions about the database setup",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/open-models-skills/proteina-complexa/complexa-design/reference/overrides.md
+++ b/open-models-skills/proteina-complexa/complexa-design/reference/overrides.md
@@ -1,0 +1,246 @@
+# Override Reference
+
+Every common `++` override grouped by stage. Each row: key, type, default,
+example, what it controls. Defaults come from the actual YAML files under
+`configs/pipeline/` — when this doc disagrees with the config, the config
+wins.
+
+All overrides use Hydra `++` (forced) syntax — `+` would error on keys not
+already in the config. Apply to a `complexa design` invocation; they propagate
+to all four stages (generate, filter, evaluate, analyze).
+
+## Top-level (pipeline YAML)
+
+These live at the root of `configs/search_*_pipeline.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `run_name` | str | (config stem, e.g. `search_binder_local`) | `++run_name=pdl1_v1` | Suffix for output dirs and log file names |
+| `ckpt_path` | str | `${oc.env:CKPT_PATH}` | `++ckpt_path=/data/ckpts` | Directory containing the model and AE checkpoints |
+| `ckpt_name` | str | per pipeline: `complexa.ckpt` / `complexa_ligand.ckpt` / `complexa_ame.ckpt` | `++ckpt_name=complexa.ckpt` | Which model checkpoint to load |
+| `autoencoder_ckpt_path` | str | `${oc.env:CKPT_PATH}/complexa[_ligand\|_ame]_ae.ckpt` | `++autoencoder_ckpt_path=/data/my_ae.ckpt` | AE checkpoint path |
+| `seed` | int | `5` | `++seed=42` | Sampling RNG seed |
+| `ncpus_` | int | `24` | `++ncpus_=16` | CPU count for dataloader workers |
+| `gen_njobs` | int | `2` (binder/ligand/AME) | `++gen_njobs=4` | Number of parallel generate jobs |
+| `eval_njobs` | int | `2` (binder/ligand/AME) | `++eval_njobs=4` | Number of parallel evaluate jobs |
+| `lora.r` | int | `32` (ligand/AME), (unset for protein binder) | `++lora.r=64` | LoRA rank |
+| `lora.lora_alpha` | float | `64.0` | `++lora.lora_alpha=128.0` | LoRA scaling factor (typically 2x rank) |
+| `lora.lora_dropout` | float | `0.0` | `++lora.lora_dropout=0.1` | Dropout on LoRA inputs |
+| `lora.train_bias` | enum | `none` | `++lora.train_bias=lora_only` | Bias training: `none`, `all`, `lora_only` |
+| `env_vars.USE_V2_COMPLEXA_ARCH` | str | `"True"` (AME), unset (binder/ligand) | `++env_vars.USE_V2_COMPLEXA_ARCH=True` | Architecture toggle; injected into subprocess env |
+
+## Generation — target and dataloader
+
+Group `generation.*`. See `configs/pipeline/binder/binder_generate.yaml` and
+the per-pipeline variants.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.task_name` | str | per config (e.g. `33_TrkA`, `39_7V11_LIGAND`, `M0096_1chm`) | `++generation.task_name=02_PDL1` | Target / AME task; must be a key in the relevant dict |
+| `generation.dataloader.batch_size` | int | `16` (binder/ligand/AME) | `++generation.dataloader.batch_size=8` | Samples per forward pass; drop on OOM |
+| `generation.dataloader.dataset.nres.low` | int | per-target binder_length[0] | `++generation.dataloader.dataset.nres.low=80` | Minimum binder / scaffold length |
+| `generation.dataloader.dataset.nres.high` | int | per-target binder_length[1] | `++generation.dataloader.dataset.nres.high=120` | Maximum binder / scaffold length |
+| `generation.dataloader.dataset.nres.nsamples` | int | `4` (binder), `2` (ligand), `4` (AME) | `++generation.dataloader.dataset.nres.nsamples=200` | Number of length samples per pipeline |
+| `generation.dataloader.dataset.nres.endpoint` | bool | `true` | `++generation.dataloader.dataset.nres.endpoint=false` | Include high in length range |
+| `generation.dataloader.dataset.nrepeat_per_sample` | int | `1` | `++generation.dataloader.dataset.nrepeat_per_sample=4` | How many designs per length sample |
+
+## Generation — diffusion sampling (`generation.args.*`)
+
+From `configs/pipeline/model_sampling.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.args.nsteps` | int | `400` | `++generation.args.nsteps=200` | Diffusion / flow-matching steps; lower = faster, lower quality |
+| `generation.args.self_cond` | bool | `True` | `++generation.args.self_cond=False` | Self-conditioning during sampling |
+| `generation.args.guidance_w` | float | `1.0` | `++generation.args.guidance_w=2.0` | Classifier-free guidance weight |
+| `generation.args.ag_ratio` | float | `0.0` | `++generation.args.ag_ratio=0.1` | Autoguidance mixing ratio |
+| `generation.args.ag_ckpt_path` | str\|null | `null` | `++generation.args.ag_ckpt_path=/path/to/ag.ckpt` | Autoguidance checkpoint |
+| `generation.args.save_trajectory_every` | int | `0` | `++generation.args.save_trajectory_every=50` | Snapshot interval (0 = disabled) |
+| `generation.args.fold_cond` | bool | `False` | `++generation.args.fold_cond=True` | Use fold conditioning |
+| `generation.n_recycle` | int | `0` | `++generation.n_recycle=1` | Recycling iterations |
+
+## Generation — search algorithm (`generation.search.*`)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.search.algorithm` | enum | `best-of-n` (binder, ligand), `single-pass` (AME) | `++generation.search.algorithm=beam-search` | Strategy: `single-pass`, `best-of-n`, `beam-search`, `fk-steering`, `mcts` |
+| `generation.search.max_batch_size` | int | inherits `dataloader.batch_size` | `++generation.search.max_batch_size=8` | Max samples per forward pass during search |
+| `generation.search.reward_threshold` | float\|null | `null` | `++generation.search.reward_threshold=0.5` | Filter lookahead samples by reward |
+| `generation.search.step_checkpoints` | list[int] | `[0, 100, 200, 300, 400]` | `++generation.search.step_checkpoints=[0,200,400]` | Diffusion-step checkpoints used by all algorithms |
+| `generation.search.best_of_n.replicas` | int | `2` | `++generation.search.best_of_n.replicas=4` | best-of-n replica count |
+| `generation.search.beam_search.beam_width` | int | `4` | `++generation.search.beam_search.beam_width=8` | Beam-search width |
+| `generation.search.beam_search.n_branch` | int | `4` | `++generation.search.beam_search.n_branch=8` | Beam-search branch factor |
+| `generation.search.beam_search.keep_lookahead_samples` | bool | `true` | `++generation.search.beam_search.keep_lookahead_samples=false` | Keep intermediate beam samples |
+| `generation.search.beam_search.save_intermediate_states` | bool | `false` | `++generation.search.beam_search.save_intermediate_states=true` | Save PDBs at each checkpoint (expensive) |
+| `generation.search.fk_steering.beam_width` | int | `4` | `++generation.search.fk_steering.beam_width=8` | FK-steering beam width |
+| `generation.search.fk_steering.n_branch` | int | `4` | `++generation.search.fk_steering.n_branch=8` | FK-steering branch factor |
+| `generation.search.fk_steering.temperature` | float | `0.1` | `++generation.search.fk_steering.temperature=0.5` | FK-steering softmax temperature |
+| `generation.search.fk_steering.keep_lookahead_samples` | bool | `true` | `++generation.search.fk_steering.keep_lookahead_samples=false` | Keep lookahead samples |
+| `generation.search.mcts.n_simulations` | int | `20` | `++generation.search.mcts.n_simulations=50` | MCTS simulations per node |
+| `generation.search.mcts.exploration_prob` | float | `0.5` | `++generation.search.mcts.exploration_prob=0.7` | MCTS exploration probability |
+| `generation.search.mcts.exploration_constant` | float | `1.0` | `++generation.search.mcts.exploration_constant=1.4` | MCTS exploration constant |
+| `generation.search.mcts.keep_lookahead_samples` | bool | `true` | `++generation.search.mcts.keep_lookahead_samples=false` | Keep MCTS lookaheads |
+
+## Generation — refinement (`generation.refinement.*`)
+
+Refinement is disabled by default. Enable `sequence_hallucination` for AF2-loss
+post-hoc optimization of the binder sequence.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.refinement.algorithm` | enum\|null | `null` | `++generation.refinement.algorithm=sequence_hallucination` | Enable refinement |
+| `generation.refinement.refine_targets` | enum | `final` | `++generation.refinement.refine_targets=all` | What to refine: `final` (samples) or `all` (final + lookaheads) |
+| `generation.refinement.save_pre_refinement` | enum | `none` | `++generation.refinement.save_pre_refinement=final` | Also save pre-refinement copies |
+| `generation.refinement.enable_soft_optimization` | bool | `false` | `++generation.refinement.enable_soft_optimization=true` | Stages 2 + 3 (softmax + one-hot) |
+| `generation.refinement.enable_greedy_optimization` | bool | `true` | `++generation.refinement.enable_greedy_optimization=false` | Stage 4 (PSSM semigreedy) |
+| `generation.refinement.n_temp_iters` | int | `45` | `++generation.refinement.n_temp_iters=60` | Temperature-anneal iterations |
+| `generation.refinement.n_hard_iters` | int | `5` | `++generation.refinement.n_hard_iters=10` | Hard one-hot iterations |
+| `generation.refinement.n_recycles` | int | `3` | `++generation.refinement.n_recycles=5` | AF2 recycling during refinement |
+| `generation.refinement.n_greedy_iters` | int | `15` | `++generation.refinement.n_greedy_iters=30` | Greedy iterations |
+| `generation.refinement.greedy_percentage` | int | `1` | `++generation.refinement.greedy_percentage=5` | Greedy fraction |
+| `generation.refinement.loss_weights.{pae,plddt,i_pae,con,i_con,dgram_cce,rg,i_ptm,helix_binder}` | float | various (see `binder_generate.yaml`) | `++generation.refinement.loss_weights.rg=0.5` | AF2 loss term weights during refinement |
+
+## Generation — post-generation filter (`generation.filter.*`)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.filter.filter_samples_limit` | int\|null | `1000` (binder/ligand/AME) | `++generation.filter.filter_samples_limit=500` | Max samples after filtering (top-N by reward) |
+| `generation.filter.delete_non_top_n_samples` | bool | `false` (binder), `true` (ligand, AME) | `++generation.filter.delete_non_top_n_samples=false` | Delete vs move filtered-out samples |
+| `generation.filter.dedup_sequence` | bool | `true` | `++generation.filter.dedup_sequence=false` | Drop duplicate sequences before ranking |
+| `generation.filter.reward_threshold` | float\|null | `null` | `++generation.filter.reward_threshold=0.3` | Drop samples below this reward before top-N |
+
+## Generation — reward model (`generation.reward_model.*`)
+
+Reward weights apply to the named sub-model inside the `CompositeRewardModel`.
+The protein binder pipeline uses `af2folding`; ligand binder and AME (when
+reward is enabled) use `rf3folding`. Other reward models (`tmol`,
+`bioinformatics`, `hbplus`, `boltz2folding`, `hbplus_af2`, `hbplus_boltz2`,
+`rf3folding`) are pre-wired but commented out — uncomment in the YAML or add
+via override.
+
+### `af2folding` reward weights (protein binder)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.reward_model.reward_models.af2folding.reward_weights.i_pae` | float | `-1.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.i_pae=-2.0` | Interface PAE weight (negative = minimize) |
+| `...af2folding.reward_weights.plddt` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.plddt=0.5` | pLDDT weight (positive = maximize) |
+| `...af2folding.reward_weights.con` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.con=1.0` | Intra-binder contact loss |
+| `...af2folding.reward_weights.dgram_cce` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.dgram_cce=0.5` | Distogram cross-entropy |
+| `...af2folding.reward_weights.min_ipae` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.min_ipae=-1.0` | Minimum interface PAE |
+| `...af2folding.reward_weights.{min,max,avg}_ipsae[_10]` | float | `0.0` | `++...avg_ipsae=0.5` | Interface pSAE family |
+| `...af2folding.num_recycles` | int | `3` | `++generation.reward_model.reward_models.af2folding.num_recycles=4` | AF2 recycling iterations |
+| `...af2folding.use_initial_guess` | bool | `True` | `++generation.reward_model.reward_models.af2folding.use_initial_guess=False` | Warm-start AF2 from generated structure |
+| `...af2folding.use_initial_atom_pos` | bool | `False` | `++generation.reward_model.reward_models.af2folding.use_initial_atom_pos=True` | Use initial atom positions |
+| `...af2folding.protocol` | enum | `binder` | `++generation.reward_model.reward_models.af2folding.protocol=binder` | AF2 protocol |
+| `...af2folding.use_multimer` | bool | `True` | `++generation.reward_model.reward_models.af2folding.use_multimer=False` | Use AF2-multimer |
+
+### `rf3folding` reward weights (ligand binder, AME)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.reward_model.reward_models.rf3folding.reward_weights.min_ipAE` | float | `-1.0` | `++generation.reward_model.reward_models.rf3folding.reward_weights.min_ipAE=-2.0` | Minimum interface PAE weight |
+| `...rf3folding.reward_weights.plddt` | float | `0.0` | `++...rf3folding.reward_weights.plddt=0.5` | pLDDT weight |
+| `...rf3folding.reward_weights.ipAE` | float | `0.0` | `++...rf3folding.reward_weights.ipAE=-0.5` | Interface PAE weight |
+| `...rf3folding.reward_weights.{mean_min_ipAE,mean_ipAE,min_mean_ipAE,pAE,ipTM,pTM,ranking_score}` | float | `0.0` | `++...rf3folding.reward_weights.ipTM=1.0` | RF3 confidence metrics |
+| `...rf3folding.reward_weights.has_clash` | float | `0.0` | `++...rf3folding.reward_weights.has_clash=-5.0` | Clash penalty (1.0 if clash; negative = penalize) |
+| `...rf3folding.reward_weights.{min,max,avg}_ipSAE` | float | `0.0` | `++...rf3folding.reward_weights.min_ipSAE=1.0` | Interface pSAE family |
+| `...rf3folding.normalize_pae` | bool | `true` | `++...rf3folding.normalize_pae=false` | Divide PAE metrics by 31 to map to 0-1 |
+| `...rf3folding.ckpt_path` | str | `${oc.env:RF3_CKPT_PATH}` | `++...rf3folding.ckpt_path=/data/rf3.pt` | RF3 checkpoint path |
+| `...rf3folding.rf3_path` | str | `${oc.env:RF3_EXEC_PATH}` | `++...rf3folding.rf3_path=/opt/rf3` | RF3 executable directory |
+
+## Evaluation (`metric.*`)
+
+From `binder_evaluate.yaml`, `ligand_binder_evaluate.yaml`, `ame_evaluate.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `protein_type` | enum | `binder` (binder/ligand), `motif_binder` (AME) | `++protein_type=binder` | Selects which metric path runs |
+| `input_mode` | enum | `generated` | `++input_mode=pdb_dir` | `generated` for design pipeline; `pdb_dir` for external PDBs |
+| `metric.compute_binder_metrics` | bool | `true` (binder/ligand) | `++metric.compute_binder_metrics=true` | Run binder refolding |
+| `metric.compute_motif_binder_metrics` | bool | (AME only) `true` | `++metric.compute_motif_binder_metrics=false` | Run joint motif + binder metrics |
+| `metric.binder_folding_method` | enum | `colabdesign` (binder), `rf3_latest` (ligand, AME) | `++metric.binder_folding_method=esmfold` | Refold backend: `colabdesign`, `rf3_latest`, `boltz2_default`, `esmfold` |
+| `metric.sequence_types` | list | `[self]` (binder default), `[self, mpnn]` (ligand), `[self, mpnn_fixed]` (AME) | `++metric.sequence_types=[self,mpnn,mpnn_fixed]` | Which inverse-folding outputs to evaluate |
+| `metric.num_redesign_seqs` | int | `2` | `++metric.num_redesign_seqs=8` | Sequences generated per design by the inverse folder |
+| `metric.inverse_folding_model` | enum | `soluble_mpnn` (binder), `ligand_mpnn` (ligand, AME) | `++metric.inverse_folding_model=protein_mpnn` | `protein_mpnn`, `ligand_mpnn`, `soluble_mpnn` |
+| `metric.interface_cutoff` | float | (binder/ligand) `8.0` | `++metric.interface_cutoff=6.0` | Interface-residue distance cutoff in Angstroms |
+| `metric.ranking_criteria` | dict\|null | `null` (default: minimize i_pAE for protein, min_ipAE for ligand) | `++metric.ranking_criteria.i_pAE.scale=1.0` | Custom composite-score ranking |
+| `metric.motif_ranking_criteria` | dict\|null | `null` | `++metric.motif_ranking_criteria.motif_rmsd_pred.scale=1.0` | Custom motif-binder ranking (AME) |
+| `metric.compute_esm_metrics` | bool | `true` (binder, ligand, AME) | `++metric.compute_esm_metrics=false` | Compute ESM pseudo-perplexity |
+| `metric.compute_pre_refolding_metrics` | bool | `false` (binder, ligand), `true` (AME) | `++metric.compute_pre_refolding_metrics=true` | Pre-refolding bioinformatics/TMOL/HBPLUS |
+| `metric.pre_refolding.bioinformatics` | bool | `true` | `++metric.pre_refolding.bioinformatics=false` | SC, SASA, hydrophobicity on generated |
+| `metric.pre_refolding.tmol` | bool | `true` | `++metric.pre_refolding.tmol=false` | TMOL forcefield on generated |
+| `metric.pre_refolding.hbplus` | bool | `true` | `++metric.pre_refolding.hbplus=false` | HBPLUS H-bond on generated |
+| `metric.compute_refolded_structure_metrics` | bool | `false` (binder, ligand), `true` (AME) | `++metric.compute_refolded_structure_metrics=true` | Same set on refolded |
+| `metric.refolded.{bioinformatics,tmol,hbplus}` | bool | `true` | `++metric.refolded.tmol=false` | Same toggles, refolded structure |
+| `metric.compute_monomer_metrics` | bool | `true` (binder, ligand), `false` (AME) | `++metric.compute_monomer_metrics=true` | Run monomer designability / codesignability |
+| `metric.monomer_folding_models` | list | `[esmfold]` | `++metric.monomer_folding_models=[esmfold,colabfold]` | Folding models for monomer metrics |
+| `metric.compute_designability` | bool | `true` | `++metric.compute_designability=false` | Designability (ProteinMPNN -> fold) |
+| `metric.designability_modes` | list | `[ca]` | `++metric.designability_modes=[ca,all_atom]` | RMSD modes for designability |
+| `metric.compute_codesignability` | bool | `true` | `++metric.compute_codesignability=false` | Codesignability (fold original sequence) |
+| `metric.codesignability_modes` | list | `[ca, all_atom]` | `++metric.codesignability_modes=[ca]` | RMSD modes for codesignability |
+| `metric.compute_co_sequence_recovery` | bool | `false` | `++metric.compute_co_sequence_recovery=true` | Compare MPNN vs original sequence |
+| `metric.compute_ss` | bool | `true` (binder) | `++metric.compute_ss=false` | Secondary-structure fractions via biotite |
+| `metric.compute_novelty_pdb` | bool | `false` | `++metric.compute_novelty_pdb=true` | Novelty vs PDB |
+| `metric.compute_novelty_afdb` | bool | `false` | `++metric.compute_novelty_afdb=true` | Novelty vs AlphaFold DB |
+| `metric.compute_novelty_afdb_rep_v4` | bool | `false` | `++metric.compute_novelty_afdb_rep_v4=true` | Novelty vs AFDB rep v4 |
+| `metric.keep_folding_outputs` | bool | `true` (binder, AME), `false` (ligand) | `++metric.keep_folding_outputs=false` | Keep refolded PDBs on disk |
+
+## Analysis (`aggregation.*`)
+
+From `binder_analyze.yaml`, `ligand_binder_analyze.yaml`, `ame_analyze.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `result_type` | enum | per pipeline | `++result_type=protein_binder` | One of: `protein_binder`, `ligand_binder`, `monomer`, `motif_protein_binder`, `motif_ligand_binder` |
+| `aggregation.limit` | int\|null | `null` | `++aggregation.limit=200` | Limit number of result files merged (null = all) |
+| `aggregation.analysis_modes` | list | `[binder, monomer]` (binder, ligand), `[motif_binder, monomer]` (AME) | `++aggregation.analysis_modes=[binder]` | Which analysis functions to run |
+| `aggregation.success_thresholds.i_pAE.threshold` | float | `7.0` (protein_binder) | `++aggregation.success_thresholds.i_pAE.threshold=10.0` | Interface PAE threshold (after `* scale`) |
+| `aggregation.success_thresholds.i_pAE.op` | str | `<=` | `++aggregation.success_thresholds.i_pAE.op=<` | Comparison operator |
+| `aggregation.success_thresholds.i_pAE.scale` | float | `31.0` | `++aggregation.success_thresholds.i_pAE.scale=1.0` | Scale factor applied before comparison |
+| `aggregation.success_thresholds.i_pAE.column_prefix` | str | `complex` | `++aggregation.success_thresholds.i_pAE.column_prefix=complex` | Column-name prefix |
+| `aggregation.success_thresholds.pLDDT.threshold` | float | `0.9` (protein_binder), `0.8` (AME) | `++aggregation.success_thresholds.pLDDT.threshold=0.85` | pLDDT threshold |
+| `aggregation.success_thresholds.pLDDT.op` | str | `>=` | `++aggregation.success_thresholds.pLDDT.op=>=` | Comparison operator |
+| `aggregation.success_thresholds.scRMSD.threshold` | float | `1.5` (protein_binder), `2.0` (ligand_binder, AME) | `++aggregation.success_thresholds.scRMSD.threshold=2.0` | scRMSD threshold |
+| `aggregation.success_thresholds.scRMSD.op` | str | `<` | `++aggregation.success_thresholds.scRMSD.op=<=` | Comparison operator |
+| `aggregation.success_thresholds.scRMSD.column_prefix` | str | `binder` | `++aggregation.success_thresholds.scRMSD.column_prefix=binder` | Column-name prefix |
+| `aggregation.motif_binder_success_thresholds.motif_rmsd_pred.threshold` | float | `1.5` (motif_ligand_binder), `2.0` (motif_protein_binder) | `++aggregation.motif_binder_success_thresholds.motif_rmsd_pred.threshold=1.0` | Motif RMSD in refolded structure |
+| `aggregation.motif_binder_success_thresholds.motif_seq_recovery.threshold` | float | `0.5` (AME default), `1.0` (motif protein binder default) | `++aggregation.motif_binder_success_thresholds.motif_seq_recovery.threshold=0.8` | Motif sequence recovery threshold |
+| `aggregation.designability_thresholds.ca.esmfold.threshold` | float | `2.0` | `++aggregation.designability_thresholds.ca.esmfold.threshold=1.5` | Designability CA-scRMSD threshold |
+| `aggregation.ca_codesignability_thresholds.ca.esmfold.threshold` | float | `2.0` | `++aggregation.ca_codesignability_thresholds.ca.esmfold.threshold=1.5` | CA codesignability threshold |
+| `aggregation.allatom_codesignability_thresholds.all_atom.esmfold.threshold` | float | `2.0` | `++aggregation.allatom_codesignability_thresholds.all_atom.esmfold.threshold=2.5` | All-atom codesignability threshold |
+| `aggregation.require_all_thresholds` | bool | `false` | `++aggregation.require_all_thresholds=true` | AND vs OR across thresholds |
+| `aggregation.compute_diversity` | bool | `true` (AME), unset elsewhere | `++aggregation.compute_diversity=false` | FoldSeek diversity |
+| `aggregation.compute_mmseqs_diversity` | bool | `true` (AME) | `++aggregation.compute_mmseqs_diversity=true` | MMseqs2 sequence diversity |
+
+## Common override patterns
+
+Cheat-sheet of full overrides users run frequently.
+
+```bash
+# Production beam-search on PDL1
+++generation.task_name=02_PDL1 \
+++generation.search.algorithm=beam-search \
+++generation.search.beam_search.beam_width=8 \
+++generation.search.beam_search.n_branch=4 \
+++run_name=pdl1_beam_v1
+
+# Fast smoke test (single-pass, fewer steps, smaller batch)
+++generation.search.algorithm=single-pass \
+++generation.args.nsteps=100 \
+++generation.dataloader.dataset.nres.nsamples=2 \
+++run_name=quick_test
+
+# Cheap iteration with ESMFold eval
+++metric.binder_folding_method=esmfold \
+++metric.compute_pre_refolding_metrics=false \
+++metric.compute_refolded_structure_metrics=false
+
+# Stricter success thresholds for top-N filtering
+++aggregation.success_thresholds.i_pAE.threshold=5.0 \
+++aggregation.success_thresholds.scRMSD.threshold=1.0
+
+# Lower VRAM (40GB GPU)
+++generation.dataloader.batch_size=8 \
+++eval_njobs=1 \
+++metric.num_redesign_seqs=2
+```

--- a/open-models-skills/proteina-complexa/complexa-design/reference/pipelines.md
+++ b/open-models-skills/proteina-complexa/complexa-design/reference/pipelines.md
@@ -1,0 +1,175 @@
+# Pipeline Reference
+
+The three `complexa design` pipelines side-by-side. Every row is sourced from a
+config file under `configs/pipeline/` or a top-level `configs/search_*.yaml`.
+When this doc disagrees with the configs, the configs win — re-read them.
+
+## Three pipelines
+
+| Aspect | Protein Binder | Ligand Binder | AME (motif + ligand) |
+|--------|----------------|---------------|----------------------|
+| Pipeline YAML | `configs/search_binder_local_pipeline.yaml` | `configs/search_ligand_binder_local_pipeline.yaml` | `configs/search_ame_local_pipeline.yaml` |
+| Generate config | `pipeline/binder/binder_generate.yaml` | `pipeline/ligand_binder/ligand_binder_generate.yaml` | `pipeline/ame/ame_generate.yaml` |
+| Evaluate config | `pipeline/binder/binder_evaluate.yaml` | `pipeline/ligand_binder/ligand_binder_evaluate.yaml` | `pipeline/ame/ame_evaluate.yaml` |
+| Analyze config | `pipeline/binder/binder_analyze.yaml` | `pipeline/ligand_binder/ligand_binder_analyze.yaml` | `pipeline/ame/ame_analyze.yaml` |
+| Model ckpt | `complexa.ckpt` | `complexa_ligand.ckpt` | `complexa_ame.ckpt` |
+| Autoencoder ckpt | `complexa_ae.ckpt` | `complexa_ligand_ae.ckpt` | `complexa_ame_ae.ckpt` |
+| LoRA | (none) | `r: 32, lora_alpha: 64.0` | `r: 32, lora_alpha: 64.0` |
+| `env_vars.USE_V2_COMPLEXA_ARCH` | (not set) | (not set) | `"True"` |
+| Targets dict | `configs/targets/targets_dict.yaml` | `configs/targets/ligand_targets_dict.yaml` | `configs/design_tasks/ame_dict_v2.yaml` |
+| Conditional features | `TargetFeatures` | `LigandFeatures` | `MotifFeatures` + `LigandFeatures` |
+| Default search algorithm | `best-of-n` | `best-of-n` | `single-pass` |
+| Generation reward model | AF2 (`af2folding`) | RF3 (`rf3folding`) | `null` (single-pass) |
+| Inverse-folding model | `soluble_mpnn` | `ligand_mpnn` | `ligand_mpnn` |
+| Evaluation `protein_type` | `binder` | `binder` | `motif_binder` |
+| Evaluation folding | `colabdesign` (AF2) | `rf3_latest` | `rf3_latest` |
+| Analysis `result_type` | `protein_binder` | `ligand_binder` | `motif_ligand_binder` |
+| Analysis modes | `[binder, monomer]` | `[binder, monomer]` | `[motif_binder, monomer]` |
+| Default `gen_njobs` / `eval_njobs` | 2 / 2 | 2 / 2 | 2 / 2 |
+| Default `dataloader.batch_size` | 16 | 16 | 16 |
+
+## Protein binder
+
+Designs a binder for a protein target. AF2 (ColabDesign) drives both the
+reward during search and the final evaluation refold. Uses `SolubleMPNN` for
+inverse folding so the redesigned binder is soluble.
+
+- Reward weights: `af2folding.reward_weights.i_pae = -1.0` (minimize interface
+  PAE). Other AF2 metrics (`con`, `plddt`, `dgram_cce`, `min_ipae`, `min_ipsae`,
+  `avg_ipsae`, `max_ipsae`, `min_ipsae_10`, `max_ipsae_10`, `avg_ipsae_10`)
+  default to 0.0 and can be enabled by override.
+- Default success thresholds: `i_pAE * 31 <= 7.0`, `pLDDT >= 0.9`, `scRMSD_ca <
+  1.5` Å.
+- Quick command:
+  ```bash
+  complexa design configs/search_binder_local_pipeline.yaml \
+      ++run_name=pdl1_v1 ++generation.task_name=02_PDL1
+  ```
+
+## Ligand binder
+
+Designs a binder for a small-molecule ligand. RF3 handles both reward and
+evaluation because it supports protein-ligand complexes. Uses `LigandMPNN` so
+the inverse-folded sequence is conditioned on the ligand.
+
+- Reward weights: `rf3folding.reward_weights.min_ipAE = -1.0` (minimize the
+  minimum interface PAE, normalized by 31). Other RF3 metrics (`plddt`, `ipAE`,
+  `mean_min_ipAE`, `mean_ipAE`, `min_mean_ipAE`, `pAE`, `ipTM`, `pTM`,
+  `ranking_score`, `has_clash`, `min_ipSAE`, `max_ipSAE`, `avg_ipSAE`) default
+  to 0.0.
+- Default success thresholds: `min_ipAE * 31 < 2.0`, `scRMSD_ca < 2.0` Å,
+  `ligand_scRMSD_aligned_allatom < 5.0` Å.
+- LoRA is required for the released ligand checkpoint (`r: 32, lora_alpha:
+  64.0, lora_dropout: 0.0, train_bias: none`) and is baked into
+  `search_ligand_binder_local_pipeline.yaml`.
+- Quick command:
+  ```bash
+  complexa design configs/search_ligand_binder_local_pipeline.yaml \
+      ++run_name=v11_v1 ++generation.task_name=39_7V11_LIGAND
+  ```
+
+## AME (motif + ligand binder)
+
+Combines `MotifFeatures` (atom-spec mode) with `LigandFeatures`. Designed for
+active-site / enzyme scaffolding: place a functional motif near a small-molecule
+ligand and let the model build the rest of the protein around them.
+
+- Generation reward defaults to `null` (single-pass). To enable reward-guided
+  search, uncomment the `CompositeRewardModel` block in `ame_generate.yaml` (it
+  pre-wires RF3) and switch `search.algorithm` to `best-of-n` or `beam-search`.
+- LoRA is required: `r: 32, lora_alpha: 64.0, lora_dropout: 0.0, train_bias:
+  none`.
+- `env_vars.USE_V2_COMPLEXA_ARCH: "True"` is set in
+  `search_ame_local_pipeline.yaml`. The CLI runner injects this into the
+  subprocess environment.
+- Default success thresholds (`motif_ligand_binder`): `i_pAE * 31 <= 10.0`,
+  `pLDDT >= 0.8`, `scRMSD < 2.0`, `motif_rmsd_pred < 1.5`, `motif_seq_recovery
+  >= 0.5`. The analysis is *joint*: a sample passes only when one redesign
+  satisfies binder + motif criteria simultaneously.
+- Pre- and post-refolding interface metrics are enabled (bioinformatics, TMOL,
+  HBPLUS).
+- Quick command:
+  ```bash
+  complexa design configs/search_ame_local_pipeline.yaml \
+      ++run_name=ame_chm ++generation.task_name=M0096_1chm
+  ```
+
+## LoRA settings
+
+Both non-protein pipelines (ligand binder, AME) require LoRA because their
+checkpoints (`complexa_ligand.ckpt`, `complexa_ame.ckpt`) were trained with
+LoRA adapters. The pipeline YAMLs declare:
+
+```yaml
+lora:
+  r: 32
+  lora_alpha: 64.0
+  lora_dropout: 0.0
+  train_bias: none
+```
+
+Removing the `lora:` block from the pipeline YAML will load the base weights
+without the LoRA delta and produce garbage. Leave it alone unless the user is
+fine-tuning their own LoRA — in which case override `r`, `lora_alpha`,
+`lora_dropout`, or `train_bias` via `++lora.r=64`.
+
+## `USE_V2_COMPLEXA_ARCH` toggle
+
+This env var picks between two on-disk architecture layouts. The CLI runner
+reads `env_vars:` from the pipeline YAML and injects them into the subprocess
+environment (see `cli_runner.py::run_step` -> `env.update(config.env_vars)`).
+
+| Pipeline | `USE_V2_COMPLEXA_ARCH` | Notes |
+|----------|------------------------|-------|
+| Protein binder | (not set; defaults to v1) | `complexa.ckpt` is v1 architecture. |
+| Ligand binder | (not set; defaults to v1) | `complexa_ligand.ckpt` is v1 architecture. |
+| AME | `"True"` | `complexa_ame.ckpt` is v2 architecture for the AME pipeline. |
+
+If the user sees `KeyError` or shape mismatches at model-load time, the most
+likely cause is the wrong `USE_V2_COMPLEXA_ARCH` value — the configs in the
+repo are correct, but a custom override (`++env_vars.USE_V2_COMPLEXA_ARCH=...`)
+can break it.
+
+## Evaluation `protein_type` and `result_type`
+
+`protein_type` (set in the evaluation config) controls *which metrics are
+computed*. `result_type` (set in the analysis config) controls *which default
+success thresholds apply*. They are paired:
+
+| Pipeline | `protein_type` | `result_type` |
+|----------|----------------|---------------|
+| Protein binder | `binder` | `protein_binder` |
+| Ligand binder | `binder` | `ligand_binder` |
+| AME | `motif_binder` | `motif_ligand_binder` |
+| Motif protein binder (standalone, not a `design` pipeline) | `motif_binder` | `motif_protein_binder` |
+
+The motif protein binder evaluation is not a top-level `design` pipeline; it
+runs via the standalone `evaluate_motif_binder.yaml` config on the outputs of a
+protein binder pipeline. Use the `complexa-evaluate-pdbs` skill for that
+workflow.
+
+## Evaluation types (summary)
+
+From `docs/EVALUATION_METRICS.md`, the types reachable from the three design
+pipelines:
+
+1. **Protein binder** (`protein_type: binder`, `result_type: protein_binder`) —
+   AF2 / RF3 / Boltz2 refold + SolubleMPNN redesign. Metrics: i_pAE, i_pTM,
+   pLDDT, binder scRMSD, complex scRMSD.
+2. **Ligand binder** (`protein_type: binder`, `result_type: ligand_binder`) —
+   RF3 refold + LigandMPNN. Adds min_ipAE, ipSAE, has_clash, ligand_scRMSD,
+   ligand_scRMSD_aligned_allatom.
+3. **Monomer** (`protein_type: monomer`) — ESMFold designability +
+   codesignability + secondary structure. Used as a component of binder
+   evaluation.
+4. **Motif protein binder** (`protein_type: motif_binder`, `result_type:
+   motif_protein_binder`) — Standalone variant of #1 + motif RMSD / sequence
+   recovery on the refolded structure. Run via `evaluate_motif_binder.yaml` on
+   protein-binder outputs, not a top-level design pipeline.
+5. **Motif ligand binder / AME** (`protein_type: motif_binder`, `result_type:
+   motif_ligand_binder`) — #2 + motif overlay + ligand clash detection on the
+   refolded structure. This is what `search_ame_local_pipeline.yaml` runs.
+
+Pass-rate columns land in `res_filter_*_pass_*.csv`; diversity columns in
+`res_div_foldseek_*.csv` and `res_div_mmseqs_*.csv`; per-design metrics in the
+combined CSV.

--- a/open-models-skills/proteina-complexa/complexa-design/reference/troubleshooting.md
+++ b/open-models-skills/proteina-complexa/complexa-design/reference/troubleshooting.md
@@ -1,0 +1,284 @@
+# Troubleshooting Reference
+
+Symptoms, causes, and fixes for `complexa design` failures. Sourced from
+`docs/INFERENCE.md` "Troubleshooting", `docs/EVALUATION_METRICS.md`, and the
+pipeline configs themselves.
+
+## GPU OOM during generation
+
+**Symptom:** `torch.cuda.OutOfMemoryError` during the `generate` step;
+process dies before the first PDB is written.
+
+**Cause:** Default `generation.dataloader.batch_size: 16` is tuned for 80 GB
+A100/H100. On a 40 GB GPU the latent flow-matching forward pass overflows.
+Beam-search amplifies this because `max_batch_size` inherits from
+`batch_size` and multiple beams run concurrently.
+
+**Fix:**
+
+```bash
+++generation.dataloader.batch_size=8
+++gen_njobs=1
+```
+
+If still OOMing, drop to `batch_size=4` and `++generation.args.nsteps=200` to
+shrink activation history. Reference: `docs/INFERENCE.md` "Memory Issues".
+
+## GPU OOM during folding
+
+**Symptom:** OOM during the `evaluate` step, typically after the AF2 or RF3
+model is loaded.
+
+**Cause:** Multiple eval jobs share the GPU; ColabDesign with
+`num_recycles: 3` and `num_redesign_seqs > 2` keeps a large state tree.
+
+**Fix:**
+
+```bash
+++eval_njobs=1
+++metric.num_redesign_seqs=2
+++metric.sequence_types=[self]      # skip mpnn / mpnn_fixed redesigns
+```
+
+For RF3 specifically, also lower `++metric.num_redesign_seqs=1` — RF3 carries a
+heavier per-sample state than AF2.
+
+## Missing `AF2_DIR` (colabdesign fails)
+
+**Symptom:** Hydra `InterpolationKeyError: AF2_DIR` raised when the reward
+model or the evaluator tries to resolve `${oc.env:AF2_DIR}`.
+
+**Cause:** The protein binder pipeline's `af2folding` reward model and the
+default `binder_folding_method: colabdesign` both read `AF2_DIR` from the
+environment. If `.env` does not define it, Hydra interpolation fails.
+
+**Fix:** Add `AF2_DIR=/path/to/af2_params` to `.env`, or switch the eval
+backend to ESMFold (does not need AF2 weights):
+
+```bash
+++metric.binder_folding_method=esmfold
+```
+
+Run `complexa download --all` to fetch AF2 weights into the canonical
+location. Reference: `docs/INFERENCE.md` "Missing Model Weights".
+
+## Missing `RF3_CKPT_PATH` / `RF3_EXEC_PATH` (rf3_latest fails)
+
+**Symptom:** `InterpolationKeyError: RF3_CKPT_PATH` or `RF3_EXEC_PATH` during
+generate (ligand binder) or evaluate (ligand binder, AME).
+
+**Cause:** Ligand binder and AME pipelines bake `${oc.env:RF3_CKPT_PATH}` and
+`${oc.env:RF3_EXEC_PATH}` into the RF3 reward and refold paths. RF3 is not
+downloaded by `complexa download --complexa-*`; it ships with the community
+model bundle.
+
+**Fix:** Export both env vars (or set them in `.env`):
+
+```bash
+export RF3_CKPT_PATH=/path/to/rf3_latest.pt
+export RF3_EXEC_PATH=/path/to/rf3
+```
+
+Run `complexa download --all` to install RF3 into the canonical location.
+Reference: `docs/INFERENCE.md` "RF3 Environment Variables".
+
+## Chain-ID mismatch between target PDB and `target_input`
+
+**Symptom:** Target loads but `n_target_residues == 0` after dataloader runs;
+or `KeyError: 'A'` raised by the target featurizer.
+
+**Cause:** The `target_input` field in the targets dict (e.g. `A1-115`)
+specifies chain A, but the PDB uses chain B (or unlabelled chains).
+
+**Fix:** Inspect the target PDB:
+
+```bash
+grep '^ATOM' /path/to/target.pdb | head -1   # check chain ID at col 22
+```
+
+Then update the target entry in `configs/targets/targets_dict.yaml` so
+`target_input` matches the actual chain. Or use the `complexa-target` skill to
+re-add the target with the correct chain.
+
+## Hotspot residue not in target PDB
+
+**Symptom:** Warning / error from `TargetFeatures` that hotspot residue
+`A45` does not exist; or hotspots silently dropped, leading to non-specific
+binders.
+
+**Cause:** `hotspot_residues: [A45, A67, A89]` references residues that the
+PDB does not contain — usually because the PDB has been re-numbered or the
+chain has been truncated.
+
+**Fix:** Pull the actual residue numbers:
+
+```bash
+grep '^ATOM' /path/to/target.pdb | awk '{print $5, $6}' | sort -u
+```
+
+Update `hotspot_residues` to a subset of residues that exist in `target_input`.
+
+## AME requires `USE_V2_COMPLEXA_ARCH: "True"`
+
+**Symptom:** Shape mismatch or `KeyError` at model-load time when running the
+AME pipeline.
+
+**Cause:** AME uses the v2 architecture. The `search_ame_local_pipeline.yaml`
+sets `env_vars.USE_V2_COMPLEXA_ARCH: "True"`, but a stray
+`++env_vars.USE_V2_COMPLEXA_ARCH=False` override (or a stale shell export)
+flips it back.
+
+**Fix:** Do not override `USE_V2_COMPLEXA_ARCH`. If a shell export is set, unset
+it:
+
+```bash
+unset USE_V2_COMPLEXA_ARCH
+```
+
+Reference: `configs/search_ame_local_pipeline.yaml` line 22.
+
+## AME ligand residue name must be `L:0` for RF3
+
+**Symptom:** RF3 reward model raises a residue-name parse error during AME
+generation; or the ligand silently disappears from the refolded structure.
+
+**Cause:** RF3 expects the ligand HETATM residue named `L` with sequence-number
+`0` (canonical AME convention). PDBs downloaded from RCSB usually have
+arbitrary ligand residue names (e.g. `OQO`, `FAD`, `ATP`).
+
+**Fix:** Use `atomworks` (the renaming tool) to rewrite the ligand residue:
+
+```bash
+python -m atomworks rename_ligand \
+    --in /path/to/target.pdb \
+    --out /path/to/target_renamed.pdb \
+    --target-resname L \
+    --target-resnum 0
+```
+
+Update the AME task in `configs/design_tasks/ame_dict_v2.yaml` to point at the
+renamed PDB. Reference: README in `target_data/` and the AME task definitions.
+
+## Override key not recognized
+
+**Symptom:** Hydra raises `InterpolationKeyError`, `MissingMandatoryValue`,
+or "Could not override 'X'" when launching the pipeline.
+
+**Cause:** Hydra `+` requires the key to already exist in the merged config;
+`++` forces a new key. If a typo lands inside an existing key path, the error
+looks like a missing value.
+
+**Fix:** Always use `++` for design pipeline overrides (the pipeline composes
+multiple configs and key existence varies by stage). Re-check the key against
+`reference/overrides.md`. Validate the run before launching:
+
+```bash
+complexa validate design <pipeline_config> ++<overrides>
+```
+
+The validator surfaces every unknown key before the pipeline starts.
+
+## Missing checkpoint reported by `complexa download --status`
+
+**Symptom:** `complexa download --status` lists a Complexa or community model
+as `Missing`, and the pipeline fails immediately at the load step.
+
+**Cause:** The relevant `complexa download --complexa-<variant>` or
+`complexa download --all` has not been run, or the download was interrupted.
+
+**Fix:**
+
+```bash
+complexa download --status                     # see what is missing
+complexa download --complexa                   # protein binder weights
+complexa download --complexa-ligand            # ligand binder weights
+complexa download --complexa-ame               # AME / motif weights
+complexa download --all                        # community models (AF2, RF3, MPNN, ESM2)
+```
+
+Hand off to the `complexa-setup` skill if the `.env` is also incomplete.
+
+## ColabDesign env var missing
+
+**Symptom:** ColabDesign fails on import or at AF2-params load with
+`FileNotFoundError`.
+
+**Cause:** `AF2_DIR` is set to a directory that does not contain
+`params_model_*.npz` files, or the path is correct but does not exist.
+
+**Fix:**
+
+```bash
+ls $AF2_DIR | grep '^params_model'
+```
+
+If empty, re-download:
+
+```bash
+complexa download --all
+```
+
+Or point `AF2_DIR` at the correct directory in `.env`.
+
+## ProteinMPNN / LigandMPNN model directory missing
+
+**Symptom:** Evaluation fails at the inverse-folding step with
+`FileNotFoundError` on the MPNN weights directory.
+
+**Cause:** The inverse-folding model is part of the community bundle, not the
+Complexa bundle. `complexa download --complexa*` does not fetch it.
+
+**Fix:**
+
+```bash
+complexa download --all
+```
+
+Or fetch the specific MPNN you need (LigandMPNN for ligand / AME pipelines,
+SolubleMPNN for protein binder, ProteinMPNN for the monomer designability
+calculation). All three live under the community-model directory.
+
+## Inverse folder returns 0 sequences
+
+**Symptom:** Per-design CSV has empty `{seq}_sequence` columns; success rate
+is 0% even though designs visually look reasonable.
+
+**Cause:** The target is too short, the interface cutoff is too tight, or the
+binder length is constrained so heavily that the MPNN sampler cannot find a
+sequence consistent with the fixed positions.
+
+**Fix:** Loosen the interface cutoff and re-run:
+
+```bash
+++metric.interface_cutoff=10.0
+++metric.num_redesign_seqs=8
+```
+
+If the binder is shorter than ~30 residues, also expand
+`generation.dataloader.dataset.nres.low/high` — the MPNN models are unreliable
+at very short lengths.
+
+## 0 designs pass success thresholds
+
+**Symptom:** Pipeline completes, `res_filter_*_pass_*.csv` shows
+`pass_rate: 0.0`. Per-design metrics look plausible but nothing passes.
+
+**Cause:** Default thresholds are tuned for the published targets (PDL1,
+TrkA, etc.) and may be too strict for harder targets or smaller search
+budgets.
+
+**Fix:** Loosen the thresholds via the aggregation overrides:
+
+```bash
+++aggregation.success_thresholds.i_pAE.threshold=10.0       # was 7.0
+++aggregation.success_thresholds.pLDDT.threshold=0.8        # was 0.9
+++aggregation.success_thresholds.scRMSD.threshold=2.0       # was 1.5
+```
+
+Or re-run analyze alone with the new thresholds — no need to re-generate:
+
+```bash
+complexa analyze configs/search_binder_local_pipeline.yaml ++run_name=<same> ++aggregation.success_thresholds.i_pAE.threshold=10.0
+```
+
+Reference: `docs/EVALUATION_METRICS.md` "Customizing Binder Thresholds".

--- a/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/SKILL.md
+++ b/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: complexa-evaluate-pdbs
+description: >
+  Standalone evaluation of an existing PDB directory with Proteina-Complexa.
+  Use this skill whenever the user wants to "evaluate PDB files", "re-fold these
+  designs", "compute interface pAE", "compute i_pLDDT for a folder",
+  "run AF2 / RF3 / ESMFold on my designs", "score binder candidates",
+  "designability of this folder", "scRMSD for designs", "motif RMSD for these
+  PDBs", "complexa analysis", "complexa evaluate from a PDB directory",
+  "evaluate from pdb dir", or score third-party outputs (BindCraft, AlphaProteo,
+  RFdiffusion, hand-curated decoys). It picks the correct `evaluate_*.yaml`
+  config, wires `++dataset.pdb_dir` and the folding backend, runs
+  `complexa analysis` (the evaluate → analyze chain), parses the result CSV,
+  reports pass-rates against the right `result_type` thresholds, and emits a
+  replayable `eval_manifest.json`. Reach for this skill before hand-rolling
+  refolding scripts.
+compatibility: "complexa CLI installed (pip install -e .); CUDA GPU; AF2_DIR (colabdesign) or RF3_CKPT_PATH+RF3_EXEC_PATH (rf3_latest); ESMFold weights for monomer paths"
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Complexa Evaluate-PDBs Skill
+
+Score a directory of pre-existing PDB files against the same metrics Proteina-Complexa uses internally. Wraps `complexa analysis <evaluate_config> ++sample_storage_path=<dir>`: the CLI runs the `evaluate` step (refold + interface metrics + monomer metrics) and then the `analyze` step (success thresholds, diversity, pass-rate CSVs). Do **not** run `complexa generate` here — the inputs already exist.
+
+## What this skill enables
+
+- Re-fold a directory of designed PDBs with AF2 (`colabdesign`), RF3 (`rf3_latest`), ESMFold (`esmfold`), or Boltz2 (`boltz2_default`).
+- Compute binder interface metrics: `i_pAE`, `min_ipAE`, `i_pTM`, `pLDDT`, binder/complex scRMSD.
+- Compute monomer **designability** (ProteinMPNN-redesigned scRMSD) and **codesignability** (original sequence refold scRMSD).
+- For motif inputs: motif RMSD (CA + all-atom), motif-region designability/codesignability, sequence recovery.
+- Aggregate into per-PDB CSVs plus pass-rate summaries using the default thresholds for the `result_type`.
+
+## Step 1: Pre-flight
+
+Always check GPU / disk / tool binaries before launching a refold job. RF3 and ColabDesign-AF2 are large.
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+Surface from `preflight.json`:
+
+- `gpu.available` and `gpu.vram_gb` — colabdesign/RF3 need ≥40 GB; ESMFold tolerates ≥24 GB.
+- `env.missing_required` — must include the keys for the chosen folding backend:
+  - `colabdesign` → `AF2_DIR`
+  - `rf3_latest` → `RF3_CKPT_PATH`, `RF3_EXEC_PATH`
+  - `esmfold` → ESMFold weights resolvable
+- `tools.{foldseek,mmseqs}` — required by `aggregation.compute_diversity` / `compute_mmseqs_diversity` (both default `true`).
+
+If any required key is missing, route the user to the `complexa-setup` skill.
+
+## Step 2: Identify the design type
+
+Like `complexa design`, evaluation has one default flow (protein binder) and two extensions (ligand binder, AME). The evaluate config you pass to `complexa analysis` decides everything else (which metrics, which refolder defaults, which thresholds the analyze step applies).
+
+### Default — protein binder
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=02_PDL1 \
+    ++result_type=protein_binder \
+    ++metric.binder_folding_method=colabdesign \
+    ++metric.inverse_folding_model=soluble_mpnn \
+    ++run_name=eval_pdl1_af2
+```
+
+Use this when the user's PDBs are protein-binder designs (multi-chain, binder is the last chain) or third-party outputs from BindCraft / AlphaProteo / RFdiffusion. Pulls thresholds for `protein_binder` (`i_pAE * 31 ≤ 7.0`, `pLDDT ≥ 0.9`, `scRMSD_ca < 1.5 Å`).
+
+### Extensions — pick the matching config
+
+| Design type | Use the protein-binder default? | Evaluate config | Analyze config | `result_type` | Default backend |
+|---|---|---|---|---|---|
+| Protein binder | **Yes (default)** | `configs/evaluate_from_pdb_dir.yaml` | `configs/analyze.yaml` | `protein_binder` | `colabdesign` (AF2) |
+| Ligand binder (binder + small-molecule) | Same evaluate config, swap 3 overrides | `configs/evaluate_from_pdb_dir.yaml` | `configs/analyze.yaml` | `ligand_binder` | `rf3_latest` |
+| AME / motif + ligand (enzyme outputs) | No — needs motif-aware config | `configs/evaluate_ame_from_pdb_dir.yaml` | `configs/analyze_motif_binder.yaml` | `motif_ligand_binder` | `rf3_latest` |
+| Motif protein binder (standalone) | No — no `_from_pdb_dir` variant | `configs/evaluate_motif_binder.yaml` + `++input_mode=pdb_dir` | `configs/analyze_motif_binder.yaml` | `motif_protein_binder` | `colabdesign` / `rf3_latest` |
+
+**Extending to ligand binder** (same evaluate config as default, three override swaps):
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=39_7V11_LIGAND \
+    ++result_type=ligand_binder \
+    ++metric.binder_folding_method=rf3_latest \
+    ++metric.inverse_folding_model=ligand_mpnn \
+    ++run_name=eval_v11_rf3
+```
+
+**Extending to AME** (different config; ligand auto-completion gotcha — see Step 4):
+
+```bash
+complexa analysis configs/evaluate_ame_from_pdb_dir.yaml \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=M0096_1chm \
+    ++run_name=eval_ame_chm
+```
+
+See `reference/eval_configs.md` for the full matrix (every `result_type`, every threshold default, every supported folding backend, motif-protein-binder variant).
+
+## Step 3: Gather inputs (AskUserQuestion)
+
+Ask in one batched `AskUserQuestion`:
+
+1. **`pdb_dir`** — absolute path to the directory of PDBs to evaluate.
+2. **Design type** — protein binder / ligand binder / AME (motif + ligand).
+3. **Folding backend** — `colabdesign` (AF2, protein binders), `rf3_latest` (ligand / AME), `boltz2_default` (alternative).
+4. **Target / task name** — must match a key in `configs/targets/targets_dict.yaml`, `configs/targets/ligand_targets_dict.yaml`, or `configs/design_tasks/ame_dict_v2.yaml`. Required for binder + AME evaluation (needed to identify the target reference and, for AME, the motif contigs).
+5. **AME-only**: confirm ligand residue name is already renamed to `L:0` in every PDB (see Troubleshooting). If not, do that rename first.
+
+## Step 4: Run evaluate → analyze
+
+Prefer `complexa analysis` (the evaluate→analyze chain) — it reuses the same config for both steps and writes a single log dir.
+
+```bash
+# Protein binder PDB dir, AF2 refold
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+  ++sample_storage_path=/abs/path/to/pdbs \
+  ++dataset.task_name=02_PDL1 \
+  ++metric.binder_folding_method=colabdesign \
+  ++metric.inverse_folding_model=soluble_mpnn \
+  ++result_type=protein_binder \
+  ++run_name=eval_pdl1_af2
+```
+
+For ligand binders flip `binder_folding_method=rf3_latest`, `inverse_folding_model=ligand_mpnn`, `result_type=ligand_binder`. For AME use `configs/evaluate_ame_from_pdb_dir.yaml` — see `reference/eval_configs.md` for full worked examples.
+
+If you need to inspect output between stages, run them separately. The configs above are shared between `evaluate` and `analyze`:
+
+```bash
+complexa evaluate configs/evaluate_from_pdb_dir.yaml ++sample_storage_path=/abs/path/to/pdbs ++run_name=eval_pdl1_af2
+complexa analyze  configs/evaluate_from_pdb_dir.yaml ++run_name=eval_pdl1_af2
+```
+
+Dry-run first if the user is unsure (no GPU work happens; the planned file walk + invocation prints):
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml ++sample_storage_path=/abs/path/to/pdbs ++dryrun=true
+```
+
+### Direct module invocation (debug fallback)
+
+`complexa evaluate` / `analyze` are subprocess wrappers around the Hydra
+modules with logging + parallel job splitting bolted on. To attach a debugger
+or run under a profiler, invoke the module directly:
+
+```bash
+python -m proteinfoundation.evaluate \
+    --config-path "$(realpath configs)" \
+    --config-name evaluate_from_pdb_dir \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=02_PDL1 \
+    ++metric.binder_folding_method=colabdesign \
+    ++run_name=eval_debug
+```
+
+For normal one-shot runs prefer `complexa analysis` — you get the shared log
+dir and a single replayable invocation, instead of having to thread the same
+overrides through two `python -m` calls.
+
+## Step 5: Parse results
+
+Output lands under `./evaluation_results/${run_name}/`:
+
+- Per-PDB metrics CSV — `*_results_*.csv` (one row per input PDB × `sequence_types`).
+- Pass-rate summaries — written by the `analyze` step (e.g. `res_designability.csv`, `res_filter_ligand_pass_*.csv`, `success_criteria_*.json`).
+- Diversity output — FoldSeek/MMseqs2 cluster files when `aggregation.compute_diversity=true` (default).
+
+Summarize to the user:
+
+- Per-PDB row count and number of successful designs vs total.
+- Default-threshold pass rate by `result_type` (e.g. for `protein_binder`: `i_pAE*31 <= 7.0 AND pLDDT >= 0.9 AND scRMSD_ca < 1.5`).
+- Top 5 designs by primary metric (`i_pAE` for protein, `min_ipAE` for ligand, `motif_rmsd_pred_all` for motif binders).
+
+## Step 6: Emit manifest
+
+Capture the resolved invocation + outputs for replay.
+
+```bash
+python3 .claude/skills/_shared/scripts/write_manifest.py \
+  --output-dir ./evaluation_results/${run_name} \
+  --command "complexa analysis configs/evaluate_from_pdb_dir.yaml ++sample_storage_path=<dir> ++dataset.task_name=<task> ++metric.binder_folding_method=<backend> ++run_name=<run>" \
+  --skill complexa-evaluate-pdbs \
+  --out ./eval_manifest.json
+```
+
+The manifest pins: resolved config, git SHA, ckpt SHA-256s, the result CSV paths, and the user-stated `result_type` for replay.
+
+## Most common overrides
+
+| Override                                       | Effect                                                                |
+|------------------------------------------------|-----------------------------------------------------------------------|
+| `++sample_storage_path=<dir>`                  | The directory of PDBs to evaluate (required).                         |
+| `++dataset.task_name=<name>`                   | Target / AME task name (binders, AME). Resolves target PDB + contigs. |
+| `++metric.binder_folding_method=<backend>`     | `colabdesign` / `rf3_latest` / `boltz2_default`.                      |
+| `++metric.inverse_folding_model=<model>`       | `protein_mpnn` / `soluble_mpnn` / `ligand_mpnn`.                      |
+| `++metric.sequence_types=[self,mpnn,mpnn_fixed]` | Which sequence flavors to refold.                                   |
+| `++metric.num_redesign_seqs=N`                 | ProteinMPNN/LigandMPNN redesign count.                                |
+| `++metric.compute_pre_refolding_metrics=true`  | Add bioinformatics/TMOL/HBPLUS metrics on the input structures.       |
+| `++metric.keep_folding_outputs=true`           | Save the refolded PDBs (large, but useful for inspection).            |
+| `++result_type=<type>`                         | Override default thresholds: `protein_binder` / `ligand_binder` / `motif_protein_binder` / `motif_ligand_binder`. |
+| `++aggregation.success_thresholds.<…>`         | Tighten or loosen specific thresholds (see `reference/eval_configs.md`). |
+| `++eval_njobs=N`                               | Parallel GPUs for the evaluate step.                                  |
+| `++dryrun=true`                                | Plan without running any folding.                                     |
+| `++file_limit=N`                               | Cap input PDBs (handy for first-pass smoke tests).                    |
+
+## Hardware
+
+- **GPU**: ≥1 CUDA GPU. AF2 (`colabdesign`) and RF3 (`rf3_latest`) need ≥40 GB VRAM (A100/H100/L40S). ESMFold runs on ≥24 GB. Multi-GPU via `++eval_njobs=N`.
+- **CPU/disk**: 24 CPUs default (`ncpus_: 24`). Each refolded PDB + intermediate output is ~1–5 MB; `keep_folding_outputs=true` can balloon to tens of GB for thousands of inputs.
+- See `_shared/reference/hardware.md` for per-backend wall-clock and VRAM tables.
+
+## Troubleshooting
+
+- **`Error: Config file not found`** — paths are relative to the repo root; `cd` to the repo before invoking `complexa analysis`.
+- **`compute_motif_binder_metrics=True` but `result_type=protein_binder`** — `result_type` and the underlying `compute_*_metrics` must agree. Use `configs/evaluate_ame_from_pdb_dir.yaml` for AME inputs rather than mutating `evaluate_from_pdb_dir.yaml`.
+- **RF3 shape errors on AME PDBs** — RF3 tries to auto-complete the ligand atoms from CCD. Rename the ligand residue to `L:0` in every input PDB before evaluation; see the snippet in `README.md` (`atom_array.res_name[ligand_mask] = "L:0"`).
+- **Diversity step fails (`foldseek not found`)** — `FOLDSEEK_EXEC` not on `PATH`. Either fix `.env` (preferred) or disable: `++aggregation.compute_diversity=false ++aggregation.compute_mmseqs_diversity=false`.
+- **All pass-rates are 0%** — check the `binder_folding_method` matches the target type (RF3 for ligand, AF2 for protein) and that `++dataset.task_name` resolves to the correct reference PDB (`complexa target show <name>` to verify).
+
+## Reference
+
+Full evaluate/analyze config matrix, every supported `result_type`, per-threshold defaults, and three worked examples (protein binder / ligand binder / AME): see `reference/eval_configs.md`.

--- a/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/evals/evals.json
+++ b/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "complexa-evaluate-pdbs",
+  "evals": [
+    {
+      "id": "complexa-evaluate-pdbs-001",
+      "prompt": "I want to use the complexa-evaluate-pdbs skill to score my binder designs in /data/designs/pdl1_binders/ using AF2 refolding. Can you run that for me?",
+      "expected_output": "The agent ran the complexa-evaluate-pdbs workflow by executing preflight checks, selecting the evaluate_from_pdb_dir.yaml config with colabdesign as the folding backend, ran complexa analysis on the specified PDB directory, and reported pass-rate metrics including i_pAE, pLDDT, and scRMSD from the resulting CSV.",
+      "assertions": [
+        "The agent executed the preflight.sh script to verify GPU availability and required environment variables",
+        "The agent ran complexa analysis with configs/evaluate_from_pdb_dir.yaml and ++sample_storage_path=/data/designs/pdl1_binders/ with colabdesign as the binder_folding_method",
+        "The agent parsed the output CSV and reported pass-rate summaries against protein_binder thresholds",
+        "The agent generated or referenced an eval_manifest.json for reproducibility",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-evaluate-pdbs",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-evaluate-pdbs-002",
+      "prompt": "I have a folder of BindCraft outputs at ~/bindcraft_results/her2/ and I need to compute interface pAE and i_pTM for all of them. Can you also check designability with ProteinMPNN?",
+      "expected_output": "The agent identified this as a PDB evaluation task, ran preflight checks, configured complexa analysis with the evaluate_from_pdb_dir.yaml config pointing to the BindCraft output directory, included designability metrics via inverse_folding_model=soluble_mpnn, and reported per-PDB interface pAE, i_pTM, and designability scRMSD results.",
+      "assertions": [
+        "The agent ran preflight.sh to check GPU, disk, and tool availability before launching the evaluation",
+        "The agent selected the protein_binder result_type and evaluate_from_pdb_dir.yaml config for third-party BindCraft outputs",
+        "The agent included ++metric.inverse_folding_model=soluble_mpnn to enable ProteinMPNN designability scoring",
+        "The agent reported interface pAE, i_pTM, and designability scRMSD metrics from the results CSV",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-evaluate-pdbs",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-evaluate-pdbs-003",
+      "prompt": "We just received 50 hand-curated binder decoys from a collaborator targeting EGFR. They're in /shared/collab_decoys/egfr_v2/. I need to validate them before our meeting tomorrow — can you refold with RoseTTAFold3 and give me pass rates? We need at least 20% of designs passing on scRMSD and i_pAE.",
+      "expected_output": "The agent performed a full complexa evaluate-pdbs workflow using RF3 as the folding backend on the collaborator's EGFR decoys, verified RF3 environment variables were set, ran complexa analysis, and reported whether the 20% pass-rate threshold was met for scRMSD and i_pAE metrics.",
+      "assertions": [
+        "The agent ran preflight.sh and verified RF3_CKPT_PATH and RF3_EXEC_PATH were available in the environment",
+        "The agent ran complexa analysis with ++metric.binder_folding_method=rf3_latest and ++sample_storage_path=/shared/collab_decoys/egfr_v2/",
+        "The agent parsed the result CSV and explicitly reported pass-rates for scRMSD and i_pAE against the protein_binder thresholds",
+        "The agent compared the observed pass-rates to the user's stated 20% requirement and communicated whether the designs met that bar",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-evaluate-pdbs",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-evaluate-pdbs-004",
+      "prompt": "How do I install RoseTTAFold3 and set up the checkpoint paths on my new workstation?",
+      "expected_output": "The agent recognized this as an installation/setup question rather than an evaluation task, and either provided general guidance on RF3 installation or directed the user to the complexa-setup skill instead of running complexa-evaluate-pdbs.",
+      "assertions": [
+        "The agent did not run complexa analysis or any evaluation workflow",
+        "The agent provided installation guidance or directed the user to the complexa-setup skill for environment configuration",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/reference/eval_configs.md
+++ b/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/reference/eval_configs.md
@@ -1,0 +1,197 @@
+# Evaluate-from-PDB-Dir Config Reference
+
+Companion to `SKILL.md`. Every `evaluate_*_from_pdb_dir.yaml` and its paired `analyze_*.yaml`, with the `result_type` they emit, the `dataset.*` keys they require, and the `metric.*` / `aggregation.*` knobs they accept. Three worked examples at the bottom.
+
+## 1. Design type → config matrix
+
+| Design type            | Evaluate config                              | Analyze config              | `result_type`            | Folding backends         | Inverse-folding default |
+|------------------------|----------------------------------------------|-----------------------------|--------------------------|--------------------------|-------------------------|
+| Protein binder         | `configs/evaluate_from_pdb_dir.yaml`         | `configs/analyze.yaml`      | `protein_binder`         | `colabdesign`, `rf3_latest`, `esmfold`, `boltz2_default`, `protenix_base_default_v0.5.0` | `soluble_mpnn` |
+| Ligand binder          | `configs/evaluate_from_pdb_dir.yaml`         | `configs/analyze.yaml`      | `ligand_binder`          | `rf3_latest` (default), `boltz2_default` | `ligand_mpnn` |
+| AME / motif ligand binder | `configs/evaluate_ame_from_pdb_dir.yaml`  | `configs/analyze_motif_binder.yaml` | `motif_ligand_binder` | `rf3_latest`            | `ligand_mpnn`           |
+| Motif protein binder   | `configs/evaluate_motif_binder.yaml` (no `_from_pdb_dir` variant; set `input_mode=pdb_dir`) | `configs/analyze_motif_binder.yaml` | `motif_protein_binder` | `colabdesign`, `rf3_latest` | `protein_mpnn` / `soluble_mpnn` |
+
+Notes:
+- The protein-binder and ligand-binder cases share `evaluate_from_pdb_dir.yaml`; switch behavior by setting `result_type`, `metric.binder_folding_method`, and `metric.inverse_folding_model` on the CLI.
+- There is no shipped `evaluate_motif_protein_binder_from_pdb_dir.yaml`; reuse `configs/evaluate_motif_binder.yaml` with `++input_mode=pdb_dir ++sample_storage_path=<dir>` and an appropriate `dataset/motif_target_dict_cfg` override.
+
+## 2. Evaluate config schema
+
+All `evaluate_*` configs share a top-level shape (run identification, `input_mode`, `protein_type`, `sample_storage_path`, `output_dir`, `eval_njobs`, `seed`, `ncpus_`, `dataset.*`, `metric.*`). Below: the differences that matter when running from a PDB directory.
+
+### `evaluate_from_pdb_dir.yaml`
+
+- `protein_type: binder` (one config handles both protein and ligand binders).
+- `input_mode: pdb_dir` (already set; never override back to `generated`).
+- `defaults: - generation/targets_dict@dataset` — resolves `dataset.task_name` against `configs/targets/targets_dict.yaml` (and ligand_targets_dict via task naming).
+- Required `dataset.*`:
+  - `dataset.task_name` — target key (e.g. `02_PDL1`, `39_7V11_LIGAND`).
+- Key `metric.*` fields:
+  - `compute_binder_metrics: true`.
+  - `binder_folding_method` — picks the refolding backend (table above).
+  - `sequence_types: [self|mpnn|mpnn_fixed]` — which sequence(s) to refold.
+  - `num_redesign_seqs` — MPNN sequence count (default 8 here).
+  - `interface_cutoff` — Å cutoff for interface residue detection (default 8.0 protein, 6.0 motif).
+  - `inverse_folding_model` — `soluble_mpnn` / `protein_mpnn` (protein) or `ligand_mpnn` (ligand).
+  - `compute_pre_refolding_metrics`, `pre_refolding.{bioinformatics,tmol,hbplus}` — optional pre-refold interface metrics.
+  - `compute_refolded_structure_metrics`, `refolded.{bioinformatics,tmol,hbplus}` — optional post-refold.
+  - `compute_monomer_metrics`, `compute_designability`, `compute_codesignability`, `designability_modes`, `codesignability_modes` — monomer-on-binder eval.
+  - `compute_co_sequence_recovery`, `compute_ss` — sequence/secondary-structure metrics.
+  - `compute_novelty_{pdb,afdb,afdb_rep_v4}` — FoldSeek novelty against known DBs.
+  - `keep_folding_outputs` — keep refolded PDBs.
+- File walk control:
+  - `ignore_generated_pdb_suffix: "_binder.pdb"` (default) — drop intermediate binder-only PDBs from the walk.
+  - `file_limit: N` — cap input count.
+- `result_type` is set inline (`ligand_binder` or `protein_binder`) and propagates to the paired analyze step.
+
+### `evaluate_ame_from_pdb_dir.yaml`
+
+- `protein_type: motif_binder`.
+- `defaults: - /design_tasks/ame_dict_v2@dataset` — resolves AME tasks (`M0024_1nzy`, `M0096_1chm`, etc.).
+- Required `dataset.task_name` — must match a key in `ame_dict_v2`.
+- Key `metric.*`:
+  - `compute_motif_binder_metrics: True`.
+  - `binder_folding_method: rf3_latest` (only RF3 makes sense for ligand motif binders).
+  - `inverse_folding_model: ligand_mpnn`.
+  - `sequence_types: [mpnn_fixed, self]` (default — `mpnn_fixed` keeps the motif residues constant).
+  - `interface_cutoff: 6.0`.
+  - `compute_binder_metrics`, `compute_monomer_metrics` — optional add-ons; `compute_motif_metrics` is incompatible with `motif_binder`.
+- `result_type: motif_ligand_binder`.
+
+### Shared reference configs (no `_from_pdb_dir` suffix)
+
+These ship for completeness; the `from_pdb_dir` variants are derived from them with `input_mode=pdb_dir` baked in.
+
+- `configs/evaluate.yaml` — unified binder evaluation, defaults `input_mode: generated`. Pass `++input_mode=pdb_dir ++sample_storage_path=<dir>` to evaluate an external directory.
+- `configs/evaluate_motif_binder.yaml` — motif binder (protein + ligand variants). Set `++result_type=motif_protein_binder` (with AF2/ColabDesign + ProteinMPNN/SolubleMPNN) or rely on the default `motif_ligand_binder` (RF3 + LigandMPNN). Use this when you have motif-protein-binder PDBs — there is no dedicated `_from_pdb_dir` variant.
+
+## 3. Analyze config schema
+
+### `analyze.yaml`
+
+- `result_type: protein_binder` (default) or `ligand_binder` (override).
+- `aggregation.analysis_modes` — default `[binder, monomer]` for binder result types.
+- `aggregation.success_thresholds` — `null` (defaults) or a dict of `{metric: {threshold, op, scale, column_prefix}}` entries.
+- Built-in defaults:
+  - `protein_binder`: `i_pAE * 31 <= 7.0`, `pLDDT >= 0.9`, `scRMSD_ca < 1.5`.
+  - `ligand_binder`: `min_ipAE * 31 < 2.0`, `scRMSD_ca < 2.0`, `ligand_scRMSD_aligned_allatom < 5.0`.
+- Monomer-mode thresholds (when `[monomer]` is in `analysis_modes`):
+  - `aggregation.designability_thresholds` — `{mode: {model: {threshold, op}}}`; default 2.0 Å.
+  - `aggregation.ca_codesignability_thresholds` — default 2.0 Å.
+  - `aggregation.allatom_codesignability_thresholds` — default 2.0 Å.
+  - `aggregation.require_all_thresholds: false` — `false` = OR across modes/models, `true` = AND.
+
+### `analyze_motif_binder.yaml`
+
+- `result_type: motif_protein_binder` (default in the YAML) or `motif_ligand_binder` (override on CLI).
+- `aggregation.analysis_modes` — default `[motif_binder, binder, monomer]`.
+- `aggregation.motif_binder_success_thresholds`:
+  - **`motif_protein_binder` defaults** — binder: `i_pAE*31 <= 7.0`, `pLDDT >= 0.8`, `scRMSD_ca < 2.0`; motif: `motif_rmsd_pred_all < 2.0`, `correct_motif_sequence_all >= 1.0`.
+  - **`motif_ligand_binder` defaults** — binder: `scRMSD_bb3 <= 2.0`; motif: `motif_rmsd_pred_all <= 1.5`, `correct_motif_sequence_all >= 1.0`, `has_ligand_clashes_all < 0.5`.
+- A sample is successful when **at least one redesign index** passes **every** binder criterion AND **every** motif criterion jointly. Per-redesign joint evaluation, not pooled.
+- `aggregation.success_thresholds` (binder-only mode) and the three monomer threshold dicts work identically to `analyze.yaml`.
+
+## 4. `motif_protein_binder` vs `motif_ligand_binder`
+
+Both come from `evaluate_motif_binder.yaml` family + `analyze_motif_binder.yaml`. The split is target-driven:
+
+| Property                    | `motif_protein_binder`           | `motif_ligand_binder` (AME)        |
+|-----------------------------|----------------------------------|------------------------------------|
+| Target                      | Protein receptor                 | Small molecule ligand              |
+| Folding (`binder_folding_method`) | `colabdesign` (AF2) or `rf3_latest` | `rf3_latest`                  |
+| Inverse folding             | `protein_mpnn` / `soluble_mpnn`  | `ligand_mpnn`                      |
+| Motif criteria              | RMSD + seq recovery              | RMSD + seq recovery + ligand clashes |
+| Default binder threshold    | `i_pAE*31 <= 7.0`, `pLDDT >= 0.8`, `scRMSD_ca < 2.0` | `scRMSD_bb3 <= 2.0` |
+| Default motif threshold     | `motif_rmsd_pred_all < 2.0`, `correct_motif_sequence_all >= 1.0` | `motif_rmsd_pred_all <= 1.5`, seq recovery, `has_ligand_clashes_all < 0.5` |
+| `evaluate_*_from_pdb_dir`   | none — use `evaluate_motif_binder.yaml` + `++input_mode=pdb_dir` | `evaluate_ame_from_pdb_dir.yaml` |
+
+When in doubt: if every PDB has a small-molecule ligand chain, it is `motif_ligand_binder`. If the second chain is another protein receptor, it is `motif_protein_binder`.
+
+## 5. Ligand `L:0` rename for AME RF3 evaluation
+
+Lifted from `README.md` "Evaluating AME Designs with Ligand Targets (RF3)":
+
+> When running RF3 evaluation on AME-generated PDB files that contain a ligand (small molecule on chain A), RF3 will attempt to add missing atoms based on the ligand's CCD code. This can cause shape errors in downstream RMSD calculations and provide the incorrect structure.
+>
+> **Solution:** rename the ligand residue to `L:0` before passing to RF3. This tells RF3 to treat it as a generic ligand and skip atom completion.
+
+```python
+from atomworks.io import load_any, to_pdb_file
+atom_array = load_any("my_design.pdb")
+ligand_mask = atom_array.chain_id == "A"
+atom_array.res_name[ligand_mask] = "L:0"
+to_pdb_file(atom_array, "my_design_rf3_ready.pdb")
+```
+
+Apply this transform once over the whole input directory before invoking
+`complexa analysis configs/evaluate_ame_from_pdb_dir.yaml ...`. If the PDBs
+came out of `complexa generate` with `protein_type=motif_binder`, the rename is
+already done.
+
+## 6. Worked examples
+
+### Example A — protein binder PDB directory, AF2 refold
+
+User: "Re-fold these 200 PDL1 binders with AlphaFold2 and tell me what fraction passes the default AlphaProteo thresholds."
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+  ++sample_storage_path=/data/pdl1_designs \
+  ++dataset.task_name=02_PDL1 \
+  ++metric.binder_folding_method=colabdesign \
+  ++metric.inverse_folding_model=soluble_mpnn \
+  ++metric.sequence_types=[self,mpnn_fixed] \
+  ++metric.num_redesign_seqs=8 \
+  ++result_type=protein_binder \
+  ++eval_njobs=2 \
+  ++run_name=pdl1_pdb_dir_af2
+```
+
+Pass-rate filter (applied by analyze):
+`mpnn_complex_i_pAE * 31 <= 7.0 AND mpnn_complex_pLDDT >= 0.9 AND mpnn_binder_scRMSD_ca < 1.5`.
+
+### Example B — AME PDB directory, RF3 refold (motif ligand binder)
+
+User: "Score this folder of AME 1nzy designs — joint binder + motif success please."
+
+```bash
+# First, rename ligand to L:0 in every PDB (one-time).
+python scripts/rename_ligand_to_L0.py /data/ame_1nzy_designs
+
+complexa analysis configs/evaluate_ame_from_pdb_dir.yaml \
+  ++sample_storage_path=/data/ame_1nzy_designs \
+  ++dataset.task_name=M0024_1nzy \
+  ++metric.binder_folding_method=rf3_latest \
+  ++metric.inverse_folding_model=ligand_mpnn \
+  ++metric.sequence_types=[mpnn_fixed,self] \
+  ++metric.num_redesign_seqs=2 \
+  ++result_type=motif_ligand_binder \
+  ++run_name=ame_m0024_pdb_dir
+```
+
+Joint success criterion (from `analyze_motif_binder.yaml`, `motif_ligand_binder` defaults): at least one redesign index satisfies binder `scRMSD_bb3 <= 2.0` AND motif `motif_rmsd_pred_all <= 1.5` AND `correct_motif_sequence_all >= 1.0` AND `has_ligand_clashes_all < 0.5`.
+
+### Example C — ligand binder PDB directory, RF3 refold
+
+User: "Score this folder of 7V11 ligand-binder designs with RF3 and LigandMPNN."
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+  ++sample_storage_path=/data/7v11_designs \
+  ++dataset.task_name=39_7V11_LIGAND \
+  ++metric.binder_folding_method=rf3_latest \
+  ++metric.inverse_folding_model=ligand_mpnn \
+  ++metric.sequence_types=[self,mpnn_fixed] \
+  ++metric.num_redesign_seqs=8 \
+  ++result_type=ligand_binder \
+  ++eval_njobs=2 \
+  ++run_name=7v11_pdb_dir_rf3
+```
+
+Pass-rate filter (applied by analyze): `min_ipAE * 31 < 2.0 AND scRMSD_ca < 2.0 AND ligand_scRMSD_aligned_allatom < 5.0`. Override via `++aggregation.success_thresholds.min_ipAE.threshold=…` etc.
+
+## 7. Pointers
+
+- Per-metric output column names: `docs/EVALUATION_METRICS.md` "Result CSV Reference".
+- Default thresholds and Python filter examples: `docs/EVALUATION_METRICS.md` "Success Criteria" and "Reading Results in Python".
+- Hardware tables (VRAM per backend, wall-clock per N PDBs): `_shared/reference/hardware.md`.

--- a/open-models-skills/proteina-complexa/complexa-setup/SKILL.md
+++ b/open-models-skills/proteina-complexa/complexa-setup/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: complexa-setup
+description: >
+  First-time setup, environment configuration, and model-weight installation for
+  Proteina-Complexa. Reach for this skill whenever the user says "set up complexa",
+  "install complexa", "configure my .env", "first-time setup", "what models do I
+  have installed", "what's in my .env", "download model weights", "download
+  Complexa / AF2 / RF3 / ProteinMPNN / LigandMPNN / ESM2 / ESMFold checkpoints",
+  "preflight my GPU", "verify environment", "complexa init", "complexa download",
+  "complexa download --status", "complexa validate env", or any time a fresh
+  checkout needs to be made runnable. This is the first skill to run on a new
+  clone — it drives `complexa init`, `complexa download`, and `complexa validate
+  env` end-to-end, edits the required `.env` keys, picks the right runtime (UV
+  vs Docker), and emits a replayable setup artifact.
+compatibility: "complexa CLI installed (pip install -e .); bash 4+; nvidia-smi optional"
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Complexa Setup Skill
+
+Drive the three steps a fresh Proteina-Complexa checkout needs before any
+design run: create `.env`, fetch model weights, and sanity-check the env.
+Probe the host for GPU / disk / tool binaries first so the user does not
+discover a missing dependency mid-pipeline. End with a JSON setup artifact the
+user (or a future agent) can re-read instead of re-deriving state.
+
+## CLI vs direct file-edit — pick the cheapest path per step
+
+| Step | Preferred path | Why |
+|---|---|---|
+| `.env` creation (Step 2) | **File edit** (`cp .env_example .env` + 3 line swaps) or `complexa init` | `complexa init` is a thin wrapper around `cp + 3 regex swaps` (`_swap_runtime_in_env` in `cli_runner.py`). Either path works; pick CLI for new humans, direct edit for agents. |
+| `.env` value edits (Step 3) | **File edit** (StrReplace `LOCAL_CODE_PATH=…` etc.) | No CLI for this — the values are user-specific paths. |
+| Download model weights (Step 4) | **CLI** (`complexa download --…`) | Dispatches to `env/download_startup.sh` (~1000 lines of bash with NGC URLs, retries, checksum-style skip-if-present). Don't try to replicate. |
+| Validate env (Step 5) | **CLI** (`complexa validate env`) or `test -f .env && test -d $DATA_PATH` | CLI prints a nicer report; the manual check is one-liner-safe. |
+| Validate full design config (after picking a pipeline) | **CLI** (`complexa validate design CONFIG`) | Non-trivial Hydra defaults traversal + ckpt + env-var checks; not worth replicating. |
+
+## What this skill enables
+
+- A correctly-shaped `.env` for either UV or Docker runtime.
+- Model checkpoints (Complexa protein/ligand/AME plus community models) downloaded to known paths.
+- A `preflight.json` snapshot of the host (GPU, disk, .env, ckpts, tool binaries).
+- A `run_manifest.json` capturing exactly which `complexa init` + `complexa download` invocations were used (replay-friendly).
+- A pass/fail report from `complexa validate env` with clear next-step hints.
+
+## Step 1: Pre-flight check
+
+Always run the shared preflight before touching the environment. It does not
+require `.env` to exist — it falls back to defaults — and it tells you whether
+the host can run Complexa at all.
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+The script writes `./complexa_setup/preflight.json`. Read it and surface:
+
+- `gpu.available` — if `false`, design / evaluate steps will fail; warn the user.
+- `gpu.vram_gb` — Complexa needs ≥40 GB (A100/H100/L40S).
+- `disk.free_gb` at `CKPT_PATH` — minimum ~50 GB for the full Complexa + community model set.
+- `env.missing_required` — anything listed here must be edited in `.env` before validation passes.
+- `tools.{foldseek,mmseqs,dssp,hbplus,sc}.exists` — missing tools degrade evaluation but do not block generation.
+
+## Step 1b: Build the Python environment (only if `.venv/` is missing)
+
+The `complexa` CLI is installed inside the project's Python environment, not on
+the system path by default. On a **fresh clone**, the `.venv/` directory does
+not yet exist and `complexa init` will fail with `command not found`. Build the
+UV venv before anything else:
+
+```bash
+test -d .venv || ./env/build_uv_env.sh   # first-time UV build
+source .venv/bin/activate
+which complexa                            # sanity check: should point inside .venv
+```
+
+Skip this step if `which complexa` already resolves — that means a previous
+build is still good. The Docker runtime skips it entirely; the venv lives
+inside the container image instead. If the user said "I just cloned" or you
+see no `.venv/` next to `pyproject.toml`, run the build script — `complexa init`
+without a venv produces a confusing `command not found` rather than an obvious
+"build the venv first" error.
+
+## Step 2: Create `.env`
+
+Pick the runtime. UV is the default and faster to start; Docker is required on
+Ubuntu 20.04 or systems with GLIBC mismatches.
+
+Use AskUserQuestion if it is not obvious from context:
+
+> "Which runtime do you want to configure? `uv` (recommended, faster) or `docker` (use if you do not have a UV venv built locally)?"
+
+### Path A: file edit (preferred for agents)
+
+`complexa init` only does three things — copy `.env_example` → `.env` and
+swap the `COMPLEXA_RUNTIME=` line plus the `UV_*` ↔ `DOCKER_*` prefixes on the
+tool/data/cache path block. You can do the same with `cp` + StrReplace and skip
+the CLI:
+
+```bash
+cp .env_example .env
+# Then StrReplace these lines in .env:
+#   COMPLEXA_RUNTIME=uv          → COMPLEXA_RUNTIME=<runtime>
+#   FOLDSEEK_EXEC=${UV_FOLDSEEK_EXEC}  → FOLDSEEK_EXEC=${DOCKER_FOLDSEEK_EXEC}   (and same for RF3_EXEC_PATH, SC_EXEC, HBPLUS_EXEC, MMSEQS_EXEC, DSSP_EXEC, TMOL_PATH)
+#   DATA_PATH=${LOCAL_DATA_PATH} → DATA_PATH=${DOCKER_DATA_PATH}                  (and same for CACHE_DIR, CKPT_PATH)
+```
+
+Skip the prefix swap entirely if you're staying on UV (the `.env_example`
+already targets UV).
+
+### Path B: CLI
+
+```bash
+complexa init                    # UV runtime (default)
+complexa init --runtime docker   # Docker runtime
+complexa init --force            # Recreate .env from .env_example (drops any edits)
+```
+
+If `.env` already exists and `--force` is not passed, only the runtime-dependent
+lines are swapped — user edits in Step 3 are preserved across runtime flips.
+
+### Verify either way
+
+```bash
+test -f .env && echo "OK: .env present" || echo "MISSING"
+grep -E '^COMPLEXA_RUNTIME=' .env
+```
+
+## Step 3: Edit .env
+
+No CLI for this — Step 2 only set the runtime; you still need to write your
+machine-specific paths into `.env` by hand (StrReplace or your editor). The two
+absolutely-required edits are:
+
+```bash
+LOCAL_CODE_PATH=/absolute/path/to/protein-foundation-models
+LOCAL_DATA_PATH=/absolute/path/to/PFM_data
+```
+
+Everything else (cache, ckpts, community-model dirs, tool binaries) is derived
+from `LOCAL_CODE_PATH` by default and only needs editing if you have a
+non-standard layout. For the full table — every key, what it controls, what
+fails if it is missing — see [reference/env_keys.md](reference/env_keys.md).
+
+Quick decision table for the four edits most users make:
+
+| Key | Default | Set this if |
+|-----|---------|-------------|
+| `LOCAL_CODE_PATH` | placeholder | Always — required |
+| `LOCAL_DATA_PATH` | `/path/to/PFM_data` | Always — required, points at target PDBs |
+| `HF_TOKEN` | placeholder | You need ESMFold or gated HF models |
+| `WANDB_API_KEY` | placeholder | You want training runs logged to W&B |
+
+## Step 4: Download checkpoints
+
+**Always use the CLI here.** `complexa download` dispatches to
+`env/download_startup.sh` (~1000 lines of bash with NGC URLs, retries, and
+skip-if-present logic across ~6 community-model families). Rolling your own
+wget loop is a recipe for partial downloads and wrong destination paths.
+
+Ask which models the user actually needs — downloading everything is ~100+ GB.
+Pick from the three Complexa variants and the community-model set. Each
+Complexa variant unlocks exactly one `complexa design` pipeline; AF2 / RF3
+inside the community-model set are what `evaluate` (and reward-guided search)
+need at run time.
+
+| Flag | What it downloads | Unlocks pipeline | Destination | Approx size |
+|------|-------------------|------------------|-------------|-------------|
+| `--complexa` | Complexa protein-binder model + AE (`complexa.ckpt`, `complexa_ae.ckpt`) | **Protein binder** (default) — `configs/search_binder_local_pipeline.yaml` | `./ckpts/` | ~3 GB |
+| `--complexa-ligand` | Ligand-binder model + AE (`complexa_ligand.ckpt`, `complexa_ligand_ae.ckpt`) | Ligand binder — `configs/search_ligand_binder_local_pipeline.yaml` | `./ckpts/` | ~3 GB |
+| `--complexa-ame` | AME motif-scaffolding model + AE (`complexa_ame.ckpt`, `complexa_ame_ae.ckpt`) | AME (enzyme) — `configs/search_ame_local_pipeline.yaml` | `./ckpts/` | ~3 GB |
+| `--complexa-all` | All three Complexa variants | All three pipelines | `./ckpts/` | ~9 GB |
+| `--all` | All community models (ProteinMPNN + LigandMPNN + AF2 + ESM2 + ESMFold + RF3) | Needed by **evaluate / reward**: AF2 (protein binder), RF3 (ligand binder + AME), MPNNs (inverse folding for every pipeline). | `./community_models/` | ~50 GB |
+| `--everything` | Complexa + community + optional (Boltz2 / Protenix) | Everything plus alternative refold backends | both | ~100+ GB |
+| `--status` | Show install state — does not download | (none) | (none) | n/a |
+
+**Minimum download per pipeline:**
+
+- Protein binder (default): `complexa download --complexa --all`
+- Ligand binder: `complexa download --complexa-ligand --all`
+- AME / enzyme: `complexa download --complexa-ame --all`
+- All three: `complexa download --everything`
+
+For the full per-model destination breakdown and per-flag NGC sources, see
+[reference/downloads.md](reference/downloads.md).
+
+Pick the smallest invocation that covers the user's goal, then run:
+
+```bash
+complexa download --complexa            # protein binder only
+complexa download --complexa-all        # all three Complexa variants
+complexa download --all                 # community models only
+complexa download --everything          # everything
+```
+
+Without arguments, `complexa download` launches an interactive wizard — prefer
+explicit flags in agent mode.
+
+Verify what landed:
+
+```bash
+complexa download --status
+```
+
+The status output groups by family (Complexa / community / optional) and prints
+"Installed" or "Missing" per ckpt. Re-run the specific flag if a ckpt is
+flagged missing.
+
+## Step 5: Validate
+
+Final check that `.env` is loadable and the required paths resolve:
+
+```bash
+complexa validate env
+```
+
+`validate env` checks: (1) `.env` exists, (2) `DATA_PATH` is set and points at
+an existing directory. It does not check ckpt files — those are checked by
+`complexa validate design <config>` once you have a pipeline config picked.
+
+Common failures and fixes:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `.env file: No .env file found` | `complexa init` not run | Run `complexa init` first |
+| `DATA_PATH: Not set in .env` | Placeholder not edited | Edit `LOCAL_DATA_PATH` in `.env` |
+| `DATA_PATH: Directory not found` | Path edited but does not exist on disk | `mkdir -p $LOCAL_DATA_PATH` or copy target data there |
+| Hydra error `InterpolationKeyError: AF2_DIR` | Reward/eval config wants AF2 but `.env` does not define it | Download AF2 weights or remove AF2 from the config |
+
+## Step 6: Emit setup artifact
+
+Drop a JSON manifest in `./complexa_setup/` so the user has a single file
+describing the resulting state. The shared helper writes it for you:
+
+```bash
+mkdir -p ./complexa_setup
+python .claude/skills/_shared/scripts/write_manifest.py \
+    --kind setup \
+    --runtime "$(grep -E '^COMPLEXA_RUNTIME=' .env | cut -d= -f2)" \
+    --preflight ./complexa_setup/preflight.json \
+    --out ./complexa_setup/run_manifest.json
+```
+
+Surface the resulting files to the user:
+
+```bash
+ls -la ./complexa_setup/
+```
+
+Expected contents:
+
+```
+complexa_setup/
+├── preflight.json      # GPU / disk / .env / ckpt / tool snapshot
+└── run_manifest.json   # init + download invocations + git SHA + runtime
+```
+
+## Hardware requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| GPU | 1× CUDA GPU, ≥24 GB VRAM | A100 / H100 / L40S, 40–80 GB VRAM |
+| CUDA | 12.0 | 12.4+ |
+| Disk (CKPT_PATH) | 50 GB | 150 GB (covers `--everything`) |
+| RAM | 16 GB | 64 GB+ |
+| OS | Ubuntu 22.04+ (UV) | Ubuntu 22.04+ or Docker on any host |
+
+Ubuntu 20.04 throws GLIBC errors with the UV runtime — use `complexa init
+--runtime docker` on those hosts. See `.claude/skills/_shared/reference/hardware.md`
+for per-pipeline (binder vs ligand vs AME) requirements.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `complexa: command not found` | Package not installed in active env | `source .venv/bin/activate` then `pip install -e .` |
+| `complexa init` says `.env_example not found` | Running outside repo root | `cd` to the project root (where `.env_example` lives) |
+| `.env_example not found. Cannot initialize .env.` | Not in project root | `cd` into `protein-foundation-models/` and retry |
+| `complexa download` fails on NGC URL | Behind firewall / no internet | Configure a proxy for the download script, or download the model `.ckpt`s manually from the NGC pages linked in the main `README.md` and drop them into `./ckpts/` |
+| `complexa download --status` shows ckpts present but `validate` fails | `.env` `CKPT_PATH` points elsewhere | Either move ckpts or edit `LOCAL_CHECKPOINT_PATH` in `.env` |
+| GLIBC error on import | Ubuntu 20.04 with UV runtime | Re-run `complexa init --runtime docker` and use `./env/docker-ops.sh run` |
+
+---
+
+For the full `.env` reference (every key, defaults, failure modes), see
+[reference/env_keys.md](reference/env_keys.md).
+
+For the full download flag matrix, NGC URLs, and destination layout, see
+[reference/downloads.md](reference/downloads.md).

--- a/open-models-skills/proteina-complexa/complexa-setup/evals/evals.json
+++ b/open-models-skills/proteina-complexa/complexa-setup/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "complexa-setup",
+  "evals": [
+    {
+      "id": "complexa-setup-001",
+      "prompt": "Set up complexa on this machine. I just cloned the repo and need everything configured from scratch.",
+      "expected_output": "The agent executed the complexa-setup skill end-to-end, running preflight checks, initializing the .env via `complexa init`, configuring user-specific paths, downloading model weights, and validating the environment, producing a replayable setup artifact.",
+      "assertions": [
+        "The agent ran `bash .claude/skills/_shared/scripts/preflight.sh` and read the resulting preflight.json",
+        "The agent executed `complexa init` to create the .env file with the appropriate runtime selection",
+        "The agent asked the user for environment-specific values (e.g., LOCAL_CODE_PATH, DATA_PATH) and edited the .env file accordingly",
+        "The agent ran `complexa validate env` to confirm the environment was correctly configured",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-setup",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-setup-002",
+      "prompt": "I need to download the AF2 and ProteinMPNN model weights for my protein design pipeline. I already have a .env but I'm not sure if my checkpoints are complete.",
+      "expected_output": "The agent identified this as a model weight download task within the complexa-setup skill, checked the current download status, and ran the appropriate `complexa download` commands to fetch missing AF2 and ProteinMPNN checkpoints.",
+      "assertions": [
+        "The agent ran preflight checks to assess disk space and existing checkpoint status",
+        "The agent executed `complexa download --status` or equivalent to determine which model weights were already present",
+        "The agent ran `complexa download` with appropriate flags to fetch the missing AF2 and ProteinMPNN checkpoints",
+        "The agent confirmed successful download by validating the environment or checking file existence",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-setup",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-setup-003",
+      "prompt": "I just spun up a new A100 instance on AWS and git cloned proteina-complexa. When I try to run a design job it says '.env not found'. How do I get this thing working? I want to use Docker as my runtime.",
+      "expected_output": "The agent recognized the fresh-instance scenario, performed the full first-time setup workflow selecting Docker as the runtime, created and configured the .env, downloaded necessary model weights, and validated the environment so the user's design jobs could proceed.",
+      "assertions": [
+        "The agent ran the preflight script to check GPU availability, VRAM, and disk space on the new instance",
+        "The agent executed `complexa init docker` (or equivalent Docker runtime selection) to generate the .env file",
+        "The agent edited the .env file with user-specific paths using file write operations",
+        "The agent ran `complexa download` to fetch required model checkpoints and then validated the environment",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-setup",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-setup-004",
+      "prompt": "Can you help me analyze the binding affinity results from my last Complexa design run? The output CSV is in ./results/run_042/scores.csv and I want to know which candidates had the best dG values.",
+      "expected_output": "The agent recognized this as a results analysis task unrelated to environment setup, and assisted with reading and interpreting the design run output CSV rather than invoking the complexa-setup skill.",
+      "assertions": [
+        "The agent read the scores.csv file from the specified path to examine binding affinity results",
+        "The agent identified and ranked candidates by dG values without running any setup or initialization commands",
+        "The agent did not execute `complexa init`, `complexa download`, or `complexa validate env`",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/open-models-skills/proteina-complexa/complexa-setup/reference/downloads.md
+++ b/open-models-skills/proteina-complexa/complexa-setup/reference/downloads.md
@@ -1,0 +1,146 @@
+# `complexa download` Reference
+
+Full flag matrix, destination layout, and NGC source for every checkpoint
+Complexa can pull.
+
+`complexa download` is a thin Python wrapper around `env/download_startup.sh`
+— the CLI argparse (in `src/proteinfoundation/cli/cli_runner.py:download_main`)
+forwards `sys.argv[2:]` straight to the bash script, so any flag the bash
+script accepts is reachable.
+
+---
+
+## Flag matrix
+
+The Python argparse explicitly defines these flags:
+
+| Flag | What it downloads | Destination | Approx size | Source |
+|------|-------------------|-------------|-------------|--------|
+| `--complexa` | `complexa.ckpt` + `complexa_ae.ckpt` (protein binder) | `./ckpts/` | ~3 GB | NGC `proteina_complexa` |
+| `--complexa-ligand` | `complexa_ligand.ckpt` + `complexa_ligand_ae.ckpt` (ligand binder) | `./ckpts/` | ~3 GB | NGC `proteina_complexa_ligand` |
+| `--complexa-ame` | `complexa_ame.ckpt` + `complexa_ame_ae.ckpt` (motif scaffolding) | `./ckpts/` | ~3 GB | NGC `proteina_complexa_ame` |
+| `--complexa-all` | All three Complexa pairs | `./ckpts/` | ~9 GB | NGC (3 models) |
+| `--all` | ProteinMPNN + LigandMPNN + AF2 + ESM2 + ESMFold + RF3 | `./community_models/...` | ~50 GB | Mixed (GitHub + AWS + HF + NGC) |
+| `--everything` | All Complexa + community + Boltz2 | both | ~100+ GB | Mixed |
+| `--status` | Show install state; downloads nothing | (none) | n/a | n/a |
+
+The underlying bash script also accepts per-model flags (`--pmpnn`,
+`--ligmpnn`, `--af2`, `--esm2`, `--esmfold`, `--rf3`, `--boltz2`) that pass
+through unchanged. They are listed in `env/download_startup.sh:show_help` but
+not in the Python argparse — they still work because of the `sys.argv[2:]`
+passthrough.
+
+| Passthrough flag | Destination | Approx size |
+|------------------|-------------|-------------|
+| `--pmpnn` | `./community_models/ProteinMPNN/{ca,vanilla}_model_weights/` | ~50 MB |
+| `--ligmpnn` | `./community_models/LigandMPNN/model_params/` | ~500 MB |
+| `--af2` | `./community_models/ckpts/AF2/params/` | ~3 GB |
+| `--esm2` | `./community_models/ckpts/ESM2/` | ~2.5 GB |
+| `--esmfold` | `./community_models/ckpts/ESMFold/` | ~8.5 GB |
+| `--rf3` | `./community_models/ckpts/RF3/` | ~10 GB |
+| `--boltz2` | `./community_models/ckpts/Boltz2/` | ~5 GB |
+
+---
+
+## Default destinations
+
+All downloads land relative to the *current working directory* (the script
+`cd`s to project root, derived from `PROJECT_ROOT` inside `download_startup.sh`).
+
+```
+$PROJECT_ROOT/
+├── ckpts/                                   ← all 6 Complexa ckpts here, flat
+│   ├── complexa.ckpt                        ← protein binder model
+│   ├── complexa_ae.ckpt                     ← protein binder autoencoder
+│   ├── complexa_ligand.ckpt                 ← ligand binder model
+│   ├── complexa_ligand_ae.ckpt              ← ligand binder autoencoder
+│   ├── complexa_ame.ckpt                    ← AME motif scaffolding model
+│   └── complexa_ame_ae.ckpt                 ← AME autoencoder
+└── community_models/
+    ├── ProteinMPNN/
+    │   ├── ca_model_weights/                ← Cα-only weights
+    │   └── vanilla_model_weights/           ← full-backbone weights
+    ├── LigandMPNN/model_params/             ← LigandMPNN weights
+    └── ckpts/
+        ├── AF2/params/                      ← AlphaFold2 .npz / .pkl params
+        ├── ESM2/                            ← ESM2-650M weights
+        ├── ESMFold/                         ← ESMFold model
+        ├── RF3/                             ← RoseTTAFold3 ckpt
+        └── Boltz2/                          ← Boltz2 (optional)
+```
+
+Note: `LOCAL_CHECKPOINT_PATH` in `.env` defaults to `${LOCAL_CODE_PATH}/ckpts`,
+which matches where `complexa download` writes Complexa ckpts. If you edit
+`LOCAL_CHECKPOINT_PATH` to point elsewhere, you must also move (or symlink)
+the existing `./ckpts/` contents — `complexa download` always writes to
+`$PROJECT_ROOT/ckpts/` regardless of the `.env` setting.
+
+---
+
+## The three Complexa model variants
+
+| Variant | Pipeline config | Required ckpt pair | Use case |
+|---------|----------------|---------------------|----------|
+| Protein binder | `configs/search_binder_local_pipeline.yaml` | `complexa.ckpt` + `complexa_ae.ckpt` | De novo binders for protein targets (PDL1, EGFR, etc.) |
+| Ligand binder | `configs/search_ligand_binder_local_pipeline.yaml` | `complexa_ligand.ckpt` + `complexa_ligand_ae.ckpt` | Binders to small-molecule pockets (FAD, OQO, etc.) |
+| AME | `configs/search_ame_local_pipeline.yaml` | `complexa_ame.ckpt` + `complexa_ame_ae.ckpt` | Scaffolding catalytic / functional motifs with ligand context |
+
+Each pipeline YAML has three checkpoint fields at the top level that you
+**must** point at your local ckpts. After `complexa download --complexa-all`
+they will be at `./ckpts/complexa{,_ae,_ligand,_ligand_ae,_ame,_ame_ae}.ckpt`:
+
+```yaml
+ckpt_path: ./ckpts
+ckpt_name: complexa.ckpt
+autoencoder_ckpt_path: ./ckpts/complexa_ae.ckpt
+```
+
+Or override on the CLI without editing the YAML:
+
+```bash
+complexa design configs/search_binder_local_pipeline.yaml \
+    ++ckpt_path=./ckpts \
+    ++ckpt_name=complexa.ckpt \
+    ++autoencoder_ckpt_path=./ckpts/complexa_ae.ckpt
+```
+
+> Note: `complexa download` always uses a *flat* `./ckpts/` layout. If you
+> downloaded ckpts manually into per-variant subdirectories
+> (`ckpts/complexa_protein/`, etc.), update the pipeline YAML `ckpt_path` to
+> match — or move/symlink into the flat layout.
+
+---
+
+## `complexa download --status` output
+
+Example output (post `--complexa-all` + `--af2`, no RF3 or ESMFold):
+
+```
+═══════════════════════════════════════════
+  Installation Status
+═══════════════════════════════════════════
+    Complexa (Protein): ✓ Installed (./ckpts/)
+    Complexa (Ligand):  ✓ Installed (./ckpts/)
+    Complexa (AME):     ✓ Installed (./ckpts/)
+    ProteinMPNN:     ○ Missing (community_models/ProteinMPNN/)
+    LigandMPNN:      ○ Missing (community_models/LigandMPNN/model_params/)
+    AF2:             ✓ Installed (community_models/ckpts/AF2/)
+    ESM2:            ○ Not installed (community_models/ckpts/ESM2/)
+    ESMFold:         ○ Not installed (community_models/ckpts/ESMFold/)
+    RF3:             ○ Missing (community_models/ckpts/RF3/)
+    Boltz2:          ○ Missing (community_models/ckpts/Boltz2/)
+═══════════════════════════════════════════
+```
+
+Read each row as: `<Model name>: <✓ Installed | ○ Missing> (<destination>)`.
+Re-run `complexa download --<flag>` for any row that is missing.
+
+---
+
+## Tips
+
+- Run `complexa download --status` **before** any download — it shows what is already on disk and saves re-downloading.
+- Re-running `complexa download --<flag>` is idempotent: existing non-empty ckpts are skipped (`download_complexa_weights` checks `[ -f "$fm_ckpt" ] && [ -s "$fm_ckpt" ]`).
+- Failed downloads leave a zero-byte file then `rm -f` it — safe to retry without manual cleanup.
+- For ESM2 / ESMFold specifically: set `HF_TOKEN` in `.env` before downloading to avoid HF Hub rate limits.
+- `complexa download --everything` will fetch every model the script supports (~100 GB). Prefer the targeted flags unless you actually need all variants.

--- a/open-models-skills/proteina-complexa/complexa-setup/reference/env_keys.md
+++ b/open-models-skills/proteina-complexa/complexa-setup/reference/env_keys.md
@@ -1,0 +1,185 @@
+# `.env` Key Reference
+
+Complete reference for every variable in `.env_example`. Sections mirror the
+ones in `.env_example` itself. Each entry says: required vs optional, default,
+what reads it, and the failure mode if it is missing or wrong.
+
+`.env` is loaded by `python-dotenv` via `proteinfoundation/cli/validate.py:load_env_config`
+and resolved into Hydra configs via `${oc.env:VARIABLE_NAME}` interpolation.
+Missing required variables surface as Hydra `InterpolationKeyError` at config
+resolution time — intentional, so you see exactly which key is missing.
+
+---
+
+## Section 1 — Required
+
+You must set these before running any pipeline command. `complexa init` does
+not fill these in; it only copies `.env_example` and rewrites runtime-dependent
+lines.
+
+### `LOCAL_CODE_PATH`
+
+- **Required.** No default — `.env_example` ships with a placeholder.
+- Absolute path to this repo checkout on the host.
+- Read by: `COMMUNITY_MODELS_PATH`, `AF2_DIR`, `ESM_DIR`, `ESMFOLD_DIR`, `RF3_DIR`, `RF3_CKPT_PATH`, `UV_VENV` (all derived via `${LOCAL_CODE_PATH}/...`).
+- **Failure mode**: every community-model and tool path resolves to `/path/to/protein-foundation-models/...` which does not exist → `complexa validate evaluate` / Hydra `FileNotFoundError`.
+- Fix: edit to an absolute path, e.g. `LOCAL_CODE_PATH=/home/me/code/protein-foundation-models`.
+
+### `LOCAL_DATA_PATH`
+
+- **Required.** Default placeholder `/path/to/PFM_data`.
+- Absolute path to the PFM data directory (target PDBs under `target_data/`, datasets, etc.).
+- Read by: `DATA_PATH` (active alias rewritten by `complexa init`); `complexa validate env` requires this to point at an existing directory.
+- **Failure mode**: `complexa validate env` reports `DATA_PATH: Directory not found`; `complexa validate target` fails to locate `target_data/`.
+- Fix: edit, then `mkdir -p $LOCAL_DATA_PATH` and populate it with the target PDBs you plan to design against (the bundled examples ship under `assets/target_data/`, or build your own with the `complexa-target` skill).
+
+---
+
+## Section 2 — Credentials (all optional)
+
+### `GITLAB_TOKEN`
+
+- **Optional.** Default placeholder `TOKEN_HERE`.
+- Used by `env/docker-ops.sh` to authenticate against a private Docker registry (only relevant if you build the image yourself and push it somewhere that needs a token).
+- **Failure mode if missing**: `docker login` is skipped → cannot pull private images. The default Dockerfile build (`docker build -f env/docker/Dockerfile .`) and all NGC downloads still work without it.
+- Fix: set if you have your own private registry configured via `REGISTRY` / `DOCKER_IMAGE`.
+
+### `WANDB_API_KEY` / `WANDB_ENTITY`
+
+- **Optional.** Default placeholders `YOUR_WANDB_KEY` / `YOUR_WANDB_ENTITY`.
+- Used by training code (`proteinfoundation.train`) for run logging.
+- Placeholder values are explicitly *not* injected — W&B logging is silently disabled when either is a placeholder.
+- **Failure mode if missing**: no W&B logging; training still runs.
+- Fix: set both if you want training runs tracked.
+
+### `HF_TOKEN`
+
+- **Optional.** Default placeholder `HF_TOKEN_HERE`.
+- Read by `env/download_startup.sh` (the script behind `complexa download`) when pulling ESM2 / ESMFold from Hugging Face Hub.
+- **Failure mode if missing**: ESM2 / ESMFold downloads may hit anonymous rate limits or fail for gated repos. Other downloads (NGC, GitHub) work without it.
+- Fix: set if `--esm2` or `--esmfold` downloads fail with 401/429.
+
+---
+
+## Section 3 — Local options (all optional)
+
+### `LOCAL_CACHE_DIR`
+
+- **Optional.** Default `${LOCAL_CODE_PATH}/.cache`.
+- Active alias `CACHE_DIR` resolves to this for UV runtime.
+- Used for Hydra cache, foldseek temp, HuggingFace hub cache.
+- **Failure mode if missing**: defaults work for almost everyone; set only if `.cache` should live on a faster / larger disk.
+
+### `LOCAL_CHECKPOINT_PATH`
+
+- **Optional.** Default in `.env_example`: `${LOCAL_CODE_PATH}/checkpoints`.
+- Active alias `CKPT_PATH` resolves to this for UV runtime.
+- Note: `complexa download` always writes Complexa model + AE checkpoints to `$PROJECT_ROOT/ckpts/` (a sibling of `checkpoints/`) regardless of this setting. If you want `CKPT_PATH` to point at the download location, set `LOCAL_CHECKPOINT_PATH=${LOCAL_CODE_PATH}/ckpts` after running `complexa download`.
+- **Failure mode if missing**: pipeline configs resolve `${oc.env:CKPT_PATH}` to the default — if the directory doesn't exist or is empty, loading the model fails.
+- Fix: either run `complexa download --complexa-all` and set `LOCAL_CHECKPOINT_PATH=${LOCAL_CODE_PATH}/ckpts`, or move/symlink the downloaded ckpts into the `checkpoints/` default.
+
+### `DOCKER_MOUNTS`
+
+- **Optional.** Default empty.
+- Comma-separated `host:container` pairs added to `env/docker-ops.sh run`.
+- **Failure mode if missing**: only standard mounts (`LOCAL_CODE_PATH`, `LOCAL_DATA_PATH`) are exposed to the container.
+- Fix: set if you need extra paths visible inside the container — e.g. `DOCKER_MOUNTS=/scratch:/scratch,/lustre:/lustre`.
+
+### `LOGURU_LEVEL`
+
+- **Optional.** Default `INFO`.
+- Read by `loguru` for Python log verbosity.
+- Set to `DEBUG` for verbose pipeline logs, `WARNING` for quieter runs.
+
+### `USE_V2_COMPLEXA_ARCH`
+
+- **Optional.** Default `False`.
+- Set to `True` only when using V2 Complexa model weights. The default-shipped checkpoints are V1.
+- **Failure mode if wrong**: loading a V2 ckpt with this `False` (or a V1 ckpt with this `True`) throws a state-dict mismatch at model load time.
+
+---
+
+## Section 4 — Docker image (rarely edited)
+
+These are read by `env/docker-ops.sh build/pull/run`.
+
+### `REGISTRY` / `REGISTRY_USER`
+
+- **Required only for `docker-ops.sh push/pull` against a private registry.** Defaults in `.env_example`: `registry.example.com` / `'$oauthuser'` (placeholders — you must edit if pushing/pulling).
+- Used in `docker login` and tagging. Local `docker build` does not need these.
+
+### `DOCKER_IMAGE`
+
+- **Required for `docker-ops.sh run` (Docker runtime).** Default placeholder `registry.example.com/org/repo:tag`.
+- Tag of the image `docker-ops.sh run` will start. If you built the image yourself with `docker build -t proteina-complexa -f env/docker/Dockerfile .`, set this to `proteina-complexa:latest`.
+
+### `CONTAINER_NAME`
+
+- **Required for Docker runtime.** Default `proteina-dev`.
+- Name applied to `docker run --name`; reused for `exec` / `stop`.
+
+### `DOCKERFILE_PATH`
+
+- **Required for `docker-ops.sh build`.** Default `env/docker/Dockerfile`.
+- Path (relative to `LOCAL_CODE_PATH`) of the Dockerfile used by `docker-ops.sh build`.
+
+---
+
+## Auto-managed — do not edit by hand
+
+These are rewritten by `complexa init` based on the `--runtime` flag. Editing
+them manually will be overwritten the next time `complexa init` runs (without
+`--force`, it still swaps the runtime-dependent lines).
+
+### `COMPLEXA_RUNTIME`
+
+- Set to `uv` or `docker` by `complexa init`. Read by tooling that needs to know which prefix to resolve.
+
+### `DATA_PATH` / `CACHE_DIR` / `CKPT_PATH`
+
+- Active aliases. Resolve to `${LOCAL_*}` for UV runtime or `${DOCKER_*}` for Docker runtime. Edit `LOCAL_*` / `DOCKER_*` instead.
+
+### `FOLDSEEK_EXEC` / `RF3_EXEC_PATH` / `SC_EXEC` / `HBPLUS_EXEC` / `MMSEQS_EXEC` / `DSSP_EXEC` / `TMOL_PATH`
+
+- Active tool binaries. Resolve to `${UV_*}` or `${DOCKER_*}` per runtime. Edit the prefix vars if you have a non-standard install (e.g. system-wide `foldseek` at `/usr/local/bin/foldseek` instead of `.venv/bin/foldseek`).
+- Used by: `complexa evaluate` (foldseek for diversity; mmseqs for sequence clustering; hbplus/sc for interface metrics; dssp for secondary structure; tmol for force-field metrics).
+- **Failure mode if path is wrong**: the tool is silently skipped (treated as a warning in `complexa validate evaluate`), and the corresponding metric column is missing from the result CSV.
+
+### `AF2_DIR` / `ESM_DIR` / `ESMFOLD_DIR` / `RF3_DIR` / `RF3_CKPT_PATH`
+
+- **Auto-managed by `complexa init`, but you must point them at real weight dirs for evaluation/reward to work.**
+- Derived from `${LOCAL_CODE_PATH}/community_models/ckpts/...`. After `complexa download --all` or `complexa download --af2`, the directories under `community_models/ckpts/` are populated.
+- Read by: reward models (`AF2RewardModel`, `RF3RewardRunner`) and evaluation folding (colabdesign / rf3 backends).
+- **Failure mode if wrong**: `complexa validate evaluate` reports `AF2 weights: Directory not found` or `RF3 checkpoint: File not found`. Generation can still run without these; only reward and refolding break.
+
+### `RF3_CKPT_PATH`
+
+- Default `${RF3_DIR}/rf3_foundry_01_24_latest_remapped.ckpt` — exact filename produced by `complexa download --rf3`. If you have a different RF3 checkpoint, edit to its full path.
+
+### `COMMUNITY_MODELS_PATH`
+
+- Default `${LOCAL_CODE_PATH}/community_models`. Edit only if you mirror community models on a separate disk.
+
+### `UV_VENV` / `UV_*_EXEC` / `DOCKER_*_EXEC`
+
+- Per-runtime tool-path families. `complexa init` selects which family the active `FOLDSEEK_EXEC` etc. point at. Edit the *family member* (e.g. `UV_FOLDSEEK_EXEC`) only if your local install lives somewhere unusual.
+
+### `DOCKER_REPO_PATH` / `DOCKER_DATA_PATH` / `DOCKER_PYTHONPATH` / `DOCKER_CHECKPOINT_PATH` / `DOCKER_CACHE_DIR` / `DOCKER_HF_HOME` / `DOCKER_HF_HUB_CACHE`
+
+- Container-internal paths inside the Complexa Docker image. Hard-coded to `/workspace/...`; only edit if you ship a custom image with different layout.
+
+---
+
+## What `complexa validate env` actually checks
+
+From `src/proteinfoundation/cli/validate.py:validate_env`:
+
+1. `.env` file exists in CWD (or any parent up to the repo root).
+2. `DATA_PATH` env var is set and resolves to an existing directory.
+
+That is the full check. It does not validate ckpts, tool binaries, or HF
+tokens. Those are checked by `complexa validate {generate,evaluate,design}
+<config>` which loads a pipeline YAML and verifies the paths each stage will
+actually read. Run `complexa validate design configs/search_binder_local_pipeline.yaml`
+once after editing `.env` to catch missing AF2/RF3/foldseek before the first
+real pipeline run.

--- a/open-models-skills/proteina-complexa/complexa-sweep/SKILL.md
+++ b/open-models-skills/proteina-complexa/complexa-sweep/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: complexa-sweep
+description: Use this skill whenever the user wants to run a parameter sweep over a Proteina-Complexa design pipeline — cartesian-product hyperparameter scans, Pareto search over generation/reward/evaluation knobs, or any "compare configurations" workflow. Trigger phrases include "sweep beam width", "sweep nsteps", "hyperparameter sweep", "parameter scan", "scan beam_width and temperature", "compare configurations", "find the best generation params", "what's the optimal nsteps", "Pareto search for binder quality vs wall-clock", "complexa sweep", "tune Complexa", "ablate the reward weights", "configs/sweeps", "--sweeper", "run beam_width.yaml". This is the only skill that owns sweeper YAML authoring, cartesian-product expansion, and per-config result ranking.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# complexa-sweep
+
+Run cartesian-product parameter sweeps over Proteina-Complexa design pipelines. Pick or author a sweeper YAML in `configs/sweeps/`, expand it to N inference configs with `script_utils/generate_inference_configs.py`, loop `complexa design` over those configs, then aggregate per-config success metrics into a ranked summary CSV plus a manifest.
+
+> **Important:** The `complexa design` CLI does **NOT** accept `--sweeper` directly. Sweeps are driven by `script_utils/generate_inference_configs.py`, which writes one `configs/inference_configs/inf_{idx}_{run_name}.yaml` per sweep combination. You then loop `complexa design` over those generated configs.
+
+## What this skill enables
+
+- Pick an existing sweeper YAML from `configs/sweeps/` (`beam_width`, `bb_ca_temperature`, `search_replicas`, `example`).
+- Author a new sweeper YAML with arbitrary dot-notation axes (cartesian product).
+- Generate N inference + evaluation config pairs with `script_utils/generate_inference_configs.py`.
+- Loop `complexa design` over the generated configs (one at a time on a single GPU, or in parallel on a multi-GPU host by sharding the config list across `CUDA_VISIBLE_DEVICES`).
+- Walk per-config output directories and parse the analyze-step CSV from each.
+- Emit `sweep_summary.csv` (one row per config: axis values + success rate + mean iPAE + diversity) and `sweep_manifest.json`.
+- Identify the best config by success rate and the Pareto frontier (wall-clock vs success).
+
+## Step 1: Pre-flight
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+Read `./complexa_setup/preflight.json`. A sweep multiplies GPU time by the number of configs. **Before launching, confirm the cost with the user**:
+
+> "This sweep produces N configs × ~M minutes per config ≈ TOTAL GPU-hours. OK to proceed? (y / reduce / cancel)"
+
+If `gpu.available=false`, stop — sweeps are not feasible on CPU.
+
+## Step 2: Pick the pipeline + target
+
+Use the same dialogue as `complexa-design` — do **not** duplicate it here. See [`.claude/skills/complexa-design/SKILL.md`](../complexa-design/SKILL.md) Step 2 ("Pick the pipeline") and Step 3 ("Gather parameters"). Capture:
+
+- `pipeline_config_name` — e.g. `search_binder_local_pipeline` (default), `search_ligand_binder_local_pipeline`, `search_ame_local_pipeline`.
+- `task_name` — e.g. `02_PDL1`, `22_DerF21`, `39_7V11_LIGAND`. Passed as `--override generation.task_name=<task>`.
+- `run_name` — short tag for output dir naming.
+
+## Step 3: Pick or author the sweeper YAML
+
+Sweeper YAMLs live in `configs/sweeps/`. Each key is a dot-notation Hydra path; each value is a list. The cartesian product becomes N configs.
+
+### Canned sweepers
+
+| File | Axis | Values | Configs |
+|---|---|---|---|
+| `configs/sweeps/beam_width.yaml` | `generation.search.beam_search.beam_width` | 1, 2, 4, 8 | 4 |
+| `configs/sweeps/bb_ca_temperature.yaml` | `generation.model.bb_ca.simulation_step_params.sc_scale_noise` | 0.1, 0.4 | 2 |
+| `configs/sweeps/search_replicas.yaml` | `generation.search.best_of_n.replicas` | 1, 4, 16, 64 | 4 |
+| `configs/sweeps/example.yaml` | beam_width × nsteps | (2,4) × (200,400) | 4 |
+
+If one matches the user's intent, use it as-is. Otherwise author a new file.
+
+### Authoring a new sweeper
+
+Minimal multi-axis example (saved to `configs/sweeps/my_sweep.yaml`):
+
+```yaml
+# 3 beam widths × 2 nsteps = 6 configs
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+  - 8
+
+generation.args.nsteps:
+  - 200
+  - 400
+```
+
+Rules (from `script_utils/generate_inference_configs.py:load_sweeper_file`):
+
+- Top-level mapping only. Keys are dot-notation Hydra paths.
+- Values must be **lists**. A scalar is auto-wrapped into a single-element list (which pins a value without adding a dimension).
+- Cartesian product: total configs = product of list lengths. Two 4-value axes = 16 configs; budget accordingly.
+- If a key appears in both the sweeper file and an `--override`, the override wins and that axis collapses.
+
+See [reference/sweep_axes.md](reference/sweep_axes.md) for the full catalogue of swept keys (typical ranges, cost multipliers, what improves/regresses).
+
+### Dry-run preview before generating
+
+Always confirm the config count first:
+
+```bash
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_local_pipeline \
+    --sweeper configs/sweeps/my_sweep.yaml \
+    --override generation.task_name=22_DerF21 \
+    --run_name my_sweep \
+    --dryrun
+```
+
+The output lists every axis + value list and prints `DRY RUN — would generate N config pair(s)`.
+
+## Step 4: Generate configs + loop `complexa design`
+
+Once the dry-run looks right, drop `--dryrun` to materialize `inf_{idx}_{run_name}.yaml` + `eval_{idx}_{run_name}.yaml` pairs under `configs/inference_configs/` and `configs/eval_configs/`. Then loop `complexa design` over the inference configs.
+
+```bash
+# 1. Generate one inf_*.yaml + one eval_*.yaml per combination.
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_local_pipeline \
+    --sweeper configs/sweeps/my_sweep.yaml \
+    --override generation.task_name=22_DerF21 \
+    --run_name my_sweep
+
+# 2. Loop complexa design over each generated inference config.
+for cfg in configs/inference_configs/inf_*_my_sweep.yaml; do
+    complexa design "$cfg" || echo "FAILED: $cfg"
+done
+```
+
+This serialises the sweep on a single GPU — be honest with the user that wall-clock = N × per-run.
+
+### Multi-GPU host (optional speed-up)
+
+On a host with K GPUs, shard the config list K ways and launch one loop per GPU in parallel. Each `complexa design` call uses exactly one GPU at default `gen_njobs=1` / `eval_njobs=1`, so pinning via `CUDA_VISIBLE_DEVICES` keeps them from colliding:
+
+```bash
+CONFIGS=(configs/inference_configs/inf_*_my_sweep.yaml)
+N=${#CONFIGS[@]}; K=4   # 4 GPUs
+for gpu in $(seq 0 $((K-1))); do
+    (
+        for i in $(seq $gpu $K $((N-1))); do
+            CUDA_VISIBLE_DEVICES=$gpu complexa design "${CONFIGS[$i]}" \
+                || echo "FAILED on GPU $gpu: ${CONFIGS[$i]}"
+        done
+    ) &
+done
+wait
+```
+
+Drop `gen_njobs` / `eval_njobs` overrides into the loop only if you intentionally want each `complexa design` invocation to consume multiple GPUs (and you have a way to keep them out of each other's way).
+
+## Step 5: Collect results
+
+Each swept config writes to its own `./inference/inf_{idx}_{run_name}/` directory; the analyze step writes `./evaluation_results/eval_{idx}_{run_name}/results_*.csv`. After the sweep finishes:
+
+```bash
+ls -d ./inference/inf_*_my_sweep/
+ls ./evaluation_results/eval_*_my_sweep/results_*.csv
+```
+
+For each config, parse the analyze CSV (one row per generated binder). Standard columns used for ranking: `i_pae`, `i_plddt`, `sc_rmsd`, `binder_seq`, `passes_filter` (bool). If `passes_filter` is missing, derive a success flag with the user's chosen thresholds (defaults: `i_pae < 10`, `i_plddt > 0.7`, `sc_rmsd < 2.0` — confirm with user).
+
+## Step 6: Rank configs
+
+Emit `sweep_summary.csv` to the run directory. One row per config:
+
+| Column | How to compute |
+|---|---|
+| `config_id` | The `{idx}` from `inf_{idx}_{run_name}` |
+| `<axis_1>`, `<axis_2>`, ... | The swept value at this combination (read from the per-config `inf_*.yaml`) |
+| `n_samples` | Row count in the analyze CSV |
+| `success_rate` | `passes_filter.mean()` |
+| `mean_i_pae` | `i_pae.mean()` (lower = better) |
+| `mean_i_plddt` | `i_plddt.mean()` (higher = better) |
+| `diversity_score` | Unique sequence count / `n_samples` (or use TM-score clustering if available) |
+| `wall_clock_min` | From the per-config log timestamps |
+
+Then report:
+
+- **Best config** = argmax of `success_rate`. Tie-break on `mean_i_pae` (lower).
+- **Pareto frontier** over (`wall_clock_min`, `success_rate`): a config is on the frontier iff no other config is both faster AND has higher success rate.
+
+Print the best config + the frontier to the terminal. Save the full table to `sweep_summary.csv`.
+
+## Step 7: Emit manifest
+
+Capture the resolved invocation + outputs for replay. The shared helper takes a single `--output-dir` (it walks for CSVs and pulls the Hydra config from the run's `.hydra/`), so call it against the best-config's evaluation directory and pass the parent `complexa design` command for that run:
+
+```bash
+BEST_ID=4   # from Step 6 ranking
+python3 .claude/skills/_shared/scripts/write_manifest.py \
+    --output-dir ./evaluation_results/eval_${BEST_ID}_my_sweep \
+    --command "python script_utils/generate_inference_configs.py --config_name search_binder_local_pipeline --sweeper configs/sweeps/my_sweep.yaml --override generation.task_name=22_DerF21 --run_name my_sweep && for cfg in configs/inference_configs/inf_*_my_sweep.yaml; do complexa design \"\$cfg\"; done" \
+    --skill complexa-sweep \
+    --out ./sweep_runs/my_sweep/sweep_manifest.json
+```
+
+Alongside the manifest, save the ranked `sweep_summary.csv` from Step 6 to `./sweep_runs/my_sweep/sweep_summary.csv` and surface both paths to the user.
+
+## Recommended sweep recipes
+
+| Symptom | Sweep this | Why |
+|---|---|---|
+| Quality not good enough | `beam_width × nsteps` (use `example.yaml` as a starting point) | Both raise compute → quality; find the cheapest combination that lands. |
+| Too slow / want speed-up | `nsteps` downward (e.g. `[100, 200, 400]`) with fixed `beam_width=4` | Find the smallest nsteps that retains success rate. |
+| Mode collapse / low diversity | `generation.model.bb_ca.simulation_step_params.sc_scale_noise` (use `bb_ca_temperature.yaml`) | Higher noise → more diverse backbones. |
+| Reward over-fitting (high reward, bad metrics) | `generation.reward_model.reward_models.af2folding.reward_weights.{i_pae, plddt}` ratio | Re-balance composite reward. |
+| Want statistical robustness on one config | `search_replicas.yaml` (`best_of_n.replicas`) | Same config, more samples → tighter success-rate estimate. |
+| Algorithm shoot-out | `generation.search.algorithm` over `[single-pass, best-of-n, beam-search, fk-steering]` | Compare search regimes; pin everything else. |
+
+## Hardware
+
+Total GPU-time for a sweep = `N_configs × per_run_GPU_time`. A single `search_binder_local_pipeline` run on one A100 is roughly 30–90 min (binder length + nsteps dependent). A 4-axis × 4-value sweep = 256 configs × ~60 min = ~256 GPU-hours — at that scale, plan on a multi-GPU host with the Step-4 sharding pattern.
+
+Refer to [`.claude/skills/_shared/reference/hardware.md`](../_shared/reference/hardware.md) for the per-run baseline + VRAM minima.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Sweeper file not found` from `generate_inference_configs.py` | Path resolved from wrong CWD | Use a path relative to the repo root; or pass an absolute path. |
+| `Sweeper YAML must be a mapping` | Top-level YAML is a list or scalar | Rewrite as `key: [v1, v2]` mapping. |
+| `No configs were generated` | One of the value lists is empty `[]` | Sweeper file has a `key: []` line — add at least one value. |
+| `complexa design` rejects `--sweeper` | Confusion between entrypoints | The CLI does not accept `--sweeper`. Use `generate_inference_configs.py` first, then loop `complexa design` over the generated configs. |
+| Override silently collapses a sweep axis | `--override key=v` shadowed a sweep key | Drop either the override OR the matching key from the sweeper file. |
+| One config in the loop fails, sweep keeps going | The `\|\| echo "FAILED…"` in Step 4 swallows the error | Re-run the failed `inf_*.yaml` standalone; check the per-config log under `./logs/`. Skip failed `config_id` when ranking. |
+
+---
+
+For per-axis reference (typical ranges, cost, what gets better/worse), see [reference/sweep_axes.md](reference/sweep_axes.md).
+
+For the user-facing sweep system overview (config generation, output layout), see [`docs/SWEEP.md`](reference/SWEEP.md).

--- a/open-models-skills/proteina-complexa/complexa-sweep/evals/evals.json
+++ b/open-models-skills/proteina-complexa/complexa-sweep/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "complexa-sweep",
+  "evals": [
+    {
+      "id": "complexa-sweep-001",
+      "prompt": "Run a complexa sweep over beam_width [4, 8, 16] and nsteps [100, 200, 400] for the PDL1 target using the search_binder_pipeline.",
+      "expected_output": "The agent used complexa-sweep to author or select a sweeper YAML with beam_width and nsteps axes, computed the cartesian product (9 configs), estimated GPU cost, and requested user confirmation before proceeding with launch.",
+      "assertions": [
+        "The agent ran the preflight script and read preflight.json to check GPU availability",
+        "The agent computed the cost estimate (9 configs × 1 target = 9 runs) and presented it to the user for confirmation",
+        "The agent authored or identified a sweeper YAML in configs/sweeps/ with the specified beam_width and nsteps values",
+        "The agent explained the launch mechanism via generate_inference_configs.py --sweeper or SLURM launcher",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-sweep",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-sweep-002",
+      "prompt": "I want to find the optimal generation parameters for my binder design. Can you compare different temperatures (0.5, 1.0, 1.5) and search replicas (2, 4, 8) to see which combination gives the best success rate on the DerF21 target?",
+      "expected_output": "The agent recognized this as a parameter sweep request, set up a cartesian-product scan over bb_ca_temperature and search_replicas, estimated GPU hours for the 9-config sweep, and prepared to generate a ranked summary CSV identifying the best configuration by success rate.",
+      "assertions": [
+        "The agent ran the preflight script to verify GPU availability and environment readiness",
+        "The agent proposed a sweeper YAML with axes for temperature [0.5, 1.0, 1.5] and search_replicas [2, 4, 8]",
+        "The agent calculated and displayed the GPU-hour estimate before proceeding",
+        "The agent described the output format including sweep_summary.csv with success rate ranking",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-sweep",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-sweep-003",
+      "prompt": "We're preparing for a paper submission and need to ablate the reward weights in our Complexa binder pipeline. Specifically, we want a Pareto analysis of binder quality (iPAE) versus wall-clock time across different beam widths and reward scaling factors. Can you set this up for targets 02_PDL1 and 22_DerF21?",
+      "expected_output": "The agent used complexa-sweep to design a multi-target Pareto sweep over beam_width and reward scaling axes, computed the total run count across both targets, flagged the potentially large GPU cost, and outlined how the Pareto frontier would be extracted from the sweep_summary.csv.",
+      "assertions": [
+        "The agent ran preflight and assessed the total cost as n_configs × 2 targets, presenting the GPU-hour estimate with a confirmation gate",
+        "The agent authored a sweeper YAML with axes for beam_width and reward weight scaling factors",
+        "The agent explained that the Pareto frontier (wall-clock vs success/iPAE) would be identified from the aggregated results",
+        "The agent asked the user to confirm the sweep size before launching, given the multi-target multiplication",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-sweep",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-sweep-004",
+      "prompt": "Can you submit my existing Complexa design job to the SLURM cluster with 4 GPUs and a 24-hour time limit? The config is already at configs/inference_configs/inf_pdl1.yaml.",
+      "expected_output": "The agent recognized this as a single-job SLURM submission request (not a parameter sweep) and directed the user to the complexa-slurm skill rather than complexa-sweep.",
+      "assertions": [
+        "The agent did not invoke complexa-sweep or attempt to create a sweeper YAML",
+        "The agent identified this as a cluster submission task appropriate for the complexa-slurm skill",
+        "The agent provided guidance on submitting the single existing config to SLURM without cartesian-product expansion",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/open-models-skills/proteina-complexa/complexa-sweep/reference/SWEEP.md
+++ b/open-models-skills/proteina-complexa/complexa-sweep/reference/SWEEP.md
@@ -1,0 +1,303 @@
+# Sweep System
+
+How to run parameter sweeps and override experiment settings without modifying source code.
+
+> **Documentation Map**
+> - Running a design? See [Inference Guide](INFERENCE.md)
+> - Tuning YAML configs? See [Configuration Guide](CONFIGURATION_GUIDE.md)
+> - Understanding metrics? See [Evaluation Guide](EVALUATION_METRICS.md)
+> - Search metadata? See [Search Metadata](SEARCH_METADATA.md)
+
+## Overview
+
+The sweep system has two mechanisms that work together:
+
+- **`--sweeper FILE`** loads a YAML file defining one or more parameter axes.
+  All combinations are generated as a cartesian product.
+- **`--override KEY=VAL [KEY=VAL ...]`** pins individual parameters to scalar
+  values, applied to every generated config.
+
+Both can be used independently or combined. When a key appears in both the
+sweeper file and the CLI overrides, the override wins and that axis is
+collapsed to a single value.
+
+## Quick Start
+
+```bash
+# 1. Single experiment with a specific target (no sweep)
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --override generation.task_name=22_DerF21
+
+# 2. Sweep beam widths for a single target
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+
+# 3. Sweep beam widths with nsteps pinned to 400
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21 generation.args.nsteps=400
+
+# 4. Dry run to preview config generation
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_pipeline \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21 \
+    --dryrun
+```
+
+## Sweep YAML Format
+
+Sweep files live in `configs/sweeps/`. Each key is a dot-notation config path
+and each value is a list of values to sweep over:
+
+```yaml
+# configs/sweeps/beam_width.yaml
+generation.search.beam_search.beam_width:
+  - 1
+  - 2
+  - 4
+  - 8
+```
+
+Multiple axes produce a cartesian product:
+
+```yaml
+# 3 beam widths x 2 nsteps = 6 configs
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+  - 8
+
+generation.args.nsteps:
+  - 200
+  - 400
+```
+
+Long values (e.g., checkpoint paths) benefit from YAML block-list style:
+
+```yaml
+ckpt_path:
+  - /path/to/checkpoints/model_v1/epoch_100.ckpt
+  - /path/to/checkpoints/model_v2/epoch_200.ckpt
+  - /path/to/checkpoints/model_v3/epoch_50.ckpt
+```
+
+A scalar value (not a list) is automatically wrapped in a single-element list,
+so it pins that parameter without adding a sweep dimension:
+
+```yaml
+generation.args.self_cond: true
+```
+
+## `--override` Format
+
+Override arguments are `KEY=VALUE` strings where:
+
+- The key uses dot notation (e.g., `generation.args.nsteps`)
+- The value is auto-typed: integers, floats, booleans (`true`/`false`),
+  null (`null`/`none`), or strings
+
+```bash
+--override generation.task_name=22_DerF21 generation.args.nsteps=400 generation.args.self_cond=true
+```
+
+Multiple overrides are space-separated after a single `--override` flag.
+
+## How It Works
+
+### Config Generation Pipeline
+
+```
+                    +-----------------+
+                    | Sweeper YAML    |  (optional)
+                    +-----------------+
+                            |
+                            v
++-----------+      +------------------+      +-------------------+
+| Pipeline  | ---> | generate_infer-  | ---> | N inf_*.yaml +    |
+| Config    |      | ence_configs.py  |      | N eval_*.yaml     |
++-----------+      +------------------+      +-------------------+
+                            ^
+                            |
+                    +-----------------+
+                    | --override      |  (optional)
+                    | KEY=VAL ...     |
+                    +-----------------+
+```
+
+1. The base pipeline config (e.g., `search_binder_pipeline.yaml`) is loaded
+   via Hydra.
+2. If a `--sweeper` file is provided, its axes are combined into a cartesian
+   product.
+3. For each combination, the sweep values are merged into the base config.
+4. `--override` values are applied on top of every config (overriding sweep
+   values if they conflict).
+5. Each config gets a unique `root_path` and is saved as a pair:
+   `inf_{idx}_{run}.yaml` and `eval_{idx}_{run}.yaml`.
+
+### Config Naming
+
+Generated config filenames follow the pattern:
+
+```
+inf_{index}_{run_name}.yaml
+eval_{index}_{run_name}.yaml
+```
+
+The index is sequential (0, 1, 2, ...) and the run name comes from the
+`--run_name` argument. Task name is intentionally NOT in the filename -- it
+lives inside the config content. This keeps filenames predictable so the bash
+launcher can construct Hydra `--config-name` paths without parsing YAML.
+
+### Directory Structure
+
+On the **remote cluster** (and on-cluster direct launches), configs always live
+at the canonical paths:
+
+```
+configs/
+  inference_configs/
+    inf_0_my_run.yaml
+    inf_1_my_run.yaml
+  eval_configs/
+    eval_0_my_run.yaml
+    eval_1_my_run.yaml
+```
+
+#### Local-to-remote flow (with rsync)
+
+When launching from a local machine, configs are first generated into a unique
+temporary directory (`configs/_gen_XXXXXX/`) so that concurrent launches never
+collide.  Inside the rsync lock, the temp directory contents are **staged**
+(moved) into the canonical `configs/inference_configs/` and
+`configs/eval_configs/` paths, rsync'd to the cluster, and then cleaned up
+locally.
+
+```
+generate_configs()        →  configs/_gen_abc123/{inference_configs,eval_configs}/
+stage_configs_for_sync()  →  configs/{inference_configs,eval_configs}/   (inside lock)
+rsync                     →  $RUN_DIR/configs/{inference_configs,eval_configs}/
+cleanup_staged_configs()  →  local canonical dirs removed                (inside lock)
+```
+
+#### Direct on-cluster flow (no rsync)
+
+When running directly on the cluster, no temp directory is needed.  Configs are
+generated straight into the canonical paths and used in-place by the SLURM
+array jobs.
+
+## Integration with SLURM Scripts
+
+All three launcher scripts accept `--sweeper` and `--override`:
+
+```bash
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+```
+
+The on-cluster script works identically (no rsync needed):
+
+```bash
+./slurm_utils/launch_protein_binder_search_conda.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+```
+
+The multi-target loop wrapper also passes these through:
+
+```bash
+./slurm_utils/launch_protein_binder_search_target_loop_conda.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    ./my_targets.txt
+```
+
+### Legacy Positional Arguments
+
+The `TARGET_TASK` positional argument is still supported for backward
+compatibility. Internally it is converted to
+`--override generation.task_name=$TARGET_TASK`.
+
+## Running Concurrent Experiments
+
+The system is designed for safe concurrent launches:
+
+- **Local config isolation**: Each launch generates configs in a unique
+  `mktemp -d configs/_gen_XXXXXX` directory.  Before rsync (inside the lock),
+  configs are staged to the canonical `configs/inference_configs/` and
+  `configs/eval_configs/` paths, rsync'd, then cleaned up.  This means the
+  generation phase is fully parallel, and the staging+rsync phase is serialised
+  by the lock.
+- **Remote directory uniqueness**: The run name on the cluster includes the
+  sweeper file basename (e.g., `my_run-search-beam_width-22_DerF21`), making
+  collisions nearly impossible for different sweeps.
+- **Lock file for rsync**: The `.lock` file prevents simultaneous rsync
+  operations from corrupting the code copy.
+
+Example: launching two experiments in parallel from different terminals:
+
+```bash
+# Terminal 1: sweep beam widths for target A
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+
+# Terminal 2: sweep replicas for target B (safe to run simultaneously)
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/search_replicas.yaml \
+    --override generation.task_name=02_PDL1
+```
+
+## Running Individual Pipeline Stages
+
+The core Python modules (`generate`, `filter`, `evaluate`, `analyze`) can
+still be run independently with Hydra `++key=value` overrides:
+
+```bash
+# Run just evaluation on existing inference outputs
+python -m proteinfoundation.evaluate \
+    --config-path /path/to/eval_configs \
+    --config-name eval_0_22_DerF21_my_run \
+    ++eval_njobs=4
+```
+
+The sweep system only affects config generation and the bash pipeline
+orchestration. It does not change how individual modules consume configs.
+
+## Migration from Old System
+
+| Old                                        | New                                              |
+|--------------------------------------------|--------------------------------------------------|
+| Edit `sweeper = {...}` dict in Python      | Create a YAML file in `configs/sweeps/`          |
+| `--target_task_override 22_DerF21`         | `--override generation.task_name=22_DerF21`      |
+| `--unified` flag                           | Removed (always unified pipeline mode)           |
+| `--eval_config_name evaluate`              | Removed (eval derived from pipeline config)      |
+| `--infer_config_name search_binder`        | `--config_name search_binder_pipeline`           |
+| `generate_binder_inference_configs.py`     | `generate_inference_configs.py`                  |
+| Hardcoded `ALPHA_PROTEO_TARGETS` list      | Removed (use sweep or override)                  |
+| `rm -rf configs/inference_configs`         | Automatic: temp dir + staging (concurrent-safe)  |
+
+## Tests
+
+The sweep system is covered by `tests/test_sweep.py` (92 tests):
+
+```bash
+pytest tests/test_sweep.py -v
+```
+
+Test categories:
+- `TestParseScalar` / `TestParseOverride`: Value parsing and type inference
+- `TestLoadSweeperFile`: YAML loading and validation
+- `TestBuildSweeper`: Merge logic and conflict resolution
+- `TestDotKeyDictToNestedDict`: Dot-notation conversion
+- `TestGetTaskNameFromConfig` / `TestCreateEvalConfig`: Config helpers
+- `TestApplySweeperAndSaveConfigs`: End-to-end cartesian product, value
+  propagation, unique paths, filename conventions
+- `TestConcurrentSafety`: Parallel generation without collisions
+- `TestBuildParser`: CLI argument parser validation
+- `TestCreateEvalConfigNjobs`: eval_njobs priority regression tests
+- `TestCreateEvalConfigPaths`: Path derivation edge cases
+- `TestEmptySweepAxis`: Zero-config guard regression tests
+- `TestConfigFilenameContract`: Filename contract between Python and bash
+- `TestEvalPathEdgeCases`: Eval path derivation with adversarial inputs

--- a/open-models-skills/proteina-complexa/complexa-sweep/reference/sweep_axes.md
+++ b/open-models-skills/proteina-complexa/complexa-sweep/reference/sweep_axes.md
@@ -1,0 +1,156 @@
+# Sweep Axes Reference
+
+Catalogue of swept keys for Proteina-Complexa design pipelines, grouped by pipeline stage. Every key is a Hydra dot-path you can put in a `configs/sweeps/*.yaml` file as a sweep axis (list value) or as an `--override KEY=VAL` pin.
+
+Defaults are read from `configs/pipeline/binder/binder_generate.yaml`, `configs/pipeline/binder/binder_evaluate.yaml`, and `configs/pipeline/model_sampling.yaml`. Verify against your actual base pipeline config before launching — different pipelines (e.g. `search_ligand_binder_local_pipeline`, `search_ame_local_pipeline`) inherit different defaults.
+
+## Generation axes
+
+These live under `generation.*` in the pipeline config (because the base pipeline pulls `binder_generate@generation`).
+
+### Search algorithm + width
+
+| Key | Default | Typical sweep values | Cost multiplier | Effect |
+|---|---|---|---|---|
+| `generation.search.algorithm` | `best-of-n` | `single-pass`, `best-of-n`, `beam-search`, `fk-steering`, `mcts` | 1× → 8× | Search regime. `single-pass` = baseline. `best-of-n` linear in replicas. `beam-search`/`fk-steering` ~ `n_branch × beam_width` extra forward passes. |
+| `generation.search.beam_search.beam_width` | 4 | 1, 2, 4, 8, 16 | linear | More beams = wider search → higher success rate. Diminishing returns past 8 in practice. |
+| `generation.search.beam_search.n_branch` | 4 | 2, 4, 8 | linear | Branching factor per beam step. Together with `beam_width` controls total samples per checkpoint. |
+| `generation.search.beam_search.keep_lookahead_samples` | `true` | `true`/`false` | minor | Whether to keep intermediate lookahead candidates as outputs. Off = fewer final PDBs. |
+| `generation.search.best_of_n.replicas` | 10 | 1, 4, 16, 64 | linear | Best-of-N draws. Increasing tightens success-rate estimate; not search depth. |
+| `generation.search.fk_steering.beam_width` | 4 | 1, 2, 4, 8 | linear | FK-steering equivalent of beam_width. |
+| `generation.search.fk_steering.n_branch` | 4 | 2, 4, 8 | linear | FK-steering branching factor. |
+| `generation.search.fk_steering.temperature` | 0.1 | 0.05, 0.1, 0.2, 0.5 | none | Softmax temperature for FK resampling. Higher = closer to uniform (more exploration). |
+| `generation.search.mcts.n_simulations` | 20 | 10, 20, 50 | linear | MCTS rollouts per decision. |
+| `generation.search.mcts.exploration_constant` | 1.0 | 0.5, 1.0, 2.0 | none | UCB exploration weight. |
+| `generation.search.reward_threshold` | `null` | `null`, -0.2, -0.1 | filters | Drop search candidates below this reward at each step. `null` = keep all. |
+
+### Diffusion / flow sampling
+
+| Key | Default | Typical sweep values | Cost multiplier | Effect |
+|---|---|---|---|---|
+| `generation.args.nsteps` | 400 | 100, 200, 400, 800 | linear | ODE integration steps. Lower = faster, lossy past ~100. 400 is a strong default. |
+| `generation.args.self_cond` | `true` | `true`, `false` | ~1.05× when true | Self-conditioning across steps; usually helps. |
+| `generation.args.guidance_w` | 1.0 | 0.0, 0.5, 1.0, 2.0 | none | Classifier-free guidance scale; 0 = unconditional, 1 = nominal, >1 = sharper conditioning. |
+| `generation.args.fold_cond` | `false` | `true`, `false` | minor | Fold-conditioning toggle. Off for most binder runs. |
+| `generation.model.bb_ca.simulation_step_params.sc_scale_noise` | 0.1 | 0.05, 0.1, 0.2, 0.4, 0.8 | none | Backbone CA noise scale ("temperature"). Higher = more diverse, less ordered structures. The `bb_ca_temperature.yaml` canned sweep tests 0.1 vs 0.4. |
+| `generation.model.bb_ca.simulation_step_params.sc_scale_score` | 1.0 | 0.5, 1.0, 1.5 | none | Score multiplier. Rarely swept. |
+| `generation.model.bb_ca.simulation_step_params.t_lim_ode` | 0.98 | 0.9, 0.95, 0.98 | none | ODE cutoff time near t=1. |
+| `generation.model.local_latents.simulation_step_params.sc_scale_noise` | 0.1 | 0.05, 0.1, 0.2 | none | Latent-feature noise. Affects sequence/local-structure diversity. |
+| `generation.n_recycle` | 0 | 0, 1, 2 | linear in N+1 | Recycling iterations through the model. Costly. |
+
+### Reward weights (`af2folding` composite)
+
+Path prefix: `generation.reward_model.reward_models.af2folding.reward_weights.*`. These compose into a single scalar reward at each search step; tuning the ratio rebalances what search optimises for.
+
+| Key (under the prefix above) | Default | Typical sweep | Effect |
+|---|---|---|---|
+| `i_pae` | -1.0 | -2.0, -1.0, -0.5, 0.0 | Negative weight on interface PAE. More negative = search pushes harder for low iPAE. |
+| `plddt` | 0.0 | 0.0, 0.5, 1.0 | Positive weight on overall pLDDT. Turn on to bias toward confident monomers. |
+| `con` | 0.0 | 0.0, 0.1, 0.5 | Binder-internal contact loss. Higher = more compact binders. |
+| `dgram_cce` | 0.0 | 0.0, 0.1, 1.0 | AF2 distogram cross-entropy. Rarely swept above 0. |
+| `min_ipae` | 0.0 | 0.0, -0.5, -1.0 | Min iPAE across chains; aggressive interface-quality push. |
+
+`generation.reward_model.reward_models.bioinformatics.reward_weights.{interface_sc, interface_hydrophobicity, surface_hydrophobicity, ...}` exist for the bioinformatics reward block (shape complementarity, SASA, hydrophobicity). Defaults live in the `binder_generate.yaml` config. Same pattern: list of floats per axis.
+
+### Refinement + filtering
+
+| Key | Default | Typical sweep | Effect |
+|---|---|---|---|
+| `generation.refinement.algorithm` | `null` | `null`, `sequence_hallucination` | Enable post-generation refinement loop. ~2× wall-clock when on. |
+| `generation.filter.reward_threshold` | `null` | `null`, -0.2, -0.1 | Hard floor on reward before top-N filtering. |
+| `generation.filter.filter_samples_limit` | 1000 | 100, 500, 1000 | Max samples to keep. |
+| `generation.filter.dedup_sequence` | `true` | `true`, `false` | Drop sequence-duplicate samples before ranking. |
+
+## Evaluation axes
+
+These live at top level (the binder_evaluate config is loaded with `@_global_`), not under `generation.*`.
+
+| Key | Default | Typical sweep | Cost multiplier | Effect |
+|---|---|---|---|---|
+| `metric.binder_folding_method` | `colabdesign` | `colabdesign`, `rf3_latest`, `boltz2_default`, `esmfold` | varies | Which refolder validates the binder. AF2 (`colabdesign`) is the standard; ESMFold ~5× faster, less accurate. |
+| `metric.num_redesign_seqs` | 2 | 1, 2, 4, 8, 16 | linear | Number of MPNN redesigns to refold per binder. Higher = more reliable designability signal. |
+| `metric.sequence_types` | `[self]` | `[self]`, `[self, mpnn]`, `[self, mpnn_fixed]` | linear per type | Which sequences to evaluate: generated, MPNN-redesigned, or MPNN with fixed interface. |
+| `metric.interface_cutoff` | 8.0 | 6.0, 8.0, 10.0 | none | Angstrom cutoff defining interface residues for MPNN_fixed and interface metrics. |
+| `metric.inverse_folding_model` | `soluble_mpnn` | `protein_mpnn`, `ligand_mpnn`, `soluble_mpnn` | none | MPNN variant used for redesign. |
+| `metric.compute_pre_refolding_metrics` | `false` | `true`, `false` | minor | Compute interface metrics on the generated structure (no fold) — fast. |
+| `metric.compute_refolded_structure_metrics` | `false` | `true`, `false` | minor | Compute interface metrics on the refolded structure — slower. |
+| `metric.pre_refolding.{bioinformatics,tmol,hbplus}` | mixed | `true`/`false` | minor | Toggle individual interface metric modules. |
+
+## Reading the sweeper YAML format
+
+Annotated example based on `configs/sweeps/example.yaml`:
+
+```yaml
+# --- Sweep axes (lists, cartesian-producted) ---
+# Each key is a Hydra dot-path. Each list value becomes one dimension.
+# Total configs = product of list lengths. Here 2 × 2 = 4.
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+generation.args.nsteps:
+  - 200
+  - 400
+
+# --- Pinned scalar (no extra dimension) ---
+# Scalars are auto-wrapped into a single-element list, so they pin a value
+# across the whole sweep without growing the cartesian product.
+# generation.args.self_cond: true
+
+# --- Long block-style list (e.g. checkpoint paths) ---
+# ckpt_path:
+#   - /lustre/checkpoints/model_v1/epoch_100.ckpt
+#   - /lustre/checkpoints/model_v2/epoch_200.ckpt
+```
+
+Validation rules (`script_utils/generate_inference_configs.py:load_sweeper_file`):
+
+- Top-level YAML must be a mapping. List or scalar at top = error.
+- All keys must be strings. Numeric keys = error.
+- List values are kept verbatim. Scalar values are wrapped to `[value]`.
+- Empty list `[]` for an axis = launcher dies with "No configs were generated."
+
+## Generating sweeper YAMLs programmatically
+
+For large parameter grids it is cleaner to render the YAML than to edit by hand:
+
+```python
+import itertools, yaml
+
+axes = {
+    "generation.search.beam_search.beam_width": [1, 2, 4, 8],
+    "generation.args.nsteps": [200, 400, 800],
+    "generation.model.bb_ca.simulation_step_params.sc_scale_noise": [0.1, 0.2, 0.4],
+}
+# 4 * 3 * 3 = 36 configs
+total = 1
+for v in axes.values():
+    total *= len(v)
+print(f"Will generate {total} configs")
+
+with open("configs/sweeps/big_grid.yaml", "w") as f:
+    yaml.safe_dump(axes, f, sort_keys=False, default_flow_style=False)
+```
+
+For an irregular set of `(key1, key2)` pairs (not a full cartesian product), there is no native support — emit one sweeper file per pair and concatenate the summary CSVs.
+
+## Result-aggregation logic
+
+`sweep_summary.csv` columns produced in Step 6 of the skill:
+
+| Column | Source | Notes |
+|---|---|---|
+| `config_id` | The index in `inf_{idx}_{run_name}.yaml` | 0-based, sequential, set by `apply_sweeper_and_save_configs`. |
+| `<axis_name>` (one per axis) | Read from the per-config `inf_*.yaml` at the swept Hydra path | Strip the dot-path to a short column header (e.g. `beam_width`). |
+| `n_samples` | `len(results_csv)` | Rows in the analyze CSV for this config. |
+| `success_rate` | `mean(passes_filter)` if column present, else thresholded `mean((i_pae < 10) & (i_plddt > 0.7) & (sc_rmsd < 2.0))` | Confirm thresholds with the user. |
+| `mean_i_pae` | `i_pae.mean()` | Lower = better. AF2 interface PAE. |
+| `mean_i_plddt` | `i_plddt.mean()` | Higher = better. Interface pLDDT. |
+| `mean_sc_rmsd` | `sc_rmsd.mean()` | Self-consistency RMSD between generated and refolded structures. |
+| `diversity_score` | Unique sequences / `n_samples`, or 1 − mean pairwise TM-score if available | Higher = more diverse pool. |
+| `wall_clock_min` | Timestamp delta from the per-config log (`./logs/design_pipeline_*_<run>_<timestamp>.log`) | Approximate (process wall-clock, not GPU time). |
+
+Ranking:
+
+- **Best by success** = argmax `success_rate`; tie-break on `mean_i_pae` ascending.
+- **Pareto frontier** on (`wall_clock_min`, `success_rate`): a config is on the frontier iff no other config has both lower wall-clock AND higher success rate. Implement with a sort + linear sweep.
+- **Sanity check**: if every config has `success_rate == 0`, the threshold is too strict OR the sweep regime is broken — surface this to the user before reporting "best".

--- a/open-models-skills/proteina-complexa/complexa-target/SKILL.md
+++ b/open-models-skills/proteina-complexa/complexa-target/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: complexa-target
+description: Use this skill whenever the user wants to add, register, edit, list, show, or validate a Proteina-Complexa design target for any pipeline — protein binder (default), ligand binder, or AME / enzyme scaffolding. Triggers include "add a target", "define a new target for binder design", "register a hotspot", "set up a PDL1 binder target", "ligand binder pocket", "SMILES target", "AME task", "enzyme motif", "M0024_1nzy", "complexa target add", "complexa target show", "configure target X", "what targets are available", "where do hotspots live", "what does target_input mean", "chain-spec syntax", "binder length range", or any question about `configs/targets/{,ligand_}targets_dict.yaml` and `configs/design_tasks/ame_dict_v2.yaml`. Also covers `complexa validate target`. This is the only skill that touches the three targets dict files.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# complexa-target
+
+Add or edit a design target in Proteina-Complexa. Targets live in **three YAML files**, one per `complexa design` pipeline:
+
+- `configs/targets/targets_dict.yaml` — protein binder (**default pipeline**)
+- `configs/targets/ligand_targets_dict.yaml` — ligand binder
+- `configs/design_tasks/ame_dict_v2.yaml` — AME / enzyme scaffolding
+
+The `complexa target` CLI only manages the first two. AME tasks use an extended schema (the same core fields as ligand targets plus `contig_atoms` for hand-curated per-residue motif atom selections) and are file-edit-only.
+
+## Preferred path: edit the YAML directly
+
+`complexa target add` is a thin wrapper around "load YAML → build dict → append a block" (see `src/proteinfoundation/cli/target_manager.py:add_target_cli` and `append_target_to_dict`). For agentic use, **just edit the targets dict directly** — the schema is short, the existing entries are great copy templates, and you skip 14 CLI flags / SMILES shell-escaping. Use the CLI only if you explicitly want its YAML auto-quoter or its overwrite-prompt safety.
+
+The skill therefore presents both paths:
+
+| Step | Direct file edit (preferred) | CLI |
+|---|---|---|
+| Look at existing targets | Read `configs/targets/{,ligand_}targets_dict.yaml` (or `configs/design_tasks/ame_dict_v2.yaml` for AME) | `complexa target list` (protein/ligand only) |
+| Look at one target | Read the dict and grep for the key | `complexa target show NAME` |
+| Add a new target | Append a YAML block (Step 3a) | `complexa target add ...` (Step 3b) |
+| Verify the PDB resolves on disk | — *(no shortcut, this checks Hydra defaults)* | `complexa validate target CONFIG --target NAME` |
+
+`complexa target` only sees the two protein-style dicts (`targets_dict.yaml` and `ligand_targets_dict.yaml`). For AME tasks (which use a different schema), file-edit is the only path — see Step 1 below.
+
+## What this skill enables
+
+- Register a **protein target** (chain + residue range + hotspots) in `configs/targets/targets_dict.yaml`.
+- Register a **ligand target** (PDB pocket + 3-letter code + SMILES) in `configs/targets/ligand_targets_dict.yaml`.
+- Resolve the right **AME task name** (e.g. `M0024_1nzy`, `M0096_1chm`) for the AME pipeline — these are not added via `complexa target add` (see Step 1).
+- Verify a target resolves to a real PDB on disk with `complexa validate target`.
+- Emit a replayable artifact (`target_definition.yaml`) for downstream design runs.
+
+## Step 1: Decide the target type
+
+Targets live in **three different files**, one per `complexa design` pipeline. Pick the file by working out which pipeline the user will run, then add the entry to that file. Each file is consumed by exactly one pipeline.
+
+| User intent | Pipeline | Targets dict file | This skill? |
+|---|---|---|---|
+| Bind a protein surface (PD-L1, IFNAR2, TNF-α, …) — **default** | `configs/search_binder_local_pipeline.yaml` | `configs/targets/targets_dict.yaml` | Yes — Step 2 (protein) |
+| Bind a small-molecule pocket (FAD, SAM, OQO, …) | `configs/search_ligand_binder_local_pipeline.yaml` | `configs/targets/ligand_targets_dict.yaml` | Yes — Step 2 (ligand) |
+| AME / enzyme scaffolding (motif + ligand, `M####_<pdb>` names) | `configs/search_ame_local_pipeline.yaml` | `configs/design_tasks/ame_dict_v2.yaml` | Partial — see "AME tasks" below |
+
+### AME tasks (enzyme pipeline)
+
+Similar story — AME tasks live in `configs/design_tasks/ame_dict_v2.yaml` under `motif_target_dict_cfg:` with their own schema (`source`, `target_filename`, `ligand`, `contig_atoms`, `binder_length`, `use_bonds_from_file`). The `contig_atoms` string encodes per-residue motif atom selections like `"A64: [O, C]; A86: [CB, CA, N, C]; ..."` — these are hand-curated, so adding a new AME task is a file edit, not a CLI invocation. Browse the file, copy a similar entry as a template, and pass `++generation.task_name=<NAME>` to `complexa design configs/search_ame_local_pipeline.yaml`.
+
+## Step 2: Gather required info
+
+Use AskUserQuestion to collect — do not guess these. Required fields differ for protein vs ligand.
+
+### Protein target
+
+| Field | Question | Example | Required |
+|---|---|---|---|
+| name | "Target name (used as the dict key and `task_name`)?" | `02_PDL1`, `MyTarget_v1` | yes |
+| source | "Source directory under `$DATA_PATH/target_data/`?" | `bindcraft_targets`, `custom_targets` | yes (or `target_path`) |
+| target_filename | "PDB filename (no `.pdb` extension)?" | `PD-L1`, `IFNAR2` | yes (or `target_path`) |
+| target_input | "Chain + residue range — see reference for grammar." | `A1-115`, `A1-50,B1-50` | yes |
+| hotspot_residues | "Hotspot residues (interface contact residues)?" | `["A33", "A95", "A102"]` | optional, recommended |
+| binder_length | "Binder length range `[min, max]` or single `[length]`?" | `[80, 150]`, `[100]` | optional (default `[60, 120]`) |
+| pdb_id | "Reference PDB ID (optional, metadata only)?" | `"2lag"` | optional |
+
+### Ligand target — protein fields above (minus `target_input`), plus:
+
+| Field | Question | Example | Required |
+|---|---|---|---|
+| ligand | "3-letter PDB ligand residue code?" | `FAD`, `OQO`, `SAM` | yes (presence marks target as ligand) |
+| smiles | "SMILES string for the ligand?" | `"O=C2C3=Nc1cc(c(...)..."` | recommended |
+| ligand_only | "Generate pocket around ligand only (no protein-protein interface)?" | `true` / `false` | optional (default `true`) |
+| use_bonds_from_file | "Use bond info from the input PDB/CIF?" | `true` / `false` | optional (default `true`) |
+| target_input | not required for ligand targets | — | no |
+
+Check for name collisions by reading the dict (`rg '^  NEW_NAME:' configs/targets/targets_dict.yaml`) or running `complexa target list -v --ligand` / `--protein`.
+
+## Step 3a: Append the YAML block directly (preferred)
+
+Open `configs/targets/targets_dict.yaml` (or `ligand_targets_dict.yaml` for ligand targets), find a similar existing entry as a style template, and append the new block under `target_dict_cfg:`. Two-space indent, single blank line between entries.
+
+### Protein template
+
+```yaml
+  02_PDL1:
+    source: bindcraft_targets
+    target_filename: PD-L1
+    target_input: "A1-115"
+    hotspot_residues: ["A37", "A39", "A49", "A98"]
+    binder_length: [64, 155]
+    pdb_id: "4z18"
+```
+
+Rules to match the existing file style (mirrors what `complexa target add` would emit):
+
+- Quote chain/residue ranges (`"A1-115"`, `"A33"`) and any SMILES — flow-style strings get tripped up by `:` and brackets otherwise.
+- Use flow-style lists (`["A33", "A95"]`, `[64, 155]`) — that's what the on-disk dump produces.
+- `target_input`, `source`, `target_filename` are required for protein. `target_path` (absolute path) can replace `source + target_filename` if the PDB lives outside `$DATA_PATH/target_data/`.
+
+### Ligand template
+
+```yaml
+  41_7BKC_LIGAND:
+    source: ligand_targets
+    target_filename: 7BKC_ligand_centered
+    hotspot_residues: [null]
+    binder_length: [100]
+    pdb_id: 7BKC
+    ligand: 'FAD'
+    ligand_only: True
+    SMILES: "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C"
+    use_bonds_from_file: True
+```
+
+The presence of the `ligand:` key flips the target into ligand mode — there is no separate `is_ligand` flag. `target_input` is not required for ligands.
+
+After saving, skip to Step 4 to verify.
+
+## Step 3b: CLI alternative (`complexa target add`)
+
+Use the CLI when you want its automatic chain/residue quoting, the overwrite-confirm prompt, or to wire target creation into a non-Python script. Prefer non-interactive mode for agentic use (`-i / --editor` opens an editor and blocks).
+
+### Confirmed flags (from `src/proteinfoundation/cli/target_cli.py`)
+
+| Flag | Type | Applies to | Notes |
+|---|---|---|---|
+| `name` (positional) | str | both | dict key |
+| `--dict PATH` | path | both | override target dict path |
+| `-i, --interactive` | flag | both | open `$EDITOR` |
+| `-e, --editor NAME` | str | both | `code`, `nano`, `vim`, `cursor`, ... |
+| `--source NAME` | str | both | directory under `$DATA_PATH/target_data/` |
+| `--target-filename NAME` | str | both | PDB stem (no `.pdb`) |
+| `--target-path PATH` | str | both | full path; overrides `source`+`filename` |
+| `--target-input SPEC` | str | protein | chain/residue range, e.g. `A1-115` |
+| `--hotspot-residues R [R ...]` | list | both | e.g. `A33 A95` |
+| `--binder-length N [N ...]` | int list | both | `[min, max]` or `[length]` |
+| `--pdb-id ID` | str | both | metadata only |
+| `--ligand CODE` | str | ligand | presence marks ligand target |
+| `--ligand-only` | flag | ligand | pocket-only mode |
+| `--smiles STR` | str | ligand | SMILES for the ligand |
+| `--use-bonds-from-file` | flag | ligand | use PDB bonds |
+| `-f, --force` | flag | both | overwrite existing without prompt |
+
+### Protein example
+
+```bash
+complexa target add 02_PDL1 \
+  --source bindcraft_targets \
+  --target-filename PD-L1 \
+  --target-input A1-115 \
+  --hotspot-residues A37 A39 A49 A98 \
+  --binder-length 64 155 \
+  --pdb-id 4z18
+```
+
+### Ligand example
+
+```bash
+complexa target add 41_7BKC_LIGAND \
+  --source ligand_targets \
+  --target-filename 7BKC_ligand_centered \
+  --pdb-id 7BKC \
+  --ligand FAD \
+  --ligand-only \
+  --use-bonds-from-file \
+  --smiles "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C" \
+  --binder-length 100
+```
+
+Why these defaults: `--source` defaults to `custom_targets` (protein) or `ligand_targets` (ligand) and `--target-filename` defaults to `name`, so be explicit when the PDB stem differs from the target name. The dict gets `ligand_only: true` and `use_bonds_from_file: true` by default for ligand targets — pass the flags to be explicit, or omit to accept defaults.
+
+## Step 4: Verify
+
+Run two checks, in order. Stop and fix on the first failure.
+
+```bash
+# 1. Confirm the entry landed and looks right.
+#    Direct read works just as well: `rg -A 7 '^  02_PDL1:' configs/targets/targets_dict.yaml`
+complexa target show 02_PDL1
+
+# 2. Resolve the PDB path and validate it exists on disk.
+#    No shortcut for this — it traverses Hydra defaults to find the target dict.
+complexa validate target configs/search_protein_local_pipeline.yaml --target 02_PDL1
+```
+
+`complexa validate target` (from `src/proteinfoundation/cli/validate.py::validate_target`) checks:
+
+- `DATA_PATH` is set and `target_data/` exists.
+- The target name resolves in `target_dict_cfg`.
+- Either `target_path` exists, or `$DATA_PATH/target_data/<source>/<target_filename>.pdb` exists.
+- `target_input`, `hotspot_residues`, `binder_length` are reported back so a human can sanity-check them.
+
+For ligand targets, point `--target` at a ligand pipeline config (e.g. a ligand binder search config).
+
+## Step 5: Emit artifact
+
+Save a replayable record under `./target_<name>/`:
+
+```bash
+mkdir -p target_02_PDL1
+complexa target show 02_PDL1 > target_02_PDL1/target_show.txt
+```
+
+Then write the appended YAML snippet (the lines `complexa target add` wrote under `target_dict_cfg:`) to `target_02_PDL1/target_definition.yaml` using the Write tool. The artifact lets the user diff target definitions across runs and re-create the entry on another checkout via `complexa target add ... --force`.
+
+## Hardware requirements
+
+None for target definition — this is a YAML edit, not a training/inference step. Disk impact is a few KB appended to the targets dict (plus an automatic `.yaml.bak` backup written by `save_targets_dict`).
+
+For the downstream design / evaluate runs that consume the target, defer to `complexa-design` and `_shared/reference/hardware.md`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Target PDB file: File not found` from `validate target` | `<source>/<target_filename>.pdb` does not exist under `$DATA_PATH/target_data/` | Confirm the PDB stem and source dir. Use `--target-path /full/path.pdb` if the file lives outside `target_data/`. |
+| "Target 'X' already exists! Overwrite? (y/N)" | Name collision in dict | Either pick a new name, or pass `-f / --force` to overwrite. |
+| Hotspot residue not in PDB | Wrong chain or residue number | Open the PDB, re-check chain letters (case-sensitive) and residue indices. Hotspots use the format `<CHAIN><RESNUM>` — see reference. |
+| Chain not found | `target_input` references a chain that does not exist in the PDB | Inspect the PDB with `grep "^ATOM" target.pdb \| awk '{print $5}' \| sort -u`. |
+| Ligand code missing from PDB | The 3-letter `ligand` code does not appear as a `HETATM` residue name in the file | Open the PDB and check `HETATM` lines; you may need a `_ligand_centered` variant of the PDB. |
+| SMILES parse failure downstream | Bad SMILES string | Validate with `rdkit.Chem.MolFromSmiles(smiles)` before adding. Quote SMILES in shell to escape brackets and parens. |
+| Target name with leading digit breaks Hydra interpolation | YAML treats `02_PDL1` as a string fine; some override syntaxes need quoting | Use `++generation.task_name=02_PDL1`; quote if the shell strips characters. |
+| `target_input` appears ignored for a ligand target | By design — ligand targets do not use `target_input`; pocket is defined by the ligand | Leave it unset for ligand targets. |
+
+## Reference
+
+- `reference/target_schema.md` — every field, chain-spec grammar, AME task-name grammar, three worked examples.
+- `configs/targets/targets_dict.yaml` — live protein entries (copy a known-good one as a template).
+- `configs/targets/ligand_targets_dict.yaml` — live ligand entries.
+- `configs/design_tasks/ame_dict_v2.yaml` — AME task definitions (file-edit only, not exposed via `complexa target` CLI).
+- `src/proteinfoundation/cli/target_cli.py` — argparse source of truth.
+- `src/proteinfoundation/cli/target_manager.py` — `add_target_cli`, `list_targets`, `show_target`, schema in `TARGET_FIELDS`.
+- `src/proteinfoundation/cli/validate.py` — `validate_target` implementation.

--- a/open-models-skills/proteina-complexa/complexa-target/evals/evals.json
+++ b/open-models-skills/proteina-complexa/complexa-target/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "complexa-target",
+  "evals": [
+    {
+      "id": "complexa-target-001",
+      "prompt": "complexa target add — I want to register a new protein binder target for PD-L1 with chain A, residues 18-134, and hotspots at Y56, E58, D61, N63, R113, A121, Y123.",
+      "expected_output": "The agent used complexa-target to add a new PD-L1 protein binder target entry to configs/targets/targets_dict.yaml with the specified chain, residue range, and hotspot residues.",
+      "assertions": [
+        "The agent read configs/targets/targets_dict.yaml to understand the existing entry format",
+        "The agent appended a new YAML block for the PD-L1 target with chain A, residues 18-134, and hotspots Y56/E58/D61/N63/R113/A121/Y123",
+        "The agent confirmed the new target was successfully written to the file",
+        "The agent provided the user with the target key name that can be referenced in downstream design runs",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-target",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-target-002",
+      "prompt": "I need to set up a small-molecule binding pocket target for FAD. The PDB is 1a8p, the ligand is in chain B with 3-letter code FAD, and the SMILES is CC1=CC2=C(C=C1C)N(C3=NC(=O)NC(=O)C3=N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC4OC(N5C=NC6=C5N=CN=C6N)C(O)C4O. How do I register this?",
+      "expected_output": "The agent used complexa-target to register a new ligand binder target in configs/targets/ligand_targets_dict.yaml with the PDB 1a8p, chain B, ligand code FAD, and the provided SMILES string.",
+      "assertions": [
+        "The agent read configs/targets/ligand_targets_dict.yaml to examine the existing ligand target schema",
+        "The agent wrote a new entry to ligand_targets_dict.yaml with the PDB, chain, 3-letter code, and SMILES fields properly formatted",
+        "The agent explained that this target will be consumed by the ligand binder pipeline (search_ligand_binder_local_pipeline.yaml)",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-target",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-target-003",
+      "prompt": "I'm working on an enzyme design project. We have a crystal structure 1nzy and need to create an AME scaffolding task M0024_1nzy with specific contig_atoms for the active site motif residues. Can you help me set this up?",
+      "expected_output": "The agent used complexa-target to guide the user through adding a new AME task entry (M0024_1nzy) to configs/design_tasks/ame_dict_v2.yaml, explaining the contig_atoms schema and that AME tasks require direct file editing rather than the CLI.",
+      "assertions": [
+        "The agent read configs/design_tasks/ame_dict_v2.yaml to understand the AME task schema including contig_atoms and per-residue motif atom selections",
+        "The agent explained that AME tasks cannot be added via complexa target add CLI and require direct file editing",
+        "The agent asked the user for the specific contig_atoms and motif residue details needed to complete the entry",
+        "The agent wrote or prepared the new M0024_1nzy block in ame_dict_v2.yaml with the appropriate schema",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-target",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-target-004",
+      "prompt": "How do I run a protein binder design campaign end-to-end using complexa design? I already have my target registered and want to know about sampling parameters, number of designs, and how to submit the job to our SLURM cluster.",
+      "expected_output": "The agent did not use complexa-target because the question is about running the design pipeline (sampling parameters, job submission, SLURM configuration) rather than adding, editing, listing, showing, or validating a target definition.",
+      "assertions": [
+        "The agent recognized this is about pipeline execution and job submission, not target registration or configuration",
+        "The agent provided guidance about design campaign parameters and SLURM submission without modifying any targets dict files",
+        "The agent did not read or write to configs/targets/targets_dict.yaml, ligand_targets_dict.yaml, or ame_dict_v2.yaml",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/open-models-skills/proteina-complexa/complexa-target/reference/target_schema.md
+++ b/open-models-skills/proteina-complexa/complexa-target/reference/target_schema.md
@@ -1,0 +1,228 @@
+# Target schema reference
+
+Authoritative source: `src/proteinfoundation/cli/target_manager.py::TARGET_FIELDS` and the live YAML dicts under `configs/targets/`. This document mirrors them.
+
+## Protein target schema
+
+Stored in `configs/targets/targets_dict.yaml` under `target_dict_cfg.<name>`. Either (`source` + `target_filename`) OR `target_path` is required, plus `target_input`.
+
+| Field | Type | Required | Default | Example | Controls |
+|---|---|---|---|---|---|
+| `source` | str | yes* | `custom_targets` | `bindcraft_targets` | Subdirectory of `$DATA_PATH/target_data/` where the PDB lives. |
+| `target_filename` | str | yes* | (name of target) | `PD-L1` | PDB stem (no `.pdb` extension). Combined with `source` to build the path. |
+| `target_path` | str | yes* | `null` | `/abs/path/target.pdb` | Full path to a PDB. If set, `source`+`target_filename` are optional. |
+| `target_input` | str | **yes** | `A1-100` | `A1-115`, `A1-50,B1-50` | Chain + residue range (the "target_input" chain-spec). |
+| `hotspot_residues` | list[str] | no | `[]` | `["A33", "A95", "A102"]` | Interface residues focused on during binder design. |
+| `binder_length` | list[int] | no | `[60, 120]` | `[80, 150]`, `[100]` | Binder length. Two-element list = uniform `[min, max]`; one-element = fixed length. |
+| `pdb_id` | str | no | `null` | `"2lag"` | Reference PDB ID, metadata only. |
+
+(* "yes" with the OR rule: either `target_path` OR (`source` AND `target_filename`).)
+
+## Ligand target schema
+
+Stored in `configs/targets/ligand_targets_dict.yaml`. The presence of the `ligand` key is what marks an entry as a ligand target (no separate `is_ligand` flag). `target_input` is not used for ligand targets.
+
+All protein fields above (with `target_input` optional / omitted), plus:
+
+| Field | Type | Required | Default | Example | Controls |
+|---|---|---|---|---|---|
+| `ligand` | str OR list[str] | **yes** | `null` | `"FAD"`, `["DHZ", "ZN"]` | Three-letter PDB residue name(s) for the ligand. Presence marks target as ligand. |
+| `ligand_only` | bool | no | `true` | `true` | If `true`, generate the binding pocket around the ligand only (no protein-protein interface). |
+| `SMILES` | str | no | `null` | `"O=C2C3=Nc1cc(...)C"` | SMILES string for the ligand (single-ligand targets only). Optional but recommended. |
+| `use_bonds_from_file` | bool | no | `true` | `true` | If `true`, use bond information from the input PDB/CIF file rather than inferring from coordinates. |
+
+Note: `hotspot_residues` is still present for ligand entries but is typically `[null]` since the pocket is ligand-defined.
+
+## `target_input` chain-spec grammar
+
+`target_input` selects which residues of the target PDB are exposed to the binder design model.
+
+| Form | Meaning | Example |
+|---|---|---|
+| `<CHAIN><START>-<END>` | One contiguous chain segment | `A1-115` = chain A, residues 1 through 115 |
+| `<CHAIN><START>-<END>,<CHAIN><START>-<END>` | Multiple chain segments (comma-separated) | `A1-50,B1-50` = chain A residues 1-50 plus chain B residues 1-50 |
+| `<CHAIN><START>-<END>/0 <NRES>-<NRES>` | Chain break + contigs syntax (RFdiffusion-style) | `A1-115/0 50-100` = target A1-115 plus a 50-100 residue binder placeholder |
+
+`<CHAIN>` is a single uppercase letter (case-sensitive — `A` and `a` are different). `<START>` and `<END>` are integer residue numbers as they appear in the PDB (not 0-indexed; respects insertion codes only if the PDB does).
+
+When is `target_input` required vs optional?
+
+- **Protein targets**: required. Default is `A1-100`.
+- **Ligand targets**: not required (and not used at runtime). The pocket is defined by the ligand position, not a chain range.
+
+## Hotspot residue format
+
+A hotspot is a single residue, identified by chain + residue number:
+
+```
+"A33"     # chain A, residue 33
+"B17"     # chain B, residue 17
+```
+
+Rules:
+- Must be a string (always quote in YAML — the YAML dumper auto-quotes any `<chain><digits>` pattern).
+- Chain letter is case-sensitive and must match a chain in the PDB.
+- Residue number must exist in the PDB (use `grep "^ATOM" target.pdb | awk '{print $5, $6}' | sort -u` to enumerate).
+- The list may be empty (`[]`) — no hotspots = no special interface focus.
+- The list may contain only `[null]` for ligand targets where the pocket is ligand-defined.
+
+CLI form: `--hotspot-residues A33 A95 A102` (space-separated, no quotes needed on the command line).
+
+## `binder_length` semantics
+
+| Value | Meaning |
+|---|---|
+| `[60, 120]` | Sample binder length uniformly in [60, 120] inclusive. |
+| `[100]` | Always generate length-100 binders. |
+| `[80, 150]` | Sample uniformly in [80, 150]. |
+| `[]` or unset | Falls back to default `[60, 120]`. |
+
+CLI form: `--binder-length 60 120` (two ints) or `--binder-length 100` (one int).
+
+## Source directory convention
+
+`source` is **not** a full path. It is a subdirectory name under `$DATA_PATH/target_data/`. The full path resolution is:
+
+```
+${DATA_PATH}/target_data/<source>/<target_filename>.pdb
+```
+
+Examples:
+
+| `source` | `target_filename` | Resolved path |
+|---|---|---|
+| `bindcraft_targets` | `PD-L1` | `${DATA_PATH}/target_data/bindcraft_targets/PD-L1.pdb` |
+| `ligand_targets` | `7BKC_ligand_centered` | `${DATA_PATH}/target_data/ligand_targets/7BKC_ligand_centered.pdb` |
+| `custom_targets` | `MyTarget_v1` | `${DATA_PATH}/target_data/custom_targets/MyTarget_v1.pdb` |
+
+Override the convention with `--target-path /absolute/path/to/file.pdb` (overrides both `source` and `target_filename`).
+
+Common existing `source` directories: `bindcraft_targets`, `alpha_proteo_targets`, `ligand_targets`, `custom_targets`.
+
+## AME task names (NOT `complexa target`)
+
+The AME pipeline uses **task names**, not targets-dict entries. Task names are defined in `configs/design_tasks/ame_dict_v2.yaml` under `motif_target_dict_cfg:` and are file-edit-only — they have a richer schema than protein/ligand targets and the `complexa target` CLI does not touch them.
+
+### Grammar
+
+```
+M{NNNN}_{pdb_id}
+```
+
+| Component | Values | Meaning |
+|---|---|---|
+| `M{NNNN}` | `M0001` … | Zero-padded sequential ID assigned when the task is added. |
+| `pdb_id` | 4-char PDB code (lowercase) | Source PDB for the motif + ligand context. |
+
+Examples (drawn from `configs/design_tasks/ame_dict_v2.yaml`): `M0024_1nzy`, `M0096_1chm`.
+
+### AME task schema
+
+Each entry under `motif_target_dict_cfg.<name>` has:
+
+| Field | Type | Example | Notes |
+|---|---|---|---|
+| `source` | str | `ame_targets` | Subdirectory under `$DATA_PATH/target_data/`. |
+| `target_filename` | str | `1nzy_v2` | PDB stem (no `.pdb`). |
+| `ligand` | str | `"FAD"` | 3-letter PDB ligand code in the motif PDB. |
+| `contig_atoms` | str | `"A64: [O, C]; A86: [CB, CA, N, C]; ..."` | Hand-curated per-residue atom selection for the motif. |
+| `binder_length` | list[int] | `[100, 160]` | Length range for the scaffold. |
+| `use_bonds_from_file` | bool | `true` | Use bond info from the PDB. |
+| `pdb_id` | str | `"1nzy"` | Reference PDB ID, metadata only. |
+
+To run an AME task:
+
+```bash
+complexa design configs/search_ame_local_pipeline.yaml \
+  ++run_name=ame_1nzy \
+  ++generation.task_name=M0024_1nzy
+```
+
+**Do not use `complexa target add` for AME tasks** — they live in a different dict and add the `contig_atoms` field (and use `motif_target_dict_cfg` instead of `target_dict_cfg`) that the CLI does not know how to construct.
+
+## Worked examples
+
+### 1. Protein target from PDB ID + chain (new BindCraft target)
+
+User wants to design binders against chain A, residues 1-115, of an existing PDB at `${DATA_PATH}/target_data/bindcraft_targets/PD-L1.pdb`, hotspot residues A37, A39, A49, A98, binder length 64-155.
+
+```bash
+complexa target add 02_PDL1 \
+  --source bindcraft_targets \
+  --target-filename PD-L1 \
+  --target-input A1-115 \
+  --hotspot-residues A37 A39 A49 A98 \
+  --binder-length 64 155 \
+  --pdb-id 4z18
+```
+
+Resulting YAML entry (appended to `configs/targets/targets_dict.yaml`):
+
+```yaml
+  02_PDL1:
+    target_input: "A1-115"
+    source: bindcraft_targets
+    target_filename: "PD-L1"
+    hotspot_residues: ["A37", "A39", "A49", "A98"]
+    binder_length: [64, 155]
+    pdb_id: 4z18
+```
+
+### 2. Ligand target with SMILES (FAD pocket)
+
+User wants binders for the FAD-binding pocket of 7BKC, fixed length 100.
+
+```bash
+complexa target add 41_7BKC_LIGAND \
+  --source ligand_targets \
+  --target-filename 7BKC_ligand_centered \
+  --pdb-id 7BKC \
+  --ligand FAD \
+  --ligand-only \
+  --use-bonds-from-file \
+  --smiles "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C" \
+  --binder-length 100
+```
+
+Resulting YAML entry (appended to `configs/targets/ligand_targets_dict.yaml`):
+
+```yaml
+  41_7BKC_LIGAND:
+    source: ligand_targets
+    target_filename: "7BKC_ligand_centered"
+    hotspot_residues: []
+    binder_length: [100]
+    pdb_id: 7BKC
+    ligand: FAD
+    ligand_only: True
+    SMILES: "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C"
+    use_bonds_from_file: True
+```
+
+### 3. Ligand target with `--use-bonds-from-file` and no SMILES
+
+User has a curated `_centered` PDB whose bonds are authoritative, and does not want to provide a SMILES (e.g. uncommon ligand). They want a length range 40-88.
+
+```bash
+complexa target add Cambridge_bloodsugar_A_4D71_pdb \
+  --source ligand_targets \
+  --target-filename Cambridge_bloodsugar_A_4D71_pdb \
+  --pdb-id 4D71 \
+  --ligand UNK \
+  --ligand-only \
+  --use-bonds-from-file \
+  --binder-length 40 88
+```
+
+(Note: `--ligand` requires a value; pass a placeholder like `UNK` or the actual 3-letter code if available. The `complexa target add` parser interprets the presence of `--ligand` as marking the target ligand-typed.)
+
+Resulting entry mirrors `Cambridge_bloodsugar_A_4D71_pdb` from `configs/targets/ligand_targets_dict.yaml` — `SMILES: null`, `use_bonds_from_file: True`, `binder_length: [40, 88]`.
+
+## Cross-references
+
+- CLI: `src/proteinfoundation/cli/target_cli.py`
+- Manager + schema: `src/proteinfoundation/cli/target_manager.py` (see `TARGET_FIELDS`)
+- Validator: `src/proteinfoundation/cli/validate.py::validate_target`
+- Protein dict: `configs/targets/targets_dict.yaml`
+- Ligand dict: `configs/targets/ligand_targets_dict.yaml`
+- AME dict: `configs/design_tasks/ame_dict_v2.yaml`

--- a/plugins.d/bionemo-agent-toolkit.yml
+++ b/plugins.d/bionemo-agent-toolkit.yml
@@ -36,6 +36,7 @@ include_skills:
   - library-skills/parabricks/
   # Open models
   - open-models-skills/kermt/
+  - open-models-skills/proteina-complexa/
   # Workflows
   - workflows/generative_protein_binder_design/
 

--- a/plugins/bionemo-agent-toolkit/skills/complexa-design/SKILL.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-design/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: complexa-design
+description: >
+  End-to-end Proteina-Complexa design pipeline driver. Reach for this skill whenever
+  the user wants to "design a binder", "design binders for X", "run complexa
+  design", "de novo binder", "PDL1 binder", "TrkA binder", "design proteins for
+  target", "protein binder design", "ligand binder", "design a small-molecule
+  binder", "ATP-binding protein", "AME motif scaffolding", "scaffold a motif
+  near a ligand", "motif + ligand design", "enzyme scaffolding", "flow matching
+  protein design", "beam-search binder", "FK steering", "MCTS protein design",
+  "refold with AF2", "refold with RF3", or wants success rates, interface pAE,
+  scRMSD, or
+  FoldSeek diversity from a single command. This is the scientific anchor of
+  the skill set: it drives `complexa design <pipeline>` from target picking to
+  manifest emission and tells the user how many designs passed.
+compatibility: "complexa CLI installed (pip install -e .); .env populated; 1x CUDA GPU >=40GB VRAM (A100/H100/L40S); 24 CPUs; ~50GB disk"
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Complexa Design Skill
+
+Drive the full four-stage `complexa design` pipeline: generate (flow matching +
+search) -> filter (top-N by reward) -> evaluate (refold with AF2/RF3) ->
+analyze (success rate, FoldSeek/MMseqs diversity). Pick the right pipeline
+config for the design intent, validate the run upfront so the user does not
+discover a missing ckpt mid-folding, run it, and emit a replayable manifest +
+per-design success CSV.
+
+## What this skill enables
+
+- Protein binder design for protein targets (AF2 reward + ColabDesign refold).
+- Ligand binder design for small-molecule targets (RF3 reward + RF3 refold).
+- AME motif scaffolding with ligand context (motif + ligand features, RF3).
+- Search-based optimization: single-pass, best-of-n, beam-search, fk-steering, mcts.
+- Refold backends: ColabDesign (AF2), RF3, Boltz2, ESMFold (fast iteration).
+- Pass-rate + diversity analysis with per-`result_type` thresholds.
+
+## Step 1: Pre-flight
+
+Always run the shared preflight before launching a design — generation needs the
+GPU and the right checkpoint, evaluation needs AF2/RF3 weights and tool
+binaries. Bail early if the host cannot run the chosen pipeline.
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+Read `./complexa_setup/preflight.json` and bail if any of these are missing for
+the chosen pipeline:
+
+- `gpu.available: false` -> all pipelines fail.
+- `gpu.vram_gb < 40` -> generation OOMs at default `batch_size: 16`; lower to 8.
+- `ckpts.complexa[.ckpt]` -> required for protein binder.
+- `ckpts.complexa_ligand[.ckpt]` -> required for ligand binder.
+- `ckpts.complexa_ame[.ckpt]` -> required for AME.
+- `env.AF2_DIR` missing -> protein binder default eval (`colabdesign`) fails.
+- `env.RF3_CKPT_PATH` or `env.RF3_EXEC_PATH` missing -> ligand binder / AME default eval (`rf3_latest`) fails.
+
+If a ckpt is missing, point at `complexa-setup` and have the user run
+`complexa download --complexa-<variant>` first.
+
+## Step 2: Pick the pipeline
+
+Complexa has **one default pipeline (protein binder) and two extensions**
+(ligand binder, AME / enzyme). The pipeline is selected entirely
+by the `configs/search_*_pipeline.yaml` you pass to `complexa design` — each
+YAML pins its own model checkpoint, autoencoder, targets dict, default reward,
+and default refold backend. Switching pipelines is just "swap the config path
+and the target name comes from a different dict".
+
+### Default — protein binder
+
+```bash
+complexa design configs/search_binder_local_pipeline.yaml \
+    ++run_name=pdl1_v1 ++generation.task_name=02_PDL1
+```
+
+Use this when the user says "design a binder for X", "PDL1 binder",
+"de novo binder", "design proteins for a target", etc. — i.e. the target is
+a protein surface. The config pins `complexa.ckpt` + `complexa_ae.ckpt`, reads
+targets from `configs/targets/targets_dict.yaml`, rewards with AF2
+(`af2folding`), inverse-folds with SolubleMPNN, and evaluates with
+ColabDesign / AF2. **If the user did not specify, this is what they want.**
+
+### Extension A — ligand binder (small-molecule pocket)
+
+```bash
+complexa design configs/search_ligand_binder_local_pipeline.yaml \
+    ++run_name=v11_v1 ++generation.task_name=39_7V11_LIGAND \
+    ++metric.binder_folding_method=rf3_latest
+```
+
+Switch to this when the user says "ligand binder", "small-molecule pocket",
+"SMILES target", "ATP-binding protein", or names a target ending in
+`_LIGAND` / from the FAD / SAM / OQO / 7V11 / etc. families. The config
+**also activates LoRA** (`r=32`, `lora_alpha=64`) which is required for the
+released ligand checkpoint — leave the `lora:` block alone.
+
+### Extension B — AME / motif + ligand (enzyme scaffolding)
+
+```bash
+complexa design configs/search_ame_local_pipeline.yaml \
+    ++run_name=ame_chm ++generation.task_name=M0096_1chm
+```
+
+Switch to this when the user says "scaffold a motif near a ligand",
+"active-site design", "enzyme scaffolding", "AME", or names a target like
+`M0024_1nzy`, `M0096_1chm` (the `M####_<pdb>` AME task naming). The config sets
+`env_vars.USE_V2_COMPLEXA_ARCH=True` (the CLI runner injects it into the
+subprocess) and uses both `MotifFeatures` and `LigandFeatures`. Default search
+is `single-pass`; switch to `best-of-n` only if you also enable the
+`CompositeRewardModel` (commented out in `ame_generate.yaml`).
+
+### Pipeline cheat sheet — what changes when you switch
+
+| Knob | Protein binder (default) | Ligand binder | AME (enzyme) |
+|---|---|---|---|
+| **Pipeline YAML** | `configs/search_binder_local_pipeline.yaml` | `configs/search_ligand_binder_local_pipeline.yaml` | `configs/search_ame_local_pipeline.yaml` |
+| **Model ckpt** | `complexa.ckpt` | `complexa_ligand.ckpt` | `complexa_ame.ckpt` |
+| **Autoencoder ckpt** | `complexa_ae.ckpt` | `complexa_ligand_ae.ckpt` | `complexa_ame_ae.ckpt` |
+| **Targets dict** | `configs/targets/targets_dict.yaml` | `configs/targets/ligand_targets_dict.yaml` | `configs/design_tasks/ame_dict_v2.yaml` |
+| **Task-name pattern** | `<NN>_<NAME>` (e.g. `02_PDL1`, `22_DerF21`) | `<NN>_<PDB>_LIGAND` (e.g. `39_7V11_LIGAND`) | `M####_<pdb>` (e.g. `M0096_1chm`) |
+| **`USE_V2_COMPLEXA_ARCH`** | (unset → v1) | (unset → v1) | `"True"` (set in YAML) |
+| **LoRA** | (none) | required (`r=32, alpha=64`) | required |
+| **Default search algo** | `best-of-n` | `best-of-n` | `single-pass` |
+| **Reward model** | AF2 (`af2folding`) | RF3 (`rf3folding`) | `null` (no reward at default) |
+| **Inverse folder** | `soluble_mpnn` | `ligand_mpnn` | `ligand_mpnn` |
+| **Default refold backend** | `colabdesign` (AF2) | `rf3_latest` | `rf3_latest` |
+| **Analysis `result_type`** | `protein_binder` | `ligand_binder` | `motif_ligand_binder` |
+| **Required ckpts (`complexa download`)** | `--complexa --all` (AF2 in community) | `--complexa-ligand --all` (RF3 in community) | `--complexa-ame --all` (RF3 in community) |
+
+For the full per-pipeline breakdown (reward weights, success thresholds,
+analysis modes), see [reference/pipelines.md](reference/pipelines.md).
+
+## Step 3: Gather parameters
+
+Use AskUserQuestion to fill in the four parameters that vary every run. Default
+to sensible production settings if the user has no preference.
+
+- **Target name** — must be a key in the relevant dict (`targets_dict.yaml` for
+  protein binder, `ligand_targets_dict.yaml` for ligand, `ame_dict_v2.yaml` for
+  AME). If the user names a target that is not in the dict, hand off to
+  `complexa-target` to add it first.
+- **Run name** — a short identifier appended to the output dir (e.g. `pdl1_v1`).
+- **Search algorithm** — default to `beam-search` with `beam_width=8` and
+  `n_branch=4` for production. Use `single-pass` for a quick smoke test.
+- **Evaluation refold backend** — protein binder defaults to `colabdesign`
+  (AF2); ligand/AME default to `rf3_latest`. Use `esmfold` for fast iteration
+  (worse but seconds per sample).
+
+## Step 4: Validate
+
+Validate before running. This is cheap (seconds) and catches missing ckpts,
+missing env vars, unknown override keys, and missing target entries — all of
+which would otherwise abort the pipeline mid-evaluation after hours of
+generation.
+
+```bash
+complexa validate design configs/search_binder_local_pipeline.yaml \
+    ++generation.task_name=02_PDL1 \
+    ++metric.binder_folding_method=colabdesign
+```
+
+The validator returns non-zero on failure and prints a pass/fail report.
+Re-run the command with the suggested overrides until it returns clean.
+
+## Step 5: Run the pipeline
+
+`complexa design` is the right tool for the full 4-stage run — it orchestrates
+`generate → filter → evaluate → analyze` as sequential subprocesses with a
+shared run name, log dir, and multi-GPU split (see `run_design_pipeline` in
+`src/proteinfoundation/cli/cli_runner.py`). Re-implementing that manually
+loses the per-stage log routing and progress prints.
+
+Use `++` (forced) Hydra overrides; they apply to all stages. The minimal
+production protein-binder invocation:
+
+```bash
+complexa design configs/search_binder_local_pipeline.yaml \
+    ++run_name=pdl1_v1 \
+    ++generation.task_name=02_PDL1 \
+    ++generation.search.algorithm=beam-search \
+    ++generation.search.beam_search.beam_width=8 \
+    ++metric.binder_folding_method=colabdesign
+```
+
+For ligand binder / AME, swap the pipeline YAML and target name per Step 2's
+cheat sheet — every other override above is pipeline-agnostic and can be
+reused as-is.
+
+Add `--verbose` to stream logs to the terminal instead of `./logs/`. The skill
+does not poll progress — the user re-invokes if they want a status; point them
+at `complexa status` and `./logs/design_pipeline_*/`.
+
+### Direct module invocation (debug fallback)
+
+To debug a single stage without pipeline orchestration, invoke the underlying
+Hydra module directly. `complexa generate CONFIG` is just a logged subprocess
+wrapper around this:
+
+```bash
+python -m proteinfoundation.generate \
+    --config-path "$(realpath configs)" \
+    --config-name search_binder_local_pipeline \
+    ++run_name=debug_pdl1 \
+    ++generation.task_name=02_PDL1
+```
+
+Same pattern for `proteinfoundation.{filter,evaluate,analyze}`. Use this when
+you want to attach `ipdb`, run under `nsys`, or skip the pipeline log dir.
+Prefer `complexa generate/filter/evaluate/analyze` for normal one-shot runs
+(you get logging and parallel job splitting for free).
+
+**AME-specific gotcha (when running AME with RF3 refold)**: RF3 will try to
+complete missing atoms on the ligand based on its CCD code, which produces
+shape errors in RMSD calculations and the wrong structure. Before RF3 sees the
+PDB, rename the ligand residue to `L:0` so RF3 treats it as a generic ligand
+and skips atom completion. If your AME generation outputs already encode the
+ligand this way (the canonical Complexa pipeline does), no extra step is
+needed; otherwise patch each PDB with `atomworks.io`:
+
+```python
+from atomworks.io import load_any, to_pdb_file
+atom_array = load_any("my_design.pdb")[0]
+ligand_mask = atom_array.chain_id == "A"
+atom_array.res_name[ligand_mask] = "L:0"
+to_pdb_file(atom_array, "my_design_rf3_ready.pdb")
+```
+
+Same applies if you're piping AME outputs into the `complexa-evaluate-pdbs`
+skill with an RF3 backend. Skip the rename for AF2/colabdesign refold or for
+non-AME pipelines.
+
+Wall-clock at default (`nsteps=400`, `beam_width=8`, `batch_size=16`, 100
+designs, colabdesign eval) is ~30–120 minutes on a single A100/H100.
+
+## Step 6: Collect results
+
+Outputs land in two directories. Surface both:
+
+```bash
+ls ./inference/${CONFIG_STEM}_${TASK}_*${RUN_NAME}/   # generated PDBs + filter
+ls ./evaluation_results/${RUN_NAME}/                  # per-design CSV + analysis
+```
+
+Read the combined results CSV and summarize:
+
+```bash
+ls ./evaluation_results/*/binder_results_*_combined.csv
+ls ./evaluation_results/*/motif_binder_results_*_combined.csv  # AME
+ls ./evaluation_results/*/res_filter_*_pass_*.csv              # success rate
+ls ./evaluation_results/*/res_div_foldseek_*.csv               # FoldSeek diversity
+```
+
+Pull the success rate from `res_filter_binder_pass_*.csv`, the per-design
+metrics (interface pAE, pLDDT, scRMSD) from the combined CSV, and FoldSeek
+TM-score diversity from `res_div_foldseek_*.csv`. Report top-N designs by
+i_pAE (protein binder) or min_ipAE (ligand binder).
+
+## Step 7: Emit manifest
+
+Drop a JSON manifest beside the results so the run is replayable. The shared
+helper captures the command, config, git SHA, and pointers to the result CSVs.
+
+```bash
+python3 .claude/skills/_shared/scripts/write_manifest.py \
+    --output-dir ./evaluation_results/${RUN_NAME} \
+    --command "complexa design configs/search_binder_local_pipeline.yaml ++run_name=${RUN_NAME} ++generation.task_name=${TASK}" \
+    --skill complexa-design \
+    --out ./run_manifest.json
+```
+
+Surface the manifest path and the result CSV to the user.
+
+## Most-common overrides
+
+The 10 overrides that cover ~90% of runs. Full reference (every key, type,
+default) is in [reference/overrides.md](reference/overrides.md).
+
+| Override | Default | What it controls |
+|----------|---------|------------------|
+| `++generation.task_name=<name>` | (per config) | Which target / AME task to design for |
+| `++run_name=<str>` | (config stem) | Output dir suffix and CSV tag |
+| `++generation.search.algorithm=beam-search` | `best-of-n` (binder/ligand), `single-pass` (AME) | Search strategy |
+| `++generation.search.beam_search.beam_width=8` | `4` | Beam-search width (more = better designs, slower) |
+| `++generation.args.nsteps=200` | `400` | Diffusion steps (fewer = faster, lower quality) |
+| `++generation.dataloader.batch_size=8` | `16` (binder/ligand/AME) | Drop to 8 on a 40GB GPU |
+| `++generation.filter.filter_samples_limit=500` | `1000` | Top-N samples to keep after filtering |
+| `++metric.binder_folding_method=esmfold` | `colabdesign` (binder), `rf3_latest` (ligand/AME) | Evaluation refold backend |
+| `++metric.num_redesign_seqs=8` | `2` | ProteinMPNN/LigandMPNN/SolubleMPNN sequences per design |
+| `++aggregation.success_thresholds.i_pAE.threshold=10.0` | `7.0` (protein binder) | Loosen / tighten success criteria |
+
+## Hardware requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| GPU | 1x CUDA GPU, 40 GB VRAM | A100 / H100 / L40S, 80 GB VRAM |
+| CPUs | 16 | 24 (the `ncpus_` default in every pipeline config) |
+| Disk | 50 GB at `./inference/` + `./evaluation_results/` | 200 GB for sweep runs |
+| RAM | 32 GB | 64 GB+ |
+
+Typical wall-clock for 100 designs, `beam_width=8`, default `nsteps=400`:
+
+- Protein binder + colabdesign refold: ~60–120 min on 1x A100/H100.
+- Ligand binder + RF3 refold: ~90–180 min (RF3 dominates).
+- AME + RF3 refold: ~120–240 min.
+- Any pipeline + ESMFold refold: ~30–60 min (fast iteration).
+
+Bumping `gen_njobs=2` and `eval_njobs=2` halves wall-clock on a 2-GPU host. See
+`.claude/skills/_shared/reference/hardware.md` for per-pipeline VRAM tables.
+
+## Troubleshooting (common cases)
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `CUDA out of memory` in generate | `batch_size: 16` too big on 40GB GPU | `++generation.dataloader.batch_size=8` |
+| `CUDA out of memory` in evaluate | AF2 / RF3 batched too aggressively | `++eval_njobs=1` and `++metric.num_redesign_seqs=2` |
+| `InterpolationKeyError: AF2_DIR` | colabdesign eval but `.env` does not set `AF2_DIR` | Set `AF2_DIR` in `.env` or `++metric.binder_folding_method=esmfold` |
+| `InterpolationKeyError: RF3_CKPT_PATH` | RF3 eval but RF3 not installed | `complexa download --all` or switch eval backend |
+| `KeyError: 'task_name' not in target_dict_cfg` | Target not in `targets_dict.yaml` / `ligand_targets_dict.yaml` / `ame_dict_v2.yaml` | Use `complexa-target` skill to add it |
+| 0 designs pass success thresholds | Defaults too strict for this target | Loosen via `++aggregation.success_thresholds.*` |
+
+For the full list (chain-ID mismatches, hotspot residues, ligand residue
+renaming for RF3, missing inverse-folding models, etc.) see
+[reference/troubleshooting.md](reference/troubleshooting.md).
+
+---
+
+For per-pipeline details (which model, reward, inverse folding, evaluation
+backend, `result_type`, LoRA settings, `USE_V2_COMPLEXA_ARCH` toggle), see
+[reference/pipelines.md](reference/pipelines.md).
+
+For the full override reference (every `generation.*`, `metric.*`,
+`aggregation.*` key with type, default, example, and effect), see
+[reference/overrides.md](reference/overrides.md).
+
+For all troubleshooting cases (cause + fix + source), see
+[reference/troubleshooting.md](reference/troubleshooting.md).

--- a/plugins/bionemo-agent-toolkit/skills/complexa-design/reference/overrides.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-design/reference/overrides.md
@@ -1,0 +1,246 @@
+# Override Reference
+
+Every common `++` override grouped by stage. Each row: key, type, default,
+example, what it controls. Defaults come from the actual YAML files under
+`configs/pipeline/` — when this doc disagrees with the config, the config
+wins.
+
+All overrides use Hydra `++` (forced) syntax — `+` would error on keys not
+already in the config. Apply to a `complexa design` invocation; they propagate
+to all four stages (generate, filter, evaluate, analyze).
+
+## Top-level (pipeline YAML)
+
+These live at the root of `configs/search_*_pipeline.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `run_name` | str | (config stem, e.g. `search_binder_local`) | `++run_name=pdl1_v1` | Suffix for output dirs and log file names |
+| `ckpt_path` | str | `${oc.env:CKPT_PATH}` | `++ckpt_path=/data/ckpts` | Directory containing the model and AE checkpoints |
+| `ckpt_name` | str | per pipeline: `complexa.ckpt` / `complexa_ligand.ckpt` / `complexa_ame.ckpt` | `++ckpt_name=complexa.ckpt` | Which model checkpoint to load |
+| `autoencoder_ckpt_path` | str | `${oc.env:CKPT_PATH}/complexa[_ligand\|_ame]_ae.ckpt` | `++autoencoder_ckpt_path=/data/my_ae.ckpt` | AE checkpoint path |
+| `seed` | int | `5` | `++seed=42` | Sampling RNG seed |
+| `ncpus_` | int | `24` | `++ncpus_=16` | CPU count for dataloader workers |
+| `gen_njobs` | int | `2` (binder/ligand/AME) | `++gen_njobs=4` | Number of parallel generate jobs |
+| `eval_njobs` | int | `2` (binder/ligand/AME) | `++eval_njobs=4` | Number of parallel evaluate jobs |
+| `lora.r` | int | `32` (ligand/AME), (unset for protein binder) | `++lora.r=64` | LoRA rank |
+| `lora.lora_alpha` | float | `64.0` | `++lora.lora_alpha=128.0` | LoRA scaling factor (typically 2x rank) |
+| `lora.lora_dropout` | float | `0.0` | `++lora.lora_dropout=0.1` | Dropout on LoRA inputs |
+| `lora.train_bias` | enum | `none` | `++lora.train_bias=lora_only` | Bias training: `none`, `all`, `lora_only` |
+| `env_vars.USE_V2_COMPLEXA_ARCH` | str | `"True"` (AME), unset (binder/ligand) | `++env_vars.USE_V2_COMPLEXA_ARCH=True` | Architecture toggle; injected into subprocess env |
+
+## Generation — target and dataloader
+
+Group `generation.*`. See `configs/pipeline/binder/binder_generate.yaml` and
+the per-pipeline variants.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.task_name` | str | per config (e.g. `33_TrkA`, `39_7V11_LIGAND`, `M0096_1chm`) | `++generation.task_name=02_PDL1` | Target / AME task; must be a key in the relevant dict |
+| `generation.dataloader.batch_size` | int | `16` (binder/ligand/AME) | `++generation.dataloader.batch_size=8` | Samples per forward pass; drop on OOM |
+| `generation.dataloader.dataset.nres.low` | int | per-target binder_length[0] | `++generation.dataloader.dataset.nres.low=80` | Minimum binder / scaffold length |
+| `generation.dataloader.dataset.nres.high` | int | per-target binder_length[1] | `++generation.dataloader.dataset.nres.high=120` | Maximum binder / scaffold length |
+| `generation.dataloader.dataset.nres.nsamples` | int | `4` (binder), `2` (ligand), `4` (AME) | `++generation.dataloader.dataset.nres.nsamples=200` | Number of length samples per pipeline |
+| `generation.dataloader.dataset.nres.endpoint` | bool | `true` | `++generation.dataloader.dataset.nres.endpoint=false` | Include high in length range |
+| `generation.dataloader.dataset.nrepeat_per_sample` | int | `1` | `++generation.dataloader.dataset.nrepeat_per_sample=4` | How many designs per length sample |
+
+## Generation — diffusion sampling (`generation.args.*`)
+
+From `configs/pipeline/model_sampling.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.args.nsteps` | int | `400` | `++generation.args.nsteps=200` | Diffusion / flow-matching steps; lower = faster, lower quality |
+| `generation.args.self_cond` | bool | `True` | `++generation.args.self_cond=False` | Self-conditioning during sampling |
+| `generation.args.guidance_w` | float | `1.0` | `++generation.args.guidance_w=2.0` | Classifier-free guidance weight |
+| `generation.args.ag_ratio` | float | `0.0` | `++generation.args.ag_ratio=0.1` | Autoguidance mixing ratio |
+| `generation.args.ag_ckpt_path` | str\|null | `null` | `++generation.args.ag_ckpt_path=/path/to/ag.ckpt` | Autoguidance checkpoint |
+| `generation.args.save_trajectory_every` | int | `0` | `++generation.args.save_trajectory_every=50` | Snapshot interval (0 = disabled) |
+| `generation.args.fold_cond` | bool | `False` | `++generation.args.fold_cond=True` | Use fold conditioning |
+| `generation.n_recycle` | int | `0` | `++generation.n_recycle=1` | Recycling iterations |
+
+## Generation — search algorithm (`generation.search.*`)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.search.algorithm` | enum | `best-of-n` (binder, ligand), `single-pass` (AME) | `++generation.search.algorithm=beam-search` | Strategy: `single-pass`, `best-of-n`, `beam-search`, `fk-steering`, `mcts` |
+| `generation.search.max_batch_size` | int | inherits `dataloader.batch_size` | `++generation.search.max_batch_size=8` | Max samples per forward pass during search |
+| `generation.search.reward_threshold` | float\|null | `null` | `++generation.search.reward_threshold=0.5` | Filter lookahead samples by reward |
+| `generation.search.step_checkpoints` | list[int] | `[0, 100, 200, 300, 400]` | `++generation.search.step_checkpoints=[0,200,400]` | Diffusion-step checkpoints used by all algorithms |
+| `generation.search.best_of_n.replicas` | int | `2` | `++generation.search.best_of_n.replicas=4` | best-of-n replica count |
+| `generation.search.beam_search.beam_width` | int | `4` | `++generation.search.beam_search.beam_width=8` | Beam-search width |
+| `generation.search.beam_search.n_branch` | int | `4` | `++generation.search.beam_search.n_branch=8` | Beam-search branch factor |
+| `generation.search.beam_search.keep_lookahead_samples` | bool | `true` | `++generation.search.beam_search.keep_lookahead_samples=false` | Keep intermediate beam samples |
+| `generation.search.beam_search.save_intermediate_states` | bool | `false` | `++generation.search.beam_search.save_intermediate_states=true` | Save PDBs at each checkpoint (expensive) |
+| `generation.search.fk_steering.beam_width` | int | `4` | `++generation.search.fk_steering.beam_width=8` | FK-steering beam width |
+| `generation.search.fk_steering.n_branch` | int | `4` | `++generation.search.fk_steering.n_branch=8` | FK-steering branch factor |
+| `generation.search.fk_steering.temperature` | float | `0.1` | `++generation.search.fk_steering.temperature=0.5` | FK-steering softmax temperature |
+| `generation.search.fk_steering.keep_lookahead_samples` | bool | `true` | `++generation.search.fk_steering.keep_lookahead_samples=false` | Keep lookahead samples |
+| `generation.search.mcts.n_simulations` | int | `20` | `++generation.search.mcts.n_simulations=50` | MCTS simulations per node |
+| `generation.search.mcts.exploration_prob` | float | `0.5` | `++generation.search.mcts.exploration_prob=0.7` | MCTS exploration probability |
+| `generation.search.mcts.exploration_constant` | float | `1.0` | `++generation.search.mcts.exploration_constant=1.4` | MCTS exploration constant |
+| `generation.search.mcts.keep_lookahead_samples` | bool | `true` | `++generation.search.mcts.keep_lookahead_samples=false` | Keep MCTS lookaheads |
+
+## Generation — refinement (`generation.refinement.*`)
+
+Refinement is disabled by default. Enable `sequence_hallucination` for AF2-loss
+post-hoc optimization of the binder sequence.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.refinement.algorithm` | enum\|null | `null` | `++generation.refinement.algorithm=sequence_hallucination` | Enable refinement |
+| `generation.refinement.refine_targets` | enum | `final` | `++generation.refinement.refine_targets=all` | What to refine: `final` (samples) or `all` (final + lookaheads) |
+| `generation.refinement.save_pre_refinement` | enum | `none` | `++generation.refinement.save_pre_refinement=final` | Also save pre-refinement copies |
+| `generation.refinement.enable_soft_optimization` | bool | `false` | `++generation.refinement.enable_soft_optimization=true` | Stages 2 + 3 (softmax + one-hot) |
+| `generation.refinement.enable_greedy_optimization` | bool | `true` | `++generation.refinement.enable_greedy_optimization=false` | Stage 4 (PSSM semigreedy) |
+| `generation.refinement.n_temp_iters` | int | `45` | `++generation.refinement.n_temp_iters=60` | Temperature-anneal iterations |
+| `generation.refinement.n_hard_iters` | int | `5` | `++generation.refinement.n_hard_iters=10` | Hard one-hot iterations |
+| `generation.refinement.n_recycles` | int | `3` | `++generation.refinement.n_recycles=5` | AF2 recycling during refinement |
+| `generation.refinement.n_greedy_iters` | int | `15` | `++generation.refinement.n_greedy_iters=30` | Greedy iterations |
+| `generation.refinement.greedy_percentage` | int | `1` | `++generation.refinement.greedy_percentage=5` | Greedy fraction |
+| `generation.refinement.loss_weights.{pae,plddt,i_pae,con,i_con,dgram_cce,rg,i_ptm,helix_binder}` | float | various (see `binder_generate.yaml`) | `++generation.refinement.loss_weights.rg=0.5` | AF2 loss term weights during refinement |
+
+## Generation — post-generation filter (`generation.filter.*`)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.filter.filter_samples_limit` | int\|null | `1000` (binder/ligand/AME) | `++generation.filter.filter_samples_limit=500` | Max samples after filtering (top-N by reward) |
+| `generation.filter.delete_non_top_n_samples` | bool | `false` (binder), `true` (ligand, AME) | `++generation.filter.delete_non_top_n_samples=false` | Delete vs move filtered-out samples |
+| `generation.filter.dedup_sequence` | bool | `true` | `++generation.filter.dedup_sequence=false` | Drop duplicate sequences before ranking |
+| `generation.filter.reward_threshold` | float\|null | `null` | `++generation.filter.reward_threshold=0.3` | Drop samples below this reward before top-N |
+
+## Generation — reward model (`generation.reward_model.*`)
+
+Reward weights apply to the named sub-model inside the `CompositeRewardModel`.
+The protein binder pipeline uses `af2folding`; ligand binder and AME (when
+reward is enabled) use `rf3folding`. Other reward models (`tmol`,
+`bioinformatics`, `hbplus`, `boltz2folding`, `hbplus_af2`, `hbplus_boltz2`,
+`rf3folding`) are pre-wired but commented out — uncomment in the YAML or add
+via override.
+
+### `af2folding` reward weights (protein binder)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.reward_model.reward_models.af2folding.reward_weights.i_pae` | float | `-1.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.i_pae=-2.0` | Interface PAE weight (negative = minimize) |
+| `...af2folding.reward_weights.plddt` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.plddt=0.5` | pLDDT weight (positive = maximize) |
+| `...af2folding.reward_weights.con` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.con=1.0` | Intra-binder contact loss |
+| `...af2folding.reward_weights.dgram_cce` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.dgram_cce=0.5` | Distogram cross-entropy |
+| `...af2folding.reward_weights.min_ipae` | float | `0.0` | `++generation.reward_model.reward_models.af2folding.reward_weights.min_ipae=-1.0` | Minimum interface PAE |
+| `...af2folding.reward_weights.{min,max,avg}_ipsae[_10]` | float | `0.0` | `++...avg_ipsae=0.5` | Interface pSAE family |
+| `...af2folding.num_recycles` | int | `3` | `++generation.reward_model.reward_models.af2folding.num_recycles=4` | AF2 recycling iterations |
+| `...af2folding.use_initial_guess` | bool | `True` | `++generation.reward_model.reward_models.af2folding.use_initial_guess=False` | Warm-start AF2 from generated structure |
+| `...af2folding.use_initial_atom_pos` | bool | `False` | `++generation.reward_model.reward_models.af2folding.use_initial_atom_pos=True` | Use initial atom positions |
+| `...af2folding.protocol` | enum | `binder` | `++generation.reward_model.reward_models.af2folding.protocol=binder` | AF2 protocol |
+| `...af2folding.use_multimer` | bool | `True` | `++generation.reward_model.reward_models.af2folding.use_multimer=False` | Use AF2-multimer |
+
+### `rf3folding` reward weights (ligand binder, AME)
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `generation.reward_model.reward_models.rf3folding.reward_weights.min_ipAE` | float | `-1.0` | `++generation.reward_model.reward_models.rf3folding.reward_weights.min_ipAE=-2.0` | Minimum interface PAE weight |
+| `...rf3folding.reward_weights.plddt` | float | `0.0` | `++...rf3folding.reward_weights.plddt=0.5` | pLDDT weight |
+| `...rf3folding.reward_weights.ipAE` | float | `0.0` | `++...rf3folding.reward_weights.ipAE=-0.5` | Interface PAE weight |
+| `...rf3folding.reward_weights.{mean_min_ipAE,mean_ipAE,min_mean_ipAE,pAE,ipTM,pTM,ranking_score}` | float | `0.0` | `++...rf3folding.reward_weights.ipTM=1.0` | RF3 confidence metrics |
+| `...rf3folding.reward_weights.has_clash` | float | `0.0` | `++...rf3folding.reward_weights.has_clash=-5.0` | Clash penalty (1.0 if clash; negative = penalize) |
+| `...rf3folding.reward_weights.{min,max,avg}_ipSAE` | float | `0.0` | `++...rf3folding.reward_weights.min_ipSAE=1.0` | Interface pSAE family |
+| `...rf3folding.normalize_pae` | bool | `true` | `++...rf3folding.normalize_pae=false` | Divide PAE metrics by 31 to map to 0-1 |
+| `...rf3folding.ckpt_path` | str | `${oc.env:RF3_CKPT_PATH}` | `++...rf3folding.ckpt_path=/data/rf3.pt` | RF3 checkpoint path |
+| `...rf3folding.rf3_path` | str | `${oc.env:RF3_EXEC_PATH}` | `++...rf3folding.rf3_path=/opt/rf3` | RF3 executable directory |
+
+## Evaluation (`metric.*`)
+
+From `binder_evaluate.yaml`, `ligand_binder_evaluate.yaml`, `ame_evaluate.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `protein_type` | enum | `binder` (binder/ligand), `motif_binder` (AME) | `++protein_type=binder` | Selects which metric path runs |
+| `input_mode` | enum | `generated` | `++input_mode=pdb_dir` | `generated` for design pipeline; `pdb_dir` for external PDBs |
+| `metric.compute_binder_metrics` | bool | `true` (binder/ligand) | `++metric.compute_binder_metrics=true` | Run binder refolding |
+| `metric.compute_motif_binder_metrics` | bool | (AME only) `true` | `++metric.compute_motif_binder_metrics=false` | Run joint motif + binder metrics |
+| `metric.binder_folding_method` | enum | `colabdesign` (binder), `rf3_latest` (ligand, AME) | `++metric.binder_folding_method=esmfold` | Refold backend: `colabdesign`, `rf3_latest`, `boltz2_default`, `esmfold` |
+| `metric.sequence_types` | list | `[self]` (binder default), `[self, mpnn]` (ligand), `[self, mpnn_fixed]` (AME) | `++metric.sequence_types=[self,mpnn,mpnn_fixed]` | Which inverse-folding outputs to evaluate |
+| `metric.num_redesign_seqs` | int | `2` | `++metric.num_redesign_seqs=8` | Sequences generated per design by the inverse folder |
+| `metric.inverse_folding_model` | enum | `soluble_mpnn` (binder), `ligand_mpnn` (ligand, AME) | `++metric.inverse_folding_model=protein_mpnn` | `protein_mpnn`, `ligand_mpnn`, `soluble_mpnn` |
+| `metric.interface_cutoff` | float | (binder/ligand) `8.0` | `++metric.interface_cutoff=6.0` | Interface-residue distance cutoff in Angstroms |
+| `metric.ranking_criteria` | dict\|null | `null` (default: minimize i_pAE for protein, min_ipAE for ligand) | `++metric.ranking_criteria.i_pAE.scale=1.0` | Custom composite-score ranking |
+| `metric.motif_ranking_criteria` | dict\|null | `null` | `++metric.motif_ranking_criteria.motif_rmsd_pred.scale=1.0` | Custom motif-binder ranking (AME) |
+| `metric.compute_esm_metrics` | bool | `true` (binder, ligand, AME) | `++metric.compute_esm_metrics=false` | Compute ESM pseudo-perplexity |
+| `metric.compute_pre_refolding_metrics` | bool | `false` (binder, ligand), `true` (AME) | `++metric.compute_pre_refolding_metrics=true` | Pre-refolding bioinformatics/TMOL/HBPLUS |
+| `metric.pre_refolding.bioinformatics` | bool | `true` | `++metric.pre_refolding.bioinformatics=false` | SC, SASA, hydrophobicity on generated |
+| `metric.pre_refolding.tmol` | bool | `true` | `++metric.pre_refolding.tmol=false` | TMOL forcefield on generated |
+| `metric.pre_refolding.hbplus` | bool | `true` | `++metric.pre_refolding.hbplus=false` | HBPLUS H-bond on generated |
+| `metric.compute_refolded_structure_metrics` | bool | `false` (binder, ligand), `true` (AME) | `++metric.compute_refolded_structure_metrics=true` | Same set on refolded |
+| `metric.refolded.{bioinformatics,tmol,hbplus}` | bool | `true` | `++metric.refolded.tmol=false` | Same toggles, refolded structure |
+| `metric.compute_monomer_metrics` | bool | `true` (binder, ligand), `false` (AME) | `++metric.compute_monomer_metrics=true` | Run monomer designability / codesignability |
+| `metric.monomer_folding_models` | list | `[esmfold]` | `++metric.monomer_folding_models=[esmfold,colabfold]` | Folding models for monomer metrics |
+| `metric.compute_designability` | bool | `true` | `++metric.compute_designability=false` | Designability (ProteinMPNN -> fold) |
+| `metric.designability_modes` | list | `[ca]` | `++metric.designability_modes=[ca,all_atom]` | RMSD modes for designability |
+| `metric.compute_codesignability` | bool | `true` | `++metric.compute_codesignability=false` | Codesignability (fold original sequence) |
+| `metric.codesignability_modes` | list | `[ca, all_atom]` | `++metric.codesignability_modes=[ca]` | RMSD modes for codesignability |
+| `metric.compute_co_sequence_recovery` | bool | `false` | `++metric.compute_co_sequence_recovery=true` | Compare MPNN vs original sequence |
+| `metric.compute_ss` | bool | `true` (binder) | `++metric.compute_ss=false` | Secondary-structure fractions via biotite |
+| `metric.compute_novelty_pdb` | bool | `false` | `++metric.compute_novelty_pdb=true` | Novelty vs PDB |
+| `metric.compute_novelty_afdb` | bool | `false` | `++metric.compute_novelty_afdb=true` | Novelty vs AlphaFold DB |
+| `metric.compute_novelty_afdb_rep_v4` | bool | `false` | `++metric.compute_novelty_afdb_rep_v4=true` | Novelty vs AFDB rep v4 |
+| `metric.keep_folding_outputs` | bool | `true` (binder, AME), `false` (ligand) | `++metric.keep_folding_outputs=false` | Keep refolded PDBs on disk |
+
+## Analysis (`aggregation.*`)
+
+From `binder_analyze.yaml`, `ligand_binder_analyze.yaml`, `ame_analyze.yaml`.
+
+| Key | Type | Default | Example override | What it controls |
+|-----|------|---------|------------------|------------------|
+| `result_type` | enum | per pipeline | `++result_type=protein_binder` | One of: `protein_binder`, `ligand_binder`, `monomer`, `motif_protein_binder`, `motif_ligand_binder` |
+| `aggregation.limit` | int\|null | `null` | `++aggregation.limit=200` | Limit number of result files merged (null = all) |
+| `aggregation.analysis_modes` | list | `[binder, monomer]` (binder, ligand), `[motif_binder, monomer]` (AME) | `++aggregation.analysis_modes=[binder]` | Which analysis functions to run |
+| `aggregation.success_thresholds.i_pAE.threshold` | float | `7.0` (protein_binder) | `++aggregation.success_thresholds.i_pAE.threshold=10.0` | Interface PAE threshold (after `* scale`) |
+| `aggregation.success_thresholds.i_pAE.op` | str | `<=` | `++aggregation.success_thresholds.i_pAE.op=<` | Comparison operator |
+| `aggregation.success_thresholds.i_pAE.scale` | float | `31.0` | `++aggregation.success_thresholds.i_pAE.scale=1.0` | Scale factor applied before comparison |
+| `aggregation.success_thresholds.i_pAE.column_prefix` | str | `complex` | `++aggregation.success_thresholds.i_pAE.column_prefix=complex` | Column-name prefix |
+| `aggregation.success_thresholds.pLDDT.threshold` | float | `0.9` (protein_binder), `0.8` (AME) | `++aggregation.success_thresholds.pLDDT.threshold=0.85` | pLDDT threshold |
+| `aggregation.success_thresholds.pLDDT.op` | str | `>=` | `++aggregation.success_thresholds.pLDDT.op=>=` | Comparison operator |
+| `aggregation.success_thresholds.scRMSD.threshold` | float | `1.5` (protein_binder), `2.0` (ligand_binder, AME) | `++aggregation.success_thresholds.scRMSD.threshold=2.0` | scRMSD threshold |
+| `aggregation.success_thresholds.scRMSD.op` | str | `<` | `++aggregation.success_thresholds.scRMSD.op=<=` | Comparison operator |
+| `aggregation.success_thresholds.scRMSD.column_prefix` | str | `binder` | `++aggregation.success_thresholds.scRMSD.column_prefix=binder` | Column-name prefix |
+| `aggregation.motif_binder_success_thresholds.motif_rmsd_pred.threshold` | float | `1.5` (motif_ligand_binder), `2.0` (motif_protein_binder) | `++aggregation.motif_binder_success_thresholds.motif_rmsd_pred.threshold=1.0` | Motif RMSD in refolded structure |
+| `aggregation.motif_binder_success_thresholds.motif_seq_recovery.threshold` | float | `0.5` (AME default), `1.0` (motif protein binder default) | `++aggregation.motif_binder_success_thresholds.motif_seq_recovery.threshold=0.8` | Motif sequence recovery threshold |
+| `aggregation.designability_thresholds.ca.esmfold.threshold` | float | `2.0` | `++aggregation.designability_thresholds.ca.esmfold.threshold=1.5` | Designability CA-scRMSD threshold |
+| `aggregation.ca_codesignability_thresholds.ca.esmfold.threshold` | float | `2.0` | `++aggregation.ca_codesignability_thresholds.ca.esmfold.threshold=1.5` | CA codesignability threshold |
+| `aggregation.allatom_codesignability_thresholds.all_atom.esmfold.threshold` | float | `2.0` | `++aggregation.allatom_codesignability_thresholds.all_atom.esmfold.threshold=2.5` | All-atom codesignability threshold |
+| `aggregation.require_all_thresholds` | bool | `false` | `++aggregation.require_all_thresholds=true` | AND vs OR across thresholds |
+| `aggregation.compute_diversity` | bool | `true` (AME), unset elsewhere | `++aggregation.compute_diversity=false` | FoldSeek diversity |
+| `aggregation.compute_mmseqs_diversity` | bool | `true` (AME) | `++aggregation.compute_mmseqs_diversity=true` | MMseqs2 sequence diversity |
+
+## Common override patterns
+
+Cheat-sheet of full overrides users run frequently.
+
+```bash
+# Production beam-search on PDL1
+++generation.task_name=02_PDL1 \
+++generation.search.algorithm=beam-search \
+++generation.search.beam_search.beam_width=8 \
+++generation.search.beam_search.n_branch=4 \
+++run_name=pdl1_beam_v1
+
+# Fast smoke test (single-pass, fewer steps, smaller batch)
+++generation.search.algorithm=single-pass \
+++generation.args.nsteps=100 \
+++generation.dataloader.dataset.nres.nsamples=2 \
+++run_name=quick_test
+
+# Cheap iteration with ESMFold eval
+++metric.binder_folding_method=esmfold \
+++metric.compute_pre_refolding_metrics=false \
+++metric.compute_refolded_structure_metrics=false
+
+# Stricter success thresholds for top-N filtering
+++aggregation.success_thresholds.i_pAE.threshold=5.0 \
+++aggregation.success_thresholds.scRMSD.threshold=1.0
+
+# Lower VRAM (40GB GPU)
+++generation.dataloader.batch_size=8 \
+++eval_njobs=1 \
+++metric.num_redesign_seqs=2
+```

--- a/plugins/bionemo-agent-toolkit/skills/complexa-design/reference/pipelines.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-design/reference/pipelines.md
@@ -1,0 +1,175 @@
+# Pipeline Reference
+
+The three `complexa design` pipelines side-by-side. Every row is sourced from a
+config file under `configs/pipeline/` or a top-level `configs/search_*.yaml`.
+When this doc disagrees with the configs, the configs win — re-read them.
+
+## Three pipelines
+
+| Aspect | Protein Binder | Ligand Binder | AME (motif + ligand) |
+|--------|----------------|---------------|----------------------|
+| Pipeline YAML | `configs/search_binder_local_pipeline.yaml` | `configs/search_ligand_binder_local_pipeline.yaml` | `configs/search_ame_local_pipeline.yaml` |
+| Generate config | `pipeline/binder/binder_generate.yaml` | `pipeline/ligand_binder/ligand_binder_generate.yaml` | `pipeline/ame/ame_generate.yaml` |
+| Evaluate config | `pipeline/binder/binder_evaluate.yaml` | `pipeline/ligand_binder/ligand_binder_evaluate.yaml` | `pipeline/ame/ame_evaluate.yaml` |
+| Analyze config | `pipeline/binder/binder_analyze.yaml` | `pipeline/ligand_binder/ligand_binder_analyze.yaml` | `pipeline/ame/ame_analyze.yaml` |
+| Model ckpt | `complexa.ckpt` | `complexa_ligand.ckpt` | `complexa_ame.ckpt` |
+| Autoencoder ckpt | `complexa_ae.ckpt` | `complexa_ligand_ae.ckpt` | `complexa_ame_ae.ckpt` |
+| LoRA | (none) | `r: 32, lora_alpha: 64.0` | `r: 32, lora_alpha: 64.0` |
+| `env_vars.USE_V2_COMPLEXA_ARCH` | (not set) | (not set) | `"True"` |
+| Targets dict | `configs/targets/targets_dict.yaml` | `configs/targets/ligand_targets_dict.yaml` | `configs/design_tasks/ame_dict_v2.yaml` |
+| Conditional features | `TargetFeatures` | `LigandFeatures` | `MotifFeatures` + `LigandFeatures` |
+| Default search algorithm | `best-of-n` | `best-of-n` | `single-pass` |
+| Generation reward model | AF2 (`af2folding`) | RF3 (`rf3folding`) | `null` (single-pass) |
+| Inverse-folding model | `soluble_mpnn` | `ligand_mpnn` | `ligand_mpnn` |
+| Evaluation `protein_type` | `binder` | `binder` | `motif_binder` |
+| Evaluation folding | `colabdesign` (AF2) | `rf3_latest` | `rf3_latest` |
+| Analysis `result_type` | `protein_binder` | `ligand_binder` | `motif_ligand_binder` |
+| Analysis modes | `[binder, monomer]` | `[binder, monomer]` | `[motif_binder, monomer]` |
+| Default `gen_njobs` / `eval_njobs` | 2 / 2 | 2 / 2 | 2 / 2 |
+| Default `dataloader.batch_size` | 16 | 16 | 16 |
+
+## Protein binder
+
+Designs a binder for a protein target. AF2 (ColabDesign) drives both the
+reward during search and the final evaluation refold. Uses `SolubleMPNN` for
+inverse folding so the redesigned binder is soluble.
+
+- Reward weights: `af2folding.reward_weights.i_pae = -1.0` (minimize interface
+  PAE). Other AF2 metrics (`con`, `plddt`, `dgram_cce`, `min_ipae`, `min_ipsae`,
+  `avg_ipsae`, `max_ipsae`, `min_ipsae_10`, `max_ipsae_10`, `avg_ipsae_10`)
+  default to 0.0 and can be enabled by override.
+- Default success thresholds: `i_pAE * 31 <= 7.0`, `pLDDT >= 0.9`, `scRMSD_ca <
+  1.5` Å.
+- Quick command:
+  ```bash
+  complexa design configs/search_binder_local_pipeline.yaml \
+      ++run_name=pdl1_v1 ++generation.task_name=02_PDL1
+  ```
+
+## Ligand binder
+
+Designs a binder for a small-molecule ligand. RF3 handles both reward and
+evaluation because it supports protein-ligand complexes. Uses `LigandMPNN` so
+the inverse-folded sequence is conditioned on the ligand.
+
+- Reward weights: `rf3folding.reward_weights.min_ipAE = -1.0` (minimize the
+  minimum interface PAE, normalized by 31). Other RF3 metrics (`plddt`, `ipAE`,
+  `mean_min_ipAE`, `mean_ipAE`, `min_mean_ipAE`, `pAE`, `ipTM`, `pTM`,
+  `ranking_score`, `has_clash`, `min_ipSAE`, `max_ipSAE`, `avg_ipSAE`) default
+  to 0.0.
+- Default success thresholds: `min_ipAE * 31 < 2.0`, `scRMSD_ca < 2.0` Å,
+  `ligand_scRMSD_aligned_allatom < 5.0` Å.
+- LoRA is required for the released ligand checkpoint (`r: 32, lora_alpha:
+  64.0, lora_dropout: 0.0, train_bias: none`) and is baked into
+  `search_ligand_binder_local_pipeline.yaml`.
+- Quick command:
+  ```bash
+  complexa design configs/search_ligand_binder_local_pipeline.yaml \
+      ++run_name=v11_v1 ++generation.task_name=39_7V11_LIGAND
+  ```
+
+## AME (motif + ligand binder)
+
+Combines `MotifFeatures` (atom-spec mode) with `LigandFeatures`. Designed for
+active-site / enzyme scaffolding: place a functional motif near a small-molecule
+ligand and let the model build the rest of the protein around them.
+
+- Generation reward defaults to `null` (single-pass). To enable reward-guided
+  search, uncomment the `CompositeRewardModel` block in `ame_generate.yaml` (it
+  pre-wires RF3) and switch `search.algorithm` to `best-of-n` or `beam-search`.
+- LoRA is required: `r: 32, lora_alpha: 64.0, lora_dropout: 0.0, train_bias:
+  none`.
+- `env_vars.USE_V2_COMPLEXA_ARCH: "True"` is set in
+  `search_ame_local_pipeline.yaml`. The CLI runner injects this into the
+  subprocess environment.
+- Default success thresholds (`motif_ligand_binder`): `i_pAE * 31 <= 10.0`,
+  `pLDDT >= 0.8`, `scRMSD < 2.0`, `motif_rmsd_pred < 1.5`, `motif_seq_recovery
+  >= 0.5`. The analysis is *joint*: a sample passes only when one redesign
+  satisfies binder + motif criteria simultaneously.
+- Pre- and post-refolding interface metrics are enabled (bioinformatics, TMOL,
+  HBPLUS).
+- Quick command:
+  ```bash
+  complexa design configs/search_ame_local_pipeline.yaml \
+      ++run_name=ame_chm ++generation.task_name=M0096_1chm
+  ```
+
+## LoRA settings
+
+Both non-protein pipelines (ligand binder, AME) require LoRA because their
+checkpoints (`complexa_ligand.ckpt`, `complexa_ame.ckpt`) were trained with
+LoRA adapters. The pipeline YAMLs declare:
+
+```yaml
+lora:
+  r: 32
+  lora_alpha: 64.0
+  lora_dropout: 0.0
+  train_bias: none
+```
+
+Removing the `lora:` block from the pipeline YAML will load the base weights
+without the LoRA delta and produce garbage. Leave it alone unless the user is
+fine-tuning their own LoRA — in which case override `r`, `lora_alpha`,
+`lora_dropout`, or `train_bias` via `++lora.r=64`.
+
+## `USE_V2_COMPLEXA_ARCH` toggle
+
+This env var picks between two on-disk architecture layouts. The CLI runner
+reads `env_vars:` from the pipeline YAML and injects them into the subprocess
+environment (see `cli_runner.py::run_step` -> `env.update(config.env_vars)`).
+
+| Pipeline | `USE_V2_COMPLEXA_ARCH` | Notes |
+|----------|------------------------|-------|
+| Protein binder | (not set; defaults to v1) | `complexa.ckpt` is v1 architecture. |
+| Ligand binder | (not set; defaults to v1) | `complexa_ligand.ckpt` is v1 architecture. |
+| AME | `"True"` | `complexa_ame.ckpt` is v2 architecture for the AME pipeline. |
+
+If the user sees `KeyError` or shape mismatches at model-load time, the most
+likely cause is the wrong `USE_V2_COMPLEXA_ARCH` value — the configs in the
+repo are correct, but a custom override (`++env_vars.USE_V2_COMPLEXA_ARCH=...`)
+can break it.
+
+## Evaluation `protein_type` and `result_type`
+
+`protein_type` (set in the evaluation config) controls *which metrics are
+computed*. `result_type` (set in the analysis config) controls *which default
+success thresholds apply*. They are paired:
+
+| Pipeline | `protein_type` | `result_type` |
+|----------|----------------|---------------|
+| Protein binder | `binder` | `protein_binder` |
+| Ligand binder | `binder` | `ligand_binder` |
+| AME | `motif_binder` | `motif_ligand_binder` |
+| Motif protein binder (standalone, not a `design` pipeline) | `motif_binder` | `motif_protein_binder` |
+
+The motif protein binder evaluation is not a top-level `design` pipeline; it
+runs via the standalone `evaluate_motif_binder.yaml` config on the outputs of a
+protein binder pipeline. Use the `complexa-evaluate-pdbs` skill for that
+workflow.
+
+## Evaluation types (summary)
+
+From `docs/EVALUATION_METRICS.md`, the types reachable from the three design
+pipelines:
+
+1. **Protein binder** (`protein_type: binder`, `result_type: protein_binder`) —
+   AF2 / RF3 / Boltz2 refold + SolubleMPNN redesign. Metrics: i_pAE, i_pTM,
+   pLDDT, binder scRMSD, complex scRMSD.
+2. **Ligand binder** (`protein_type: binder`, `result_type: ligand_binder`) —
+   RF3 refold + LigandMPNN. Adds min_ipAE, ipSAE, has_clash, ligand_scRMSD,
+   ligand_scRMSD_aligned_allatom.
+3. **Monomer** (`protein_type: monomer`) — ESMFold designability +
+   codesignability + secondary structure. Used as a component of binder
+   evaluation.
+4. **Motif protein binder** (`protein_type: motif_binder`, `result_type:
+   motif_protein_binder`) — Standalone variant of #1 + motif RMSD / sequence
+   recovery on the refolded structure. Run via `evaluate_motif_binder.yaml` on
+   protein-binder outputs, not a top-level design pipeline.
+5. **Motif ligand binder / AME** (`protein_type: motif_binder`, `result_type:
+   motif_ligand_binder`) — #2 + motif overlay + ligand clash detection on the
+   refolded structure. This is what `search_ame_local_pipeline.yaml` runs.
+
+Pass-rate columns land in `res_filter_*_pass_*.csv`; diversity columns in
+`res_div_foldseek_*.csv` and `res_div_mmseqs_*.csv`; per-design metrics in the
+combined CSV.

--- a/plugins/bionemo-agent-toolkit/skills/complexa-design/reference/troubleshooting.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-design/reference/troubleshooting.md
@@ -1,0 +1,284 @@
+# Troubleshooting Reference
+
+Symptoms, causes, and fixes for `complexa design` failures. Sourced from
+`docs/INFERENCE.md` "Troubleshooting", `docs/EVALUATION_METRICS.md`, and the
+pipeline configs themselves.
+
+## GPU OOM during generation
+
+**Symptom:** `torch.cuda.OutOfMemoryError` during the `generate` step;
+process dies before the first PDB is written.
+
+**Cause:** Default `generation.dataloader.batch_size: 16` is tuned for 80 GB
+A100/H100. On a 40 GB GPU the latent flow-matching forward pass overflows.
+Beam-search amplifies this because `max_batch_size` inherits from
+`batch_size` and multiple beams run concurrently.
+
+**Fix:**
+
+```bash
+++generation.dataloader.batch_size=8
+++gen_njobs=1
+```
+
+If still OOMing, drop to `batch_size=4` and `++generation.args.nsteps=200` to
+shrink activation history. Reference: `docs/INFERENCE.md` "Memory Issues".
+
+## GPU OOM during folding
+
+**Symptom:** OOM during the `evaluate` step, typically after the AF2 or RF3
+model is loaded.
+
+**Cause:** Multiple eval jobs share the GPU; ColabDesign with
+`num_recycles: 3` and `num_redesign_seqs > 2` keeps a large state tree.
+
+**Fix:**
+
+```bash
+++eval_njobs=1
+++metric.num_redesign_seqs=2
+++metric.sequence_types=[self]      # skip mpnn / mpnn_fixed redesigns
+```
+
+For RF3 specifically, also lower `++metric.num_redesign_seqs=1` — RF3 carries a
+heavier per-sample state than AF2.
+
+## Missing `AF2_DIR` (colabdesign fails)
+
+**Symptom:** Hydra `InterpolationKeyError: AF2_DIR` raised when the reward
+model or the evaluator tries to resolve `${oc.env:AF2_DIR}`.
+
+**Cause:** The protein binder pipeline's `af2folding` reward model and the
+default `binder_folding_method: colabdesign` both read `AF2_DIR` from the
+environment. If `.env` does not define it, Hydra interpolation fails.
+
+**Fix:** Add `AF2_DIR=/path/to/af2_params` to `.env`, or switch the eval
+backend to ESMFold (does not need AF2 weights):
+
+```bash
+++metric.binder_folding_method=esmfold
+```
+
+Run `complexa download --all` to fetch AF2 weights into the canonical
+location. Reference: `docs/INFERENCE.md` "Missing Model Weights".
+
+## Missing `RF3_CKPT_PATH` / `RF3_EXEC_PATH` (rf3_latest fails)
+
+**Symptom:** `InterpolationKeyError: RF3_CKPT_PATH` or `RF3_EXEC_PATH` during
+generate (ligand binder) or evaluate (ligand binder, AME).
+
+**Cause:** Ligand binder and AME pipelines bake `${oc.env:RF3_CKPT_PATH}` and
+`${oc.env:RF3_EXEC_PATH}` into the RF3 reward and refold paths. RF3 is not
+downloaded by `complexa download --complexa-*`; it ships with the community
+model bundle.
+
+**Fix:** Export both env vars (or set them in `.env`):
+
+```bash
+export RF3_CKPT_PATH=/path/to/rf3_latest.pt
+export RF3_EXEC_PATH=/path/to/rf3
+```
+
+Run `complexa download --all` to install RF3 into the canonical location.
+Reference: `docs/INFERENCE.md` "RF3 Environment Variables".
+
+## Chain-ID mismatch between target PDB and `target_input`
+
+**Symptom:** Target loads but `n_target_residues == 0` after dataloader runs;
+or `KeyError: 'A'` raised by the target featurizer.
+
+**Cause:** The `target_input` field in the targets dict (e.g. `A1-115`)
+specifies chain A, but the PDB uses chain B (or unlabelled chains).
+
+**Fix:** Inspect the target PDB:
+
+```bash
+grep '^ATOM' /path/to/target.pdb | head -1   # check chain ID at col 22
+```
+
+Then update the target entry in `configs/targets/targets_dict.yaml` so
+`target_input` matches the actual chain. Or use the `complexa-target` skill to
+re-add the target with the correct chain.
+
+## Hotspot residue not in target PDB
+
+**Symptom:** Warning / error from `TargetFeatures` that hotspot residue
+`A45` does not exist; or hotspots silently dropped, leading to non-specific
+binders.
+
+**Cause:** `hotspot_residues: [A45, A67, A89]` references residues that the
+PDB does not contain — usually because the PDB has been re-numbered or the
+chain has been truncated.
+
+**Fix:** Pull the actual residue numbers:
+
+```bash
+grep '^ATOM' /path/to/target.pdb | awk '{print $5, $6}' | sort -u
+```
+
+Update `hotspot_residues` to a subset of residues that exist in `target_input`.
+
+## AME requires `USE_V2_COMPLEXA_ARCH: "True"`
+
+**Symptom:** Shape mismatch or `KeyError` at model-load time when running the
+AME pipeline.
+
+**Cause:** AME uses the v2 architecture. The `search_ame_local_pipeline.yaml`
+sets `env_vars.USE_V2_COMPLEXA_ARCH: "True"`, but a stray
+`++env_vars.USE_V2_COMPLEXA_ARCH=False` override (or a stale shell export)
+flips it back.
+
+**Fix:** Do not override `USE_V2_COMPLEXA_ARCH`. If a shell export is set, unset
+it:
+
+```bash
+unset USE_V2_COMPLEXA_ARCH
+```
+
+Reference: `configs/search_ame_local_pipeline.yaml` line 22.
+
+## AME ligand residue name must be `L:0` for RF3
+
+**Symptom:** RF3 reward model raises a residue-name parse error during AME
+generation; or the ligand silently disappears from the refolded structure.
+
+**Cause:** RF3 expects the ligand HETATM residue named `L` with sequence-number
+`0` (canonical AME convention). PDBs downloaded from RCSB usually have
+arbitrary ligand residue names (e.g. `OQO`, `FAD`, `ATP`).
+
+**Fix:** Use `atomworks` (the renaming tool) to rewrite the ligand residue:
+
+```bash
+python -m atomworks rename_ligand \
+    --in /path/to/target.pdb \
+    --out /path/to/target_renamed.pdb \
+    --target-resname L \
+    --target-resnum 0
+```
+
+Update the AME task in `configs/design_tasks/ame_dict_v2.yaml` to point at the
+renamed PDB. Reference: README in `target_data/` and the AME task definitions.
+
+## Override key not recognized
+
+**Symptom:** Hydra raises `InterpolationKeyError`, `MissingMandatoryValue`,
+or "Could not override 'X'" when launching the pipeline.
+
+**Cause:** Hydra `+` requires the key to already exist in the merged config;
+`++` forces a new key. If a typo lands inside an existing key path, the error
+looks like a missing value.
+
+**Fix:** Always use `++` for design pipeline overrides (the pipeline composes
+multiple configs and key existence varies by stage). Re-check the key against
+`reference/overrides.md`. Validate the run before launching:
+
+```bash
+complexa validate design <pipeline_config> ++<overrides>
+```
+
+The validator surfaces every unknown key before the pipeline starts.
+
+## Missing checkpoint reported by `complexa download --status`
+
+**Symptom:** `complexa download --status` lists a Complexa or community model
+as `Missing`, and the pipeline fails immediately at the load step.
+
+**Cause:** The relevant `complexa download --complexa-<variant>` or
+`complexa download --all` has not been run, or the download was interrupted.
+
+**Fix:**
+
+```bash
+complexa download --status                     # see what is missing
+complexa download --complexa                   # protein binder weights
+complexa download --complexa-ligand            # ligand binder weights
+complexa download --complexa-ame               # AME / motif weights
+complexa download --all                        # community models (AF2, RF3, MPNN, ESM2)
+```
+
+Hand off to the `complexa-setup` skill if the `.env` is also incomplete.
+
+## ColabDesign env var missing
+
+**Symptom:** ColabDesign fails on import or at AF2-params load with
+`FileNotFoundError`.
+
+**Cause:** `AF2_DIR` is set to a directory that does not contain
+`params_model_*.npz` files, or the path is correct but does not exist.
+
+**Fix:**
+
+```bash
+ls $AF2_DIR | grep '^params_model'
+```
+
+If empty, re-download:
+
+```bash
+complexa download --all
+```
+
+Or point `AF2_DIR` at the correct directory in `.env`.
+
+## ProteinMPNN / LigandMPNN model directory missing
+
+**Symptom:** Evaluation fails at the inverse-folding step with
+`FileNotFoundError` on the MPNN weights directory.
+
+**Cause:** The inverse-folding model is part of the community bundle, not the
+Complexa bundle. `complexa download --complexa*` does not fetch it.
+
+**Fix:**
+
+```bash
+complexa download --all
+```
+
+Or fetch the specific MPNN you need (LigandMPNN for ligand / AME pipelines,
+SolubleMPNN for protein binder, ProteinMPNN for the monomer designability
+calculation). All three live under the community-model directory.
+
+## Inverse folder returns 0 sequences
+
+**Symptom:** Per-design CSV has empty `{seq}_sequence` columns; success rate
+is 0% even though designs visually look reasonable.
+
+**Cause:** The target is too short, the interface cutoff is too tight, or the
+binder length is constrained so heavily that the MPNN sampler cannot find a
+sequence consistent with the fixed positions.
+
+**Fix:** Loosen the interface cutoff and re-run:
+
+```bash
+++metric.interface_cutoff=10.0
+++metric.num_redesign_seqs=8
+```
+
+If the binder is shorter than ~30 residues, also expand
+`generation.dataloader.dataset.nres.low/high` — the MPNN models are unreliable
+at very short lengths.
+
+## 0 designs pass success thresholds
+
+**Symptom:** Pipeline completes, `res_filter_*_pass_*.csv` shows
+`pass_rate: 0.0`. Per-design metrics look plausible but nothing passes.
+
+**Cause:** Default thresholds are tuned for the published targets (PDL1,
+TrkA, etc.) and may be too strict for harder targets or smaller search
+budgets.
+
+**Fix:** Loosen the thresholds via the aggregation overrides:
+
+```bash
+++aggregation.success_thresholds.i_pAE.threshold=10.0       # was 7.0
+++aggregation.success_thresholds.pLDDT.threshold=0.8        # was 0.9
+++aggregation.success_thresholds.scRMSD.threshold=2.0       # was 1.5
+```
+
+Or re-run analyze alone with the new thresholds — no need to re-generate:
+
+```bash
+complexa analyze configs/search_binder_local_pipeline.yaml ++run_name=<same> ++aggregation.success_thresholds.i_pAE.threshold=10.0
+```
+
+Reference: `docs/EVALUATION_METRICS.md` "Customizing Binder Thresholds".

--- a/plugins/bionemo-agent-toolkit/skills/complexa-evaluate-pdbs/SKILL.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-evaluate-pdbs/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: complexa-evaluate-pdbs
+description: >
+  Standalone evaluation of an existing PDB directory with Proteina-Complexa.
+  Use this skill whenever the user wants to "evaluate PDB files", "re-fold these
+  designs", "compute interface pAE", "compute i_pLDDT for a folder",
+  "run AF2 / RF3 / ESMFold on my designs", "score binder candidates",
+  "designability of this folder", "scRMSD for designs", "motif RMSD for these
+  PDBs", "complexa analysis", "complexa evaluate from a PDB directory",
+  "evaluate from pdb dir", or score third-party outputs (BindCraft, AlphaProteo,
+  RFdiffusion, hand-curated decoys). It picks the correct `evaluate_*.yaml`
+  config, wires `++dataset.pdb_dir` and the folding backend, runs
+  `complexa analysis` (the evaluate → analyze chain), parses the result CSV,
+  reports pass-rates against the right `result_type` thresholds, and emits a
+  replayable `eval_manifest.json`. Reach for this skill before hand-rolling
+  refolding scripts.
+compatibility: "complexa CLI installed (pip install -e .); CUDA GPU; AF2_DIR (colabdesign) or RF3_CKPT_PATH+RF3_EXEC_PATH (rf3_latest); ESMFold weights for monomer paths"
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Complexa Evaluate-PDBs Skill
+
+Score a directory of pre-existing PDB files against the same metrics Proteina-Complexa uses internally. Wraps `complexa analysis <evaluate_config> ++sample_storage_path=<dir>`: the CLI runs the `evaluate` step (refold + interface metrics + monomer metrics) and then the `analyze` step (success thresholds, diversity, pass-rate CSVs). Do **not** run `complexa generate` here — the inputs already exist.
+
+## What this skill enables
+
+- Re-fold a directory of designed PDBs with AF2 (`colabdesign`), RF3 (`rf3_latest`), ESMFold (`esmfold`), or Boltz2 (`boltz2_default`).
+- Compute binder interface metrics: `i_pAE`, `min_ipAE`, `i_pTM`, `pLDDT`, binder/complex scRMSD.
+- Compute monomer **designability** (ProteinMPNN-redesigned scRMSD) and **codesignability** (original sequence refold scRMSD).
+- For motif inputs: motif RMSD (CA + all-atom), motif-region designability/codesignability, sequence recovery.
+- Aggregate into per-PDB CSVs plus pass-rate summaries using the default thresholds for the `result_type`.
+
+## Step 1: Pre-flight
+
+Always check GPU / disk / tool binaries before launching a refold job. RF3 and ColabDesign-AF2 are large.
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+Surface from `preflight.json`:
+
+- `gpu.available` and `gpu.vram_gb` — colabdesign/RF3 need ≥40 GB; ESMFold tolerates ≥24 GB.
+- `env.missing_required` — must include the keys for the chosen folding backend:
+  - `colabdesign` → `AF2_DIR`
+  - `rf3_latest` → `RF3_CKPT_PATH`, `RF3_EXEC_PATH`
+  - `esmfold` → ESMFold weights resolvable
+- `tools.{foldseek,mmseqs}` — required by `aggregation.compute_diversity` / `compute_mmseqs_diversity` (both default `true`).
+
+If any required key is missing, route the user to the `complexa-setup` skill.
+
+## Step 2: Identify the design type
+
+Like `complexa design`, evaluation has one default flow (protein binder) and two extensions (ligand binder, AME). The evaluate config you pass to `complexa analysis` decides everything else (which metrics, which refolder defaults, which thresholds the analyze step applies).
+
+### Default — protein binder
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=02_PDL1 \
+    ++result_type=protein_binder \
+    ++metric.binder_folding_method=colabdesign \
+    ++metric.inverse_folding_model=soluble_mpnn \
+    ++run_name=eval_pdl1_af2
+```
+
+Use this when the user's PDBs are protein-binder designs (multi-chain, binder is the last chain) or third-party outputs from BindCraft / AlphaProteo / RFdiffusion. Pulls thresholds for `protein_binder` (`i_pAE * 31 ≤ 7.0`, `pLDDT ≥ 0.9`, `scRMSD_ca < 1.5 Å`).
+
+### Extensions — pick the matching config
+
+| Design type | Use the protein-binder default? | Evaluate config | Analyze config | `result_type` | Default backend |
+|---|---|---|---|---|---|
+| Protein binder | **Yes (default)** | `configs/evaluate_from_pdb_dir.yaml` | `configs/analyze.yaml` | `protein_binder` | `colabdesign` (AF2) |
+| Ligand binder (binder + small-molecule) | Same evaluate config, swap 3 overrides | `configs/evaluate_from_pdb_dir.yaml` | `configs/analyze.yaml` | `ligand_binder` | `rf3_latest` |
+| AME / motif + ligand (enzyme outputs) | No — needs motif-aware config | `configs/evaluate_ame_from_pdb_dir.yaml` | `configs/analyze_motif_binder.yaml` | `motif_ligand_binder` | `rf3_latest` |
+| Motif protein binder (standalone) | No — no `_from_pdb_dir` variant | `configs/evaluate_motif_binder.yaml` + `++input_mode=pdb_dir` | `configs/analyze_motif_binder.yaml` | `motif_protein_binder` | `colabdesign` / `rf3_latest` |
+
+**Extending to ligand binder** (same evaluate config as default, three override swaps):
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=39_7V11_LIGAND \
+    ++result_type=ligand_binder \
+    ++metric.binder_folding_method=rf3_latest \
+    ++metric.inverse_folding_model=ligand_mpnn \
+    ++run_name=eval_v11_rf3
+```
+
+**Extending to AME** (different config; ligand auto-completion gotcha — see Step 4):
+
+```bash
+complexa analysis configs/evaluate_ame_from_pdb_dir.yaml \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=M0096_1chm \
+    ++run_name=eval_ame_chm
+```
+
+See `reference/eval_configs.md` for the full matrix (every `result_type`, every threshold default, every supported folding backend, motif-protein-binder variant).
+
+## Step 3: Gather inputs (AskUserQuestion)
+
+Ask in one batched `AskUserQuestion`:
+
+1. **`pdb_dir`** — absolute path to the directory of PDBs to evaluate.
+2. **Design type** — protein binder / ligand binder / AME (motif + ligand).
+3. **Folding backend** — `colabdesign` (AF2, protein binders), `rf3_latest` (ligand / AME), `boltz2_default` (alternative).
+4. **Target / task name** — must match a key in `configs/targets/targets_dict.yaml`, `configs/targets/ligand_targets_dict.yaml`, or `configs/design_tasks/ame_dict_v2.yaml`. Required for binder + AME evaluation (needed to identify the target reference and, for AME, the motif contigs).
+5. **AME-only**: confirm ligand residue name is already renamed to `L:0` in every PDB (see Troubleshooting). If not, do that rename first.
+
+## Step 4: Run evaluate → analyze
+
+Prefer `complexa analysis` (the evaluate→analyze chain) — it reuses the same config for both steps and writes a single log dir.
+
+```bash
+# Protein binder PDB dir, AF2 refold
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+  ++sample_storage_path=/abs/path/to/pdbs \
+  ++dataset.task_name=02_PDL1 \
+  ++metric.binder_folding_method=colabdesign \
+  ++metric.inverse_folding_model=soluble_mpnn \
+  ++result_type=protein_binder \
+  ++run_name=eval_pdl1_af2
+```
+
+For ligand binders flip `binder_folding_method=rf3_latest`, `inverse_folding_model=ligand_mpnn`, `result_type=ligand_binder`. For AME use `configs/evaluate_ame_from_pdb_dir.yaml` — see `reference/eval_configs.md` for full worked examples.
+
+If you need to inspect output between stages, run them separately. The configs above are shared between `evaluate` and `analyze`:
+
+```bash
+complexa evaluate configs/evaluate_from_pdb_dir.yaml ++sample_storage_path=/abs/path/to/pdbs ++run_name=eval_pdl1_af2
+complexa analyze  configs/evaluate_from_pdb_dir.yaml ++run_name=eval_pdl1_af2
+```
+
+Dry-run first if the user is unsure (no GPU work happens; the planned file walk + invocation prints):
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml ++sample_storage_path=/abs/path/to/pdbs ++dryrun=true
+```
+
+### Direct module invocation (debug fallback)
+
+`complexa evaluate` / `analyze` are subprocess wrappers around the Hydra
+modules with logging + parallel job splitting bolted on. To attach a debugger
+or run under a profiler, invoke the module directly:
+
+```bash
+python -m proteinfoundation.evaluate \
+    --config-path "$(realpath configs)" \
+    --config-name evaluate_from_pdb_dir \
+    ++sample_storage_path=/abs/path/to/pdbs \
+    ++dataset.task_name=02_PDL1 \
+    ++metric.binder_folding_method=colabdesign \
+    ++run_name=eval_debug
+```
+
+For normal one-shot runs prefer `complexa analysis` — you get the shared log
+dir and a single replayable invocation, instead of having to thread the same
+overrides through two `python -m` calls.
+
+## Step 5: Parse results
+
+Output lands under `./evaluation_results/${run_name}/`:
+
+- Per-PDB metrics CSV — `*_results_*.csv` (one row per input PDB × `sequence_types`).
+- Pass-rate summaries — written by the `analyze` step (e.g. `res_designability.csv`, `res_filter_ligand_pass_*.csv`, `success_criteria_*.json`).
+- Diversity output — FoldSeek/MMseqs2 cluster files when `aggregation.compute_diversity=true` (default).
+
+Summarize to the user:
+
+- Per-PDB row count and number of successful designs vs total.
+- Default-threshold pass rate by `result_type` (e.g. for `protein_binder`: `i_pAE*31 <= 7.0 AND pLDDT >= 0.9 AND scRMSD_ca < 1.5`).
+- Top 5 designs by primary metric (`i_pAE` for protein, `min_ipAE` for ligand, `motif_rmsd_pred_all` for motif binders).
+
+## Step 6: Emit manifest
+
+Capture the resolved invocation + outputs for replay.
+
+```bash
+python3 .claude/skills/_shared/scripts/write_manifest.py \
+  --output-dir ./evaluation_results/${run_name} \
+  --command "complexa analysis configs/evaluate_from_pdb_dir.yaml ++sample_storage_path=<dir> ++dataset.task_name=<task> ++metric.binder_folding_method=<backend> ++run_name=<run>" \
+  --skill complexa-evaluate-pdbs \
+  --out ./eval_manifest.json
+```
+
+The manifest pins: resolved config, git SHA, ckpt SHA-256s, the result CSV paths, and the user-stated `result_type` for replay.
+
+## Most common overrides
+
+| Override                                       | Effect                                                                |
+|------------------------------------------------|-----------------------------------------------------------------------|
+| `++sample_storage_path=<dir>`                  | The directory of PDBs to evaluate (required).                         |
+| `++dataset.task_name=<name>`                   | Target / AME task name (binders, AME). Resolves target PDB + contigs. |
+| `++metric.binder_folding_method=<backend>`     | `colabdesign` / `rf3_latest` / `boltz2_default`.                      |
+| `++metric.inverse_folding_model=<model>`       | `protein_mpnn` / `soluble_mpnn` / `ligand_mpnn`.                      |
+| `++metric.sequence_types=[self,mpnn,mpnn_fixed]` | Which sequence flavors to refold.                                   |
+| `++metric.num_redesign_seqs=N`                 | ProteinMPNN/LigandMPNN redesign count.                                |
+| `++metric.compute_pre_refolding_metrics=true`  | Add bioinformatics/TMOL/HBPLUS metrics on the input structures.       |
+| `++metric.keep_folding_outputs=true`           | Save the refolded PDBs (large, but useful for inspection).            |
+| `++result_type=<type>`                         | Override default thresholds: `protein_binder` / `ligand_binder` / `motif_protein_binder` / `motif_ligand_binder`. |
+| `++aggregation.success_thresholds.<…>`         | Tighten or loosen specific thresholds (see `reference/eval_configs.md`). |
+| `++eval_njobs=N`                               | Parallel GPUs for the evaluate step.                                  |
+| `++dryrun=true`                                | Plan without running any folding.                                     |
+| `++file_limit=N`                               | Cap input PDBs (handy for first-pass smoke tests).                    |
+
+## Hardware
+
+- **GPU**: ≥1 CUDA GPU. AF2 (`colabdesign`) and RF3 (`rf3_latest`) need ≥40 GB VRAM (A100/H100/L40S). ESMFold runs on ≥24 GB. Multi-GPU via `++eval_njobs=N`.
+- **CPU/disk**: 24 CPUs default (`ncpus_: 24`). Each refolded PDB + intermediate output is ~1–5 MB; `keep_folding_outputs=true` can balloon to tens of GB for thousands of inputs.
+- See `_shared/reference/hardware.md` for per-backend wall-clock and VRAM tables.
+
+## Troubleshooting
+
+- **`Error: Config file not found`** — paths are relative to the repo root; `cd` to the repo before invoking `complexa analysis`.
+- **`compute_motif_binder_metrics=True` but `result_type=protein_binder`** — `result_type` and the underlying `compute_*_metrics` must agree. Use `configs/evaluate_ame_from_pdb_dir.yaml` for AME inputs rather than mutating `evaluate_from_pdb_dir.yaml`.
+- **RF3 shape errors on AME PDBs** — RF3 tries to auto-complete the ligand atoms from CCD. Rename the ligand residue to `L:0` in every input PDB before evaluation; see the snippet in `README.md` (`atom_array.res_name[ligand_mask] = "L:0"`).
+- **Diversity step fails (`foldseek not found`)** — `FOLDSEEK_EXEC` not on `PATH`. Either fix `.env` (preferred) or disable: `++aggregation.compute_diversity=false ++aggregation.compute_mmseqs_diversity=false`.
+- **All pass-rates are 0%** — check the `binder_folding_method` matches the target type (RF3 for ligand, AF2 for protein) and that `++dataset.task_name` resolves to the correct reference PDB (`complexa target show <name>` to verify).
+
+## Reference
+
+Full evaluate/analyze config matrix, every supported `result_type`, per-threshold defaults, and three worked examples (protein binder / ligand binder / AME): see `reference/eval_configs.md`.

--- a/plugins/bionemo-agent-toolkit/skills/complexa-evaluate-pdbs/reference/eval_configs.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-evaluate-pdbs/reference/eval_configs.md
@@ -1,0 +1,197 @@
+# Evaluate-from-PDB-Dir Config Reference
+
+Companion to `SKILL.md`. Every `evaluate_*_from_pdb_dir.yaml` and its paired `analyze_*.yaml`, with the `result_type` they emit, the `dataset.*` keys they require, and the `metric.*` / `aggregation.*` knobs they accept. Three worked examples at the bottom.
+
+## 1. Design type → config matrix
+
+| Design type            | Evaluate config                              | Analyze config              | `result_type`            | Folding backends         | Inverse-folding default |
+|------------------------|----------------------------------------------|-----------------------------|--------------------------|--------------------------|-------------------------|
+| Protein binder         | `configs/evaluate_from_pdb_dir.yaml`         | `configs/analyze.yaml`      | `protein_binder`         | `colabdesign`, `rf3_latest`, `esmfold`, `boltz2_default`, `protenix_base_default_v0.5.0` | `soluble_mpnn` |
+| Ligand binder          | `configs/evaluate_from_pdb_dir.yaml`         | `configs/analyze.yaml`      | `ligand_binder`          | `rf3_latest` (default), `boltz2_default` | `ligand_mpnn` |
+| AME / motif ligand binder | `configs/evaluate_ame_from_pdb_dir.yaml`  | `configs/analyze_motif_binder.yaml` | `motif_ligand_binder` | `rf3_latest`            | `ligand_mpnn`           |
+| Motif protein binder   | `configs/evaluate_motif_binder.yaml` (no `_from_pdb_dir` variant; set `input_mode=pdb_dir`) | `configs/analyze_motif_binder.yaml` | `motif_protein_binder` | `colabdesign`, `rf3_latest` | `protein_mpnn` / `soluble_mpnn` |
+
+Notes:
+- The protein-binder and ligand-binder cases share `evaluate_from_pdb_dir.yaml`; switch behavior by setting `result_type`, `metric.binder_folding_method`, and `metric.inverse_folding_model` on the CLI.
+- There is no shipped `evaluate_motif_protein_binder_from_pdb_dir.yaml`; reuse `configs/evaluate_motif_binder.yaml` with `++input_mode=pdb_dir ++sample_storage_path=<dir>` and an appropriate `dataset/motif_target_dict_cfg` override.
+
+## 2. Evaluate config schema
+
+All `evaluate_*` configs share a top-level shape (run identification, `input_mode`, `protein_type`, `sample_storage_path`, `output_dir`, `eval_njobs`, `seed`, `ncpus_`, `dataset.*`, `metric.*`). Below: the differences that matter when running from a PDB directory.
+
+### `evaluate_from_pdb_dir.yaml`
+
+- `protein_type: binder` (one config handles both protein and ligand binders).
+- `input_mode: pdb_dir` (already set; never override back to `generated`).
+- `defaults: - generation/targets_dict@dataset` — resolves `dataset.task_name` against `configs/targets/targets_dict.yaml` (and ligand_targets_dict via task naming).
+- Required `dataset.*`:
+  - `dataset.task_name` — target key (e.g. `02_PDL1`, `39_7V11_LIGAND`).
+- Key `metric.*` fields:
+  - `compute_binder_metrics: true`.
+  - `binder_folding_method` — picks the refolding backend (table above).
+  - `sequence_types: [self|mpnn|mpnn_fixed]` — which sequence(s) to refold.
+  - `num_redesign_seqs` — MPNN sequence count (default 8 here).
+  - `interface_cutoff` — Å cutoff for interface residue detection (default 8.0 protein, 6.0 motif).
+  - `inverse_folding_model` — `soluble_mpnn` / `protein_mpnn` (protein) or `ligand_mpnn` (ligand).
+  - `compute_pre_refolding_metrics`, `pre_refolding.{bioinformatics,tmol,hbplus}` — optional pre-refold interface metrics.
+  - `compute_refolded_structure_metrics`, `refolded.{bioinformatics,tmol,hbplus}` — optional post-refold.
+  - `compute_monomer_metrics`, `compute_designability`, `compute_codesignability`, `designability_modes`, `codesignability_modes` — monomer-on-binder eval.
+  - `compute_co_sequence_recovery`, `compute_ss` — sequence/secondary-structure metrics.
+  - `compute_novelty_{pdb,afdb,afdb_rep_v4}` — FoldSeek novelty against known DBs.
+  - `keep_folding_outputs` — keep refolded PDBs.
+- File walk control:
+  - `ignore_generated_pdb_suffix: "_binder.pdb"` (default) — drop intermediate binder-only PDBs from the walk.
+  - `file_limit: N` — cap input count.
+- `result_type` is set inline (`ligand_binder` or `protein_binder`) and propagates to the paired analyze step.
+
+### `evaluate_ame_from_pdb_dir.yaml`
+
+- `protein_type: motif_binder`.
+- `defaults: - /design_tasks/ame_dict_v2@dataset` — resolves AME tasks (`M0024_1nzy`, `M0096_1chm`, etc.).
+- Required `dataset.task_name` — must match a key in `ame_dict_v2`.
+- Key `metric.*`:
+  - `compute_motif_binder_metrics: True`.
+  - `binder_folding_method: rf3_latest` (only RF3 makes sense for ligand motif binders).
+  - `inverse_folding_model: ligand_mpnn`.
+  - `sequence_types: [mpnn_fixed, self]` (default — `mpnn_fixed` keeps the motif residues constant).
+  - `interface_cutoff: 6.0`.
+  - `compute_binder_metrics`, `compute_monomer_metrics` — optional add-ons; `compute_motif_metrics` is incompatible with `motif_binder`.
+- `result_type: motif_ligand_binder`.
+
+### Shared reference configs (no `_from_pdb_dir` suffix)
+
+These ship for completeness; the `from_pdb_dir` variants are derived from them with `input_mode=pdb_dir` baked in.
+
+- `configs/evaluate.yaml` — unified binder evaluation, defaults `input_mode: generated`. Pass `++input_mode=pdb_dir ++sample_storage_path=<dir>` to evaluate an external directory.
+- `configs/evaluate_motif_binder.yaml` — motif binder (protein + ligand variants). Set `++result_type=motif_protein_binder` (with AF2/ColabDesign + ProteinMPNN/SolubleMPNN) or rely on the default `motif_ligand_binder` (RF3 + LigandMPNN). Use this when you have motif-protein-binder PDBs — there is no dedicated `_from_pdb_dir` variant.
+
+## 3. Analyze config schema
+
+### `analyze.yaml`
+
+- `result_type: protein_binder` (default) or `ligand_binder` (override).
+- `aggregation.analysis_modes` — default `[binder, monomer]` for binder result types.
+- `aggregation.success_thresholds` — `null` (defaults) or a dict of `{metric: {threshold, op, scale, column_prefix}}` entries.
+- Built-in defaults:
+  - `protein_binder`: `i_pAE * 31 <= 7.0`, `pLDDT >= 0.9`, `scRMSD_ca < 1.5`.
+  - `ligand_binder`: `min_ipAE * 31 < 2.0`, `scRMSD_ca < 2.0`, `ligand_scRMSD_aligned_allatom < 5.0`.
+- Monomer-mode thresholds (when `[monomer]` is in `analysis_modes`):
+  - `aggregation.designability_thresholds` — `{mode: {model: {threshold, op}}}`; default 2.0 Å.
+  - `aggregation.ca_codesignability_thresholds` — default 2.0 Å.
+  - `aggregation.allatom_codesignability_thresholds` — default 2.0 Å.
+  - `aggregation.require_all_thresholds: false` — `false` = OR across modes/models, `true` = AND.
+
+### `analyze_motif_binder.yaml`
+
+- `result_type: motif_protein_binder` (default in the YAML) or `motif_ligand_binder` (override on CLI).
+- `aggregation.analysis_modes` — default `[motif_binder, binder, monomer]`.
+- `aggregation.motif_binder_success_thresholds`:
+  - **`motif_protein_binder` defaults** — binder: `i_pAE*31 <= 7.0`, `pLDDT >= 0.8`, `scRMSD_ca < 2.0`; motif: `motif_rmsd_pred_all < 2.0`, `correct_motif_sequence_all >= 1.0`.
+  - **`motif_ligand_binder` defaults** — binder: `scRMSD_bb3 <= 2.0`; motif: `motif_rmsd_pred_all <= 1.5`, `correct_motif_sequence_all >= 1.0`, `has_ligand_clashes_all < 0.5`.
+- A sample is successful when **at least one redesign index** passes **every** binder criterion AND **every** motif criterion jointly. Per-redesign joint evaluation, not pooled.
+- `aggregation.success_thresholds` (binder-only mode) and the three monomer threshold dicts work identically to `analyze.yaml`.
+
+## 4. `motif_protein_binder` vs `motif_ligand_binder`
+
+Both come from `evaluate_motif_binder.yaml` family + `analyze_motif_binder.yaml`. The split is target-driven:
+
+| Property                    | `motif_protein_binder`           | `motif_ligand_binder` (AME)        |
+|-----------------------------|----------------------------------|------------------------------------|
+| Target                      | Protein receptor                 | Small molecule ligand              |
+| Folding (`binder_folding_method`) | `colabdesign` (AF2) or `rf3_latest` | `rf3_latest`                  |
+| Inverse folding             | `protein_mpnn` / `soluble_mpnn`  | `ligand_mpnn`                      |
+| Motif criteria              | RMSD + seq recovery              | RMSD + seq recovery + ligand clashes |
+| Default binder threshold    | `i_pAE*31 <= 7.0`, `pLDDT >= 0.8`, `scRMSD_ca < 2.0` | `scRMSD_bb3 <= 2.0` |
+| Default motif threshold     | `motif_rmsd_pred_all < 2.0`, `correct_motif_sequence_all >= 1.0` | `motif_rmsd_pred_all <= 1.5`, seq recovery, `has_ligand_clashes_all < 0.5` |
+| `evaluate_*_from_pdb_dir`   | none — use `evaluate_motif_binder.yaml` + `++input_mode=pdb_dir` | `evaluate_ame_from_pdb_dir.yaml` |
+
+When in doubt: if every PDB has a small-molecule ligand chain, it is `motif_ligand_binder`. If the second chain is another protein receptor, it is `motif_protein_binder`.
+
+## 5. Ligand `L:0` rename for AME RF3 evaluation
+
+Lifted from `README.md` "Evaluating AME Designs with Ligand Targets (RF3)":
+
+> When running RF3 evaluation on AME-generated PDB files that contain a ligand (small molecule on chain A), RF3 will attempt to add missing atoms based on the ligand's CCD code. This can cause shape errors in downstream RMSD calculations and provide the incorrect structure.
+>
+> **Solution:** rename the ligand residue to `L:0` before passing to RF3. This tells RF3 to treat it as a generic ligand and skip atom completion.
+
+```python
+from atomworks.io import load_any, to_pdb_file
+atom_array = load_any("my_design.pdb")
+ligand_mask = atom_array.chain_id == "A"
+atom_array.res_name[ligand_mask] = "L:0"
+to_pdb_file(atom_array, "my_design_rf3_ready.pdb")
+```
+
+Apply this transform once over the whole input directory before invoking
+`complexa analysis configs/evaluate_ame_from_pdb_dir.yaml ...`. If the PDBs
+came out of `complexa generate` with `protein_type=motif_binder`, the rename is
+already done.
+
+## 6. Worked examples
+
+### Example A — protein binder PDB directory, AF2 refold
+
+User: "Re-fold these 200 PDL1 binders with AlphaFold2 and tell me what fraction passes the default AlphaProteo thresholds."
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+  ++sample_storage_path=/data/pdl1_designs \
+  ++dataset.task_name=02_PDL1 \
+  ++metric.binder_folding_method=colabdesign \
+  ++metric.inverse_folding_model=soluble_mpnn \
+  ++metric.sequence_types=[self,mpnn_fixed] \
+  ++metric.num_redesign_seqs=8 \
+  ++result_type=protein_binder \
+  ++eval_njobs=2 \
+  ++run_name=pdl1_pdb_dir_af2
+```
+
+Pass-rate filter (applied by analyze):
+`mpnn_complex_i_pAE * 31 <= 7.0 AND mpnn_complex_pLDDT >= 0.9 AND mpnn_binder_scRMSD_ca < 1.5`.
+
+### Example B — AME PDB directory, RF3 refold (motif ligand binder)
+
+User: "Score this folder of AME 1nzy designs — joint binder + motif success please."
+
+```bash
+# First, rename ligand to L:0 in every PDB (one-time).
+python scripts/rename_ligand_to_L0.py /data/ame_1nzy_designs
+
+complexa analysis configs/evaluate_ame_from_pdb_dir.yaml \
+  ++sample_storage_path=/data/ame_1nzy_designs \
+  ++dataset.task_name=M0024_1nzy \
+  ++metric.binder_folding_method=rf3_latest \
+  ++metric.inverse_folding_model=ligand_mpnn \
+  ++metric.sequence_types=[mpnn_fixed,self] \
+  ++metric.num_redesign_seqs=2 \
+  ++result_type=motif_ligand_binder \
+  ++run_name=ame_m0024_pdb_dir
+```
+
+Joint success criterion (from `analyze_motif_binder.yaml`, `motif_ligand_binder` defaults): at least one redesign index satisfies binder `scRMSD_bb3 <= 2.0` AND motif `motif_rmsd_pred_all <= 1.5` AND `correct_motif_sequence_all >= 1.0` AND `has_ligand_clashes_all < 0.5`.
+
+### Example C — ligand binder PDB directory, RF3 refold
+
+User: "Score this folder of 7V11 ligand-binder designs with RF3 and LigandMPNN."
+
+```bash
+complexa analysis configs/evaluate_from_pdb_dir.yaml \
+  ++sample_storage_path=/data/7v11_designs \
+  ++dataset.task_name=39_7V11_LIGAND \
+  ++metric.binder_folding_method=rf3_latest \
+  ++metric.inverse_folding_model=ligand_mpnn \
+  ++metric.sequence_types=[self,mpnn_fixed] \
+  ++metric.num_redesign_seqs=8 \
+  ++result_type=ligand_binder \
+  ++eval_njobs=2 \
+  ++run_name=7v11_pdb_dir_rf3
+```
+
+Pass-rate filter (applied by analyze): `min_ipAE * 31 < 2.0 AND scRMSD_ca < 2.0 AND ligand_scRMSD_aligned_allatom < 5.0`. Override via `++aggregation.success_thresholds.min_ipAE.threshold=…` etc.
+
+## 7. Pointers
+
+- Per-metric output column names: `docs/EVALUATION_METRICS.md` "Result CSV Reference".
+- Default thresholds and Python filter examples: `docs/EVALUATION_METRICS.md` "Success Criteria" and "Reading Results in Python".
+- Hardware tables (VRAM per backend, wall-clock per N PDBs): `_shared/reference/hardware.md`.

--- a/plugins/bionemo-agent-toolkit/skills/complexa-setup/SKILL.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-setup/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: complexa-setup
+description: >
+  First-time setup, environment configuration, and model-weight installation for
+  Proteina-Complexa. Reach for this skill whenever the user says "set up complexa",
+  "install complexa", "configure my .env", "first-time setup", "what models do I
+  have installed", "what's in my .env", "download model weights", "download
+  Complexa / AF2 / RF3 / ProteinMPNN / LigandMPNN / ESM2 / ESMFold checkpoints",
+  "preflight my GPU", "verify environment", "complexa init", "complexa download",
+  "complexa download --status", "complexa validate env", or any time a fresh
+  checkout needs to be made runnable. This is the first skill to run on a new
+  clone — it drives `complexa init`, `complexa download`, and `complexa validate
+  env` end-to-end, edits the required `.env` keys, picks the right runtime (UV
+  vs Docker), and emits a replayable setup artifact.
+compatibility: "complexa CLI installed (pip install -e .); bash 4+; nvidia-smi optional"
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Complexa Setup Skill
+
+Drive the three steps a fresh Proteina-Complexa checkout needs before any
+design run: create `.env`, fetch model weights, and sanity-check the env.
+Probe the host for GPU / disk / tool binaries first so the user does not
+discover a missing dependency mid-pipeline. End with a JSON setup artifact the
+user (or a future agent) can re-read instead of re-deriving state.
+
+## CLI vs direct file-edit — pick the cheapest path per step
+
+| Step | Preferred path | Why |
+|---|---|---|
+| `.env` creation (Step 2) | **File edit** (`cp .env_example .env` + 3 line swaps) or `complexa init` | `complexa init` is a thin wrapper around `cp + 3 regex swaps` (`_swap_runtime_in_env` in `cli_runner.py`). Either path works; pick CLI for new humans, direct edit for agents. |
+| `.env` value edits (Step 3) | **File edit** (StrReplace `LOCAL_CODE_PATH=…` etc.) | No CLI for this — the values are user-specific paths. |
+| Download model weights (Step 4) | **CLI** (`complexa download --…`) | Dispatches to `env/download_startup.sh` (~1000 lines of bash with NGC URLs, retries, checksum-style skip-if-present). Don't try to replicate. |
+| Validate env (Step 5) | **CLI** (`complexa validate env`) or `test -f .env && test -d $DATA_PATH` | CLI prints a nicer report; the manual check is one-liner-safe. |
+| Validate full design config (after picking a pipeline) | **CLI** (`complexa validate design CONFIG`) | Non-trivial Hydra defaults traversal + ckpt + env-var checks; not worth replicating. |
+
+## What this skill enables
+
+- A correctly-shaped `.env` for either UV or Docker runtime.
+- Model checkpoints (Complexa protein/ligand/AME plus community models) downloaded to known paths.
+- A `preflight.json` snapshot of the host (GPU, disk, .env, ckpts, tool binaries).
+- A `run_manifest.json` capturing exactly which `complexa init` + `complexa download` invocations were used (replay-friendly).
+- A pass/fail report from `complexa validate env` with clear next-step hints.
+
+## Step 1: Pre-flight check
+
+Always run the shared preflight before touching the environment. It does not
+require `.env` to exist — it falls back to defaults — and it tells you whether
+the host can run Complexa at all.
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+The script writes `./complexa_setup/preflight.json`. Read it and surface:
+
+- `gpu.available` — if `false`, design / evaluate steps will fail; warn the user.
+- `gpu.vram_gb` — Complexa needs ≥40 GB (A100/H100/L40S).
+- `disk.free_gb` at `CKPT_PATH` — minimum ~50 GB for the full Complexa + community model set.
+- `env.missing_required` — anything listed here must be edited in `.env` before validation passes.
+- `tools.{foldseek,mmseqs,dssp,hbplus,sc}.exists` — missing tools degrade evaluation but do not block generation.
+
+## Step 1b: Build the Python environment (only if `.venv/` is missing)
+
+The `complexa` CLI is installed inside the project's Python environment, not on
+the system path by default. On a **fresh clone**, the `.venv/` directory does
+not yet exist and `complexa init` will fail with `command not found`. Build the
+UV venv before anything else:
+
+```bash
+test -d .venv || ./env/build_uv_env.sh   # first-time UV build
+source .venv/bin/activate
+which complexa                            # sanity check: should point inside .venv
+```
+
+Skip this step if `which complexa` already resolves — that means a previous
+build is still good. The Docker runtime skips it entirely; the venv lives
+inside the container image instead. If the user said "I just cloned" or you
+see no `.venv/` next to `pyproject.toml`, run the build script — `complexa init`
+without a venv produces a confusing `command not found` rather than an obvious
+"build the venv first" error.
+
+## Step 2: Create `.env`
+
+Pick the runtime. UV is the default and faster to start; Docker is required on
+Ubuntu 20.04 or systems with GLIBC mismatches.
+
+Use AskUserQuestion if it is not obvious from context:
+
+> "Which runtime do you want to configure? `uv` (recommended, faster) or `docker` (use if you do not have a UV venv built locally)?"
+
+### Path A: file edit (preferred for agents)
+
+`complexa init` only does three things — copy `.env_example` → `.env` and
+swap the `COMPLEXA_RUNTIME=` line plus the `UV_*` ↔ `DOCKER_*` prefixes on the
+tool/data/cache path block. You can do the same with `cp` + StrReplace and skip
+the CLI:
+
+```bash
+cp .env_example .env
+# Then StrReplace these lines in .env:
+#   COMPLEXA_RUNTIME=uv          → COMPLEXA_RUNTIME=<runtime>
+#   FOLDSEEK_EXEC=${UV_FOLDSEEK_EXEC}  → FOLDSEEK_EXEC=${DOCKER_FOLDSEEK_EXEC}   (and same for RF3_EXEC_PATH, SC_EXEC, HBPLUS_EXEC, MMSEQS_EXEC, DSSP_EXEC, TMOL_PATH)
+#   DATA_PATH=${LOCAL_DATA_PATH} → DATA_PATH=${DOCKER_DATA_PATH}                  (and same for CACHE_DIR, CKPT_PATH)
+```
+
+Skip the prefix swap entirely if you're staying on UV (the `.env_example`
+already targets UV).
+
+### Path B: CLI
+
+```bash
+complexa init                    # UV runtime (default)
+complexa init --runtime docker   # Docker runtime
+complexa init --force            # Recreate .env from .env_example (drops any edits)
+```
+
+If `.env` already exists and `--force` is not passed, only the runtime-dependent
+lines are swapped — user edits in Step 3 are preserved across runtime flips.
+
+### Verify either way
+
+```bash
+test -f .env && echo "OK: .env present" || echo "MISSING"
+grep -E '^COMPLEXA_RUNTIME=' .env
+```
+
+## Step 3: Edit .env
+
+No CLI for this — Step 2 only set the runtime; you still need to write your
+machine-specific paths into `.env` by hand (StrReplace or your editor). The two
+absolutely-required edits are:
+
+```bash
+LOCAL_CODE_PATH=/absolute/path/to/protein-foundation-models
+LOCAL_DATA_PATH=/absolute/path/to/PFM_data
+```
+
+Everything else (cache, ckpts, community-model dirs, tool binaries) is derived
+from `LOCAL_CODE_PATH` by default and only needs editing if you have a
+non-standard layout. For the full table — every key, what it controls, what
+fails if it is missing — see [reference/env_keys.md](reference/env_keys.md).
+
+Quick decision table for the four edits most users make:
+
+| Key | Default | Set this if |
+|-----|---------|-------------|
+| `LOCAL_CODE_PATH` | placeholder | Always — required |
+| `LOCAL_DATA_PATH` | `/path/to/PFM_data` | Always — required, points at target PDBs |
+| `HF_TOKEN` | placeholder | You need ESMFold or gated HF models |
+| `WANDB_API_KEY` | placeholder | You want training runs logged to W&B |
+
+## Step 4: Download checkpoints
+
+**Always use the CLI here.** `complexa download` dispatches to
+`env/download_startup.sh` (~1000 lines of bash with NGC URLs, retries, and
+skip-if-present logic across ~6 community-model families). Rolling your own
+wget loop is a recipe for partial downloads and wrong destination paths.
+
+Ask which models the user actually needs — downloading everything is ~100+ GB.
+Pick from the three Complexa variants and the community-model set. Each
+Complexa variant unlocks exactly one `complexa design` pipeline; AF2 / RF3
+inside the community-model set are what `evaluate` (and reward-guided search)
+need at run time.
+
+| Flag | What it downloads | Unlocks pipeline | Destination | Approx size |
+|------|-------------------|------------------|-------------|-------------|
+| `--complexa` | Complexa protein-binder model + AE (`complexa.ckpt`, `complexa_ae.ckpt`) | **Protein binder** (default) — `configs/search_binder_local_pipeline.yaml` | `./ckpts/` | ~3 GB |
+| `--complexa-ligand` | Ligand-binder model + AE (`complexa_ligand.ckpt`, `complexa_ligand_ae.ckpt`) | Ligand binder — `configs/search_ligand_binder_local_pipeline.yaml` | `./ckpts/` | ~3 GB |
+| `--complexa-ame` | AME motif-scaffolding model + AE (`complexa_ame.ckpt`, `complexa_ame_ae.ckpt`) | AME (enzyme) — `configs/search_ame_local_pipeline.yaml` | `./ckpts/` | ~3 GB |
+| `--complexa-all` | All three Complexa variants | All three pipelines | `./ckpts/` | ~9 GB |
+| `--all` | All community models (ProteinMPNN + LigandMPNN + AF2 + ESM2 + ESMFold + RF3) | Needed by **evaluate / reward**: AF2 (protein binder), RF3 (ligand binder + AME), MPNNs (inverse folding for every pipeline). | `./community_models/` | ~50 GB |
+| `--everything` | Complexa + community + optional (Boltz2 / Protenix) | Everything plus alternative refold backends | both | ~100+ GB |
+| `--status` | Show install state — does not download | (none) | (none) | n/a |
+
+**Minimum download per pipeline:**
+
+- Protein binder (default): `complexa download --complexa --all`
+- Ligand binder: `complexa download --complexa-ligand --all`
+- AME / enzyme: `complexa download --complexa-ame --all`
+- All three: `complexa download --everything`
+
+For the full per-model destination breakdown and per-flag NGC sources, see
+[reference/downloads.md](reference/downloads.md).
+
+Pick the smallest invocation that covers the user's goal, then run:
+
+```bash
+complexa download --complexa            # protein binder only
+complexa download --complexa-all        # all three Complexa variants
+complexa download --all                 # community models only
+complexa download --everything          # everything
+```
+
+Without arguments, `complexa download` launches an interactive wizard — prefer
+explicit flags in agent mode.
+
+Verify what landed:
+
+```bash
+complexa download --status
+```
+
+The status output groups by family (Complexa / community / optional) and prints
+"Installed" or "Missing" per ckpt. Re-run the specific flag if a ckpt is
+flagged missing.
+
+## Step 5: Validate
+
+Final check that `.env` is loadable and the required paths resolve:
+
+```bash
+complexa validate env
+```
+
+`validate env` checks: (1) `.env` exists, (2) `DATA_PATH` is set and points at
+an existing directory. It does not check ckpt files — those are checked by
+`complexa validate design <config>` once you have a pipeline config picked.
+
+Common failures and fixes:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `.env file: No .env file found` | `complexa init` not run | Run `complexa init` first |
+| `DATA_PATH: Not set in .env` | Placeholder not edited | Edit `LOCAL_DATA_PATH` in `.env` |
+| `DATA_PATH: Directory not found` | Path edited but does not exist on disk | `mkdir -p $LOCAL_DATA_PATH` or copy target data there |
+| Hydra error `InterpolationKeyError: AF2_DIR` | Reward/eval config wants AF2 but `.env` does not define it | Download AF2 weights or remove AF2 from the config |
+
+## Step 6: Emit setup artifact
+
+Drop a JSON manifest in `./complexa_setup/` so the user has a single file
+describing the resulting state. The shared helper writes it for you:
+
+```bash
+mkdir -p ./complexa_setup
+python .claude/skills/_shared/scripts/write_manifest.py \
+    --kind setup \
+    --runtime "$(grep -E '^COMPLEXA_RUNTIME=' .env | cut -d= -f2)" \
+    --preflight ./complexa_setup/preflight.json \
+    --out ./complexa_setup/run_manifest.json
+```
+
+Surface the resulting files to the user:
+
+```bash
+ls -la ./complexa_setup/
+```
+
+Expected contents:
+
+```
+complexa_setup/
+├── preflight.json      # GPU / disk / .env / ckpt / tool snapshot
+└── run_manifest.json   # init + download invocations + git SHA + runtime
+```
+
+## Hardware requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| GPU | 1× CUDA GPU, ≥24 GB VRAM | A100 / H100 / L40S, 40–80 GB VRAM |
+| CUDA | 12.0 | 12.4+ |
+| Disk (CKPT_PATH) | 50 GB | 150 GB (covers `--everything`) |
+| RAM | 16 GB | 64 GB+ |
+| OS | Ubuntu 22.04+ (UV) | Ubuntu 22.04+ or Docker on any host |
+
+Ubuntu 20.04 throws GLIBC errors with the UV runtime — use `complexa init
+--runtime docker` on those hosts. See `.claude/skills/_shared/reference/hardware.md`
+for per-pipeline (binder vs ligand vs AME) requirements.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `complexa: command not found` | Package not installed in active env | `source .venv/bin/activate` then `pip install -e .` |
+| `complexa init` says `.env_example not found` | Running outside repo root | `cd` to the project root (where `.env_example` lives) |
+| `.env_example not found. Cannot initialize .env.` | Not in project root | `cd` into `protein-foundation-models/` and retry |
+| `complexa download` fails on NGC URL | Behind firewall / no internet | Configure a proxy for the download script, or download the model `.ckpt`s manually from the NGC pages linked in the main `README.md` and drop them into `./ckpts/` |
+| `complexa download --status` shows ckpts present but `validate` fails | `.env` `CKPT_PATH` points elsewhere | Either move ckpts or edit `LOCAL_CHECKPOINT_PATH` in `.env` |
+| GLIBC error on import | Ubuntu 20.04 with UV runtime | Re-run `complexa init --runtime docker` and use `./env/docker-ops.sh run` |
+
+---
+
+For the full `.env` reference (every key, defaults, failure modes), see
+[reference/env_keys.md](reference/env_keys.md).
+
+For the full download flag matrix, NGC URLs, and destination layout, see
+[reference/downloads.md](reference/downloads.md).

--- a/plugins/bionemo-agent-toolkit/skills/complexa-setup/reference/downloads.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-setup/reference/downloads.md
@@ -1,0 +1,146 @@
+# `complexa download` Reference
+
+Full flag matrix, destination layout, and NGC source for every checkpoint
+Complexa can pull.
+
+`complexa download` is a thin Python wrapper around `env/download_startup.sh`
+— the CLI argparse (in `src/proteinfoundation/cli/cli_runner.py:download_main`)
+forwards `sys.argv[2:]` straight to the bash script, so any flag the bash
+script accepts is reachable.
+
+---
+
+## Flag matrix
+
+The Python argparse explicitly defines these flags:
+
+| Flag | What it downloads | Destination | Approx size | Source |
+|------|-------------------|-------------|-------------|--------|
+| `--complexa` | `complexa.ckpt` + `complexa_ae.ckpt` (protein binder) | `./ckpts/` | ~3 GB | NGC `proteina_complexa` |
+| `--complexa-ligand` | `complexa_ligand.ckpt` + `complexa_ligand_ae.ckpt` (ligand binder) | `./ckpts/` | ~3 GB | NGC `proteina_complexa_ligand` |
+| `--complexa-ame` | `complexa_ame.ckpt` + `complexa_ame_ae.ckpt` (motif scaffolding) | `./ckpts/` | ~3 GB | NGC `proteina_complexa_ame` |
+| `--complexa-all` | All three Complexa pairs | `./ckpts/` | ~9 GB | NGC (3 models) |
+| `--all` | ProteinMPNN + LigandMPNN + AF2 + ESM2 + ESMFold + RF3 | `./community_models/...` | ~50 GB | Mixed (GitHub + AWS + HF + NGC) |
+| `--everything` | All Complexa + community + Boltz2 | both | ~100+ GB | Mixed |
+| `--status` | Show install state; downloads nothing | (none) | n/a | n/a |
+
+The underlying bash script also accepts per-model flags (`--pmpnn`,
+`--ligmpnn`, `--af2`, `--esm2`, `--esmfold`, `--rf3`, `--boltz2`) that pass
+through unchanged. They are listed in `env/download_startup.sh:show_help` but
+not in the Python argparse — they still work because of the `sys.argv[2:]`
+passthrough.
+
+| Passthrough flag | Destination | Approx size |
+|------------------|-------------|-------------|
+| `--pmpnn` | `./community_models/ProteinMPNN/{ca,vanilla}_model_weights/` | ~50 MB |
+| `--ligmpnn` | `./community_models/LigandMPNN/model_params/` | ~500 MB |
+| `--af2` | `./community_models/ckpts/AF2/params/` | ~3 GB |
+| `--esm2` | `./community_models/ckpts/ESM2/` | ~2.5 GB |
+| `--esmfold` | `./community_models/ckpts/ESMFold/` | ~8.5 GB |
+| `--rf3` | `./community_models/ckpts/RF3/` | ~10 GB |
+| `--boltz2` | `./community_models/ckpts/Boltz2/` | ~5 GB |
+
+---
+
+## Default destinations
+
+All downloads land relative to the *current working directory* (the script
+`cd`s to project root, derived from `PROJECT_ROOT` inside `download_startup.sh`).
+
+```
+$PROJECT_ROOT/
+├── ckpts/                                   ← all 6 Complexa ckpts here, flat
+│   ├── complexa.ckpt                        ← protein binder model
+│   ├── complexa_ae.ckpt                     ← protein binder autoencoder
+│   ├── complexa_ligand.ckpt                 ← ligand binder model
+│   ├── complexa_ligand_ae.ckpt              ← ligand binder autoencoder
+│   ├── complexa_ame.ckpt                    ← AME motif scaffolding model
+│   └── complexa_ame_ae.ckpt                 ← AME autoencoder
+└── community_models/
+    ├── ProteinMPNN/
+    │   ├── ca_model_weights/                ← Cα-only weights
+    │   └── vanilla_model_weights/           ← full-backbone weights
+    ├── LigandMPNN/model_params/             ← LigandMPNN weights
+    └── ckpts/
+        ├── AF2/params/                      ← AlphaFold2 .npz / .pkl params
+        ├── ESM2/                            ← ESM2-650M weights
+        ├── ESMFold/                         ← ESMFold model
+        ├── RF3/                             ← RoseTTAFold3 ckpt
+        └── Boltz2/                          ← Boltz2 (optional)
+```
+
+Note: `LOCAL_CHECKPOINT_PATH` in `.env` defaults to `${LOCAL_CODE_PATH}/ckpts`,
+which matches where `complexa download` writes Complexa ckpts. If you edit
+`LOCAL_CHECKPOINT_PATH` to point elsewhere, you must also move (or symlink)
+the existing `./ckpts/` contents — `complexa download` always writes to
+`$PROJECT_ROOT/ckpts/` regardless of the `.env` setting.
+
+---
+
+## The three Complexa model variants
+
+| Variant | Pipeline config | Required ckpt pair | Use case |
+|---------|----------------|---------------------|----------|
+| Protein binder | `configs/search_binder_local_pipeline.yaml` | `complexa.ckpt` + `complexa_ae.ckpt` | De novo binders for protein targets (PDL1, EGFR, etc.) |
+| Ligand binder | `configs/search_ligand_binder_local_pipeline.yaml` | `complexa_ligand.ckpt` + `complexa_ligand_ae.ckpt` | Binders to small-molecule pockets (FAD, OQO, etc.) |
+| AME | `configs/search_ame_local_pipeline.yaml` | `complexa_ame.ckpt` + `complexa_ame_ae.ckpt` | Scaffolding catalytic / functional motifs with ligand context |
+
+Each pipeline YAML has three checkpoint fields at the top level that you
+**must** point at your local ckpts. After `complexa download --complexa-all`
+they will be at `./ckpts/complexa{,_ae,_ligand,_ligand_ae,_ame,_ame_ae}.ckpt`:
+
+```yaml
+ckpt_path: ./ckpts
+ckpt_name: complexa.ckpt
+autoencoder_ckpt_path: ./ckpts/complexa_ae.ckpt
+```
+
+Or override on the CLI without editing the YAML:
+
+```bash
+complexa design configs/search_binder_local_pipeline.yaml \
+    ++ckpt_path=./ckpts \
+    ++ckpt_name=complexa.ckpt \
+    ++autoencoder_ckpt_path=./ckpts/complexa_ae.ckpt
+```
+
+> Note: `complexa download` always uses a *flat* `./ckpts/` layout. If you
+> downloaded ckpts manually into per-variant subdirectories
+> (`ckpts/complexa_protein/`, etc.), update the pipeline YAML `ckpt_path` to
+> match — or move/symlink into the flat layout.
+
+---
+
+## `complexa download --status` output
+
+Example output (post `--complexa-all` + `--af2`, no RF3 or ESMFold):
+
+```
+═══════════════════════════════════════════
+  Installation Status
+═══════════════════════════════════════════
+    Complexa (Protein): ✓ Installed (./ckpts/)
+    Complexa (Ligand):  ✓ Installed (./ckpts/)
+    Complexa (AME):     ✓ Installed (./ckpts/)
+    ProteinMPNN:     ○ Missing (community_models/ProteinMPNN/)
+    LigandMPNN:      ○ Missing (community_models/LigandMPNN/model_params/)
+    AF2:             ✓ Installed (community_models/ckpts/AF2/)
+    ESM2:            ○ Not installed (community_models/ckpts/ESM2/)
+    ESMFold:         ○ Not installed (community_models/ckpts/ESMFold/)
+    RF3:             ○ Missing (community_models/ckpts/RF3/)
+    Boltz2:          ○ Missing (community_models/ckpts/Boltz2/)
+═══════════════════════════════════════════
+```
+
+Read each row as: `<Model name>: <✓ Installed | ○ Missing> (<destination>)`.
+Re-run `complexa download --<flag>` for any row that is missing.
+
+---
+
+## Tips
+
+- Run `complexa download --status` **before** any download — it shows what is already on disk and saves re-downloading.
+- Re-running `complexa download --<flag>` is idempotent: existing non-empty ckpts are skipped (`download_complexa_weights` checks `[ -f "$fm_ckpt" ] && [ -s "$fm_ckpt" ]`).
+- Failed downloads leave a zero-byte file then `rm -f` it — safe to retry without manual cleanup.
+- For ESM2 / ESMFold specifically: set `HF_TOKEN` in `.env` before downloading to avoid HF Hub rate limits.
+- `complexa download --everything` will fetch every model the script supports (~100 GB). Prefer the targeted flags unless you actually need all variants.

--- a/plugins/bionemo-agent-toolkit/skills/complexa-setup/reference/env_keys.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-setup/reference/env_keys.md
@@ -1,0 +1,185 @@
+# `.env` Key Reference
+
+Complete reference for every variable in `.env_example`. Sections mirror the
+ones in `.env_example` itself. Each entry says: required vs optional, default,
+what reads it, and the failure mode if it is missing or wrong.
+
+`.env` is loaded by `python-dotenv` via `proteinfoundation/cli/validate.py:load_env_config`
+and resolved into Hydra configs via `${oc.env:VARIABLE_NAME}` interpolation.
+Missing required variables surface as Hydra `InterpolationKeyError` at config
+resolution time — intentional, so you see exactly which key is missing.
+
+---
+
+## Section 1 — Required
+
+You must set these before running any pipeline command. `complexa init` does
+not fill these in; it only copies `.env_example` and rewrites runtime-dependent
+lines.
+
+### `LOCAL_CODE_PATH`
+
+- **Required.** No default — `.env_example` ships with a placeholder.
+- Absolute path to this repo checkout on the host.
+- Read by: `COMMUNITY_MODELS_PATH`, `AF2_DIR`, `ESM_DIR`, `ESMFOLD_DIR`, `RF3_DIR`, `RF3_CKPT_PATH`, `UV_VENV` (all derived via `${LOCAL_CODE_PATH}/...`).
+- **Failure mode**: every community-model and tool path resolves to `/path/to/protein-foundation-models/...` which does not exist → `complexa validate evaluate` / Hydra `FileNotFoundError`.
+- Fix: edit to an absolute path, e.g. `LOCAL_CODE_PATH=/home/me/code/protein-foundation-models`.
+
+### `LOCAL_DATA_PATH`
+
+- **Required.** Default placeholder `/path/to/PFM_data`.
+- Absolute path to the PFM data directory (target PDBs under `target_data/`, datasets, etc.).
+- Read by: `DATA_PATH` (active alias rewritten by `complexa init`); `complexa validate env` requires this to point at an existing directory.
+- **Failure mode**: `complexa validate env` reports `DATA_PATH: Directory not found`; `complexa validate target` fails to locate `target_data/`.
+- Fix: edit, then `mkdir -p $LOCAL_DATA_PATH` and populate it with the target PDBs you plan to design against (the bundled examples ship under `assets/target_data/`, or build your own with the `complexa-target` skill).
+
+---
+
+## Section 2 — Credentials (all optional)
+
+### `GITLAB_TOKEN`
+
+- **Optional.** Default placeholder `TOKEN_HERE`.
+- Used by `env/docker-ops.sh` to authenticate against a private Docker registry (only relevant if you build the image yourself and push it somewhere that needs a token).
+- **Failure mode if missing**: `docker login` is skipped → cannot pull private images. The default Dockerfile build (`docker build -f env/docker/Dockerfile .`) and all NGC downloads still work without it.
+- Fix: set if you have your own private registry configured via `REGISTRY` / `DOCKER_IMAGE`.
+
+### `WANDB_API_KEY` / `WANDB_ENTITY`
+
+- **Optional.** Default placeholders `YOUR_WANDB_KEY` / `YOUR_WANDB_ENTITY`.
+- Used by training code (`proteinfoundation.train`) for run logging.
+- Placeholder values are explicitly *not* injected — W&B logging is silently disabled when either is a placeholder.
+- **Failure mode if missing**: no W&B logging; training still runs.
+- Fix: set both if you want training runs tracked.
+
+### `HF_TOKEN`
+
+- **Optional.** Default placeholder `HF_TOKEN_HERE`.
+- Read by `env/download_startup.sh` (the script behind `complexa download`) when pulling ESM2 / ESMFold from Hugging Face Hub.
+- **Failure mode if missing**: ESM2 / ESMFold downloads may hit anonymous rate limits or fail for gated repos. Other downloads (NGC, GitHub) work without it.
+- Fix: set if `--esm2` or `--esmfold` downloads fail with 401/429.
+
+---
+
+## Section 3 — Local options (all optional)
+
+### `LOCAL_CACHE_DIR`
+
+- **Optional.** Default `${LOCAL_CODE_PATH}/.cache`.
+- Active alias `CACHE_DIR` resolves to this for UV runtime.
+- Used for Hydra cache, foldseek temp, HuggingFace hub cache.
+- **Failure mode if missing**: defaults work for almost everyone; set only if `.cache` should live on a faster / larger disk.
+
+### `LOCAL_CHECKPOINT_PATH`
+
+- **Optional.** Default in `.env_example`: `${LOCAL_CODE_PATH}/checkpoints`.
+- Active alias `CKPT_PATH` resolves to this for UV runtime.
+- Note: `complexa download` always writes Complexa model + AE checkpoints to `$PROJECT_ROOT/ckpts/` (a sibling of `checkpoints/`) regardless of this setting. If you want `CKPT_PATH` to point at the download location, set `LOCAL_CHECKPOINT_PATH=${LOCAL_CODE_PATH}/ckpts` after running `complexa download`.
+- **Failure mode if missing**: pipeline configs resolve `${oc.env:CKPT_PATH}` to the default — if the directory doesn't exist or is empty, loading the model fails.
+- Fix: either run `complexa download --complexa-all` and set `LOCAL_CHECKPOINT_PATH=${LOCAL_CODE_PATH}/ckpts`, or move/symlink the downloaded ckpts into the `checkpoints/` default.
+
+### `DOCKER_MOUNTS`
+
+- **Optional.** Default empty.
+- Comma-separated `host:container` pairs added to `env/docker-ops.sh run`.
+- **Failure mode if missing**: only standard mounts (`LOCAL_CODE_PATH`, `LOCAL_DATA_PATH`) are exposed to the container.
+- Fix: set if you need extra paths visible inside the container — e.g. `DOCKER_MOUNTS=/scratch:/scratch,/lustre:/lustre`.
+
+### `LOGURU_LEVEL`
+
+- **Optional.** Default `INFO`.
+- Read by `loguru` for Python log verbosity.
+- Set to `DEBUG` for verbose pipeline logs, `WARNING` for quieter runs.
+
+### `USE_V2_COMPLEXA_ARCH`
+
+- **Optional.** Default `False`.
+- Set to `True` only when using V2 Complexa model weights. The default-shipped checkpoints are V1.
+- **Failure mode if wrong**: loading a V2 ckpt with this `False` (or a V1 ckpt with this `True`) throws a state-dict mismatch at model load time.
+
+---
+
+## Section 4 — Docker image (rarely edited)
+
+These are read by `env/docker-ops.sh build/pull/run`.
+
+### `REGISTRY` / `REGISTRY_USER`
+
+- **Required only for `docker-ops.sh push/pull` against a private registry.** Defaults in `.env_example`: `registry.example.com` / `'$oauthuser'` (placeholders — you must edit if pushing/pulling).
+- Used in `docker login` and tagging. Local `docker build` does not need these.
+
+### `DOCKER_IMAGE`
+
+- **Required for `docker-ops.sh run` (Docker runtime).** Default placeholder `registry.example.com/org/repo:tag`.
+- Tag of the image `docker-ops.sh run` will start. If you built the image yourself with `docker build -t proteina-complexa -f env/docker/Dockerfile .`, set this to `proteina-complexa:latest`.
+
+### `CONTAINER_NAME`
+
+- **Required for Docker runtime.** Default `proteina-dev`.
+- Name applied to `docker run --name`; reused for `exec` / `stop`.
+
+### `DOCKERFILE_PATH`
+
+- **Required for `docker-ops.sh build`.** Default `env/docker/Dockerfile`.
+- Path (relative to `LOCAL_CODE_PATH`) of the Dockerfile used by `docker-ops.sh build`.
+
+---
+
+## Auto-managed — do not edit by hand
+
+These are rewritten by `complexa init` based on the `--runtime` flag. Editing
+them manually will be overwritten the next time `complexa init` runs (without
+`--force`, it still swaps the runtime-dependent lines).
+
+### `COMPLEXA_RUNTIME`
+
+- Set to `uv` or `docker` by `complexa init`. Read by tooling that needs to know which prefix to resolve.
+
+### `DATA_PATH` / `CACHE_DIR` / `CKPT_PATH`
+
+- Active aliases. Resolve to `${LOCAL_*}` for UV runtime or `${DOCKER_*}` for Docker runtime. Edit `LOCAL_*` / `DOCKER_*` instead.
+
+### `FOLDSEEK_EXEC` / `RF3_EXEC_PATH` / `SC_EXEC` / `HBPLUS_EXEC` / `MMSEQS_EXEC` / `DSSP_EXEC` / `TMOL_PATH`
+
+- Active tool binaries. Resolve to `${UV_*}` or `${DOCKER_*}` per runtime. Edit the prefix vars if you have a non-standard install (e.g. system-wide `foldseek` at `/usr/local/bin/foldseek` instead of `.venv/bin/foldseek`).
+- Used by: `complexa evaluate` (foldseek for diversity; mmseqs for sequence clustering; hbplus/sc for interface metrics; dssp for secondary structure; tmol for force-field metrics).
+- **Failure mode if path is wrong**: the tool is silently skipped (treated as a warning in `complexa validate evaluate`), and the corresponding metric column is missing from the result CSV.
+
+### `AF2_DIR` / `ESM_DIR` / `ESMFOLD_DIR` / `RF3_DIR` / `RF3_CKPT_PATH`
+
+- **Auto-managed by `complexa init`, but you must point them at real weight dirs for evaluation/reward to work.**
+- Derived from `${LOCAL_CODE_PATH}/community_models/ckpts/...`. After `complexa download --all` or `complexa download --af2`, the directories under `community_models/ckpts/` are populated.
+- Read by: reward models (`AF2RewardModel`, `RF3RewardRunner`) and evaluation folding (colabdesign / rf3 backends).
+- **Failure mode if wrong**: `complexa validate evaluate` reports `AF2 weights: Directory not found` or `RF3 checkpoint: File not found`. Generation can still run without these; only reward and refolding break.
+
+### `RF3_CKPT_PATH`
+
+- Default `${RF3_DIR}/rf3_foundry_01_24_latest_remapped.ckpt` — exact filename produced by `complexa download --rf3`. If you have a different RF3 checkpoint, edit to its full path.
+
+### `COMMUNITY_MODELS_PATH`
+
+- Default `${LOCAL_CODE_PATH}/community_models`. Edit only if you mirror community models on a separate disk.
+
+### `UV_VENV` / `UV_*_EXEC` / `DOCKER_*_EXEC`
+
+- Per-runtime tool-path families. `complexa init` selects which family the active `FOLDSEEK_EXEC` etc. point at. Edit the *family member* (e.g. `UV_FOLDSEEK_EXEC`) only if your local install lives somewhere unusual.
+
+### `DOCKER_REPO_PATH` / `DOCKER_DATA_PATH` / `DOCKER_PYTHONPATH` / `DOCKER_CHECKPOINT_PATH` / `DOCKER_CACHE_DIR` / `DOCKER_HF_HOME` / `DOCKER_HF_HUB_CACHE`
+
+- Container-internal paths inside the Complexa Docker image. Hard-coded to `/workspace/...`; only edit if you ship a custom image with different layout.
+
+---
+
+## What `complexa validate env` actually checks
+
+From `src/proteinfoundation/cli/validate.py:validate_env`:
+
+1. `.env` file exists in CWD (or any parent up to the repo root).
+2. `DATA_PATH` env var is set and resolves to an existing directory.
+
+That is the full check. It does not validate ckpts, tool binaries, or HF
+tokens. Those are checked by `complexa validate {generate,evaluate,design}
+<config>` which loads a pipeline YAML and verifies the paths each stage will
+actually read. Run `complexa validate design configs/search_binder_local_pipeline.yaml`
+once after editing `.env` to catch missing AF2/RF3/foldseek before the first
+real pipeline run.

--- a/plugins/bionemo-agent-toolkit/skills/complexa-sweep/SKILL.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-sweep/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: complexa-sweep
+description: Use this skill whenever the user wants to run a parameter sweep over a Proteina-Complexa design pipeline — cartesian-product hyperparameter scans, Pareto search over generation/reward/evaluation knobs, or any "compare configurations" workflow. Trigger phrases include "sweep beam width", "sweep nsteps", "hyperparameter sweep", "parameter scan", "scan beam_width and temperature", "compare configurations", "find the best generation params", "what's the optimal nsteps", "Pareto search for binder quality vs wall-clock", "complexa sweep", "tune Complexa", "ablate the reward weights", "configs/sweeps", "--sweeper", "run beam_width.yaml". This is the only skill that owns sweeper YAML authoring, cartesian-product expansion, and per-config result ranking.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# complexa-sweep
+
+Run cartesian-product parameter sweeps over Proteina-Complexa design pipelines. Pick or author a sweeper YAML in `configs/sweeps/`, expand it to N inference configs with `script_utils/generate_inference_configs.py`, loop `complexa design` over those configs, then aggregate per-config success metrics into a ranked summary CSV plus a manifest.
+
+> **Important:** The `complexa design` CLI does **NOT** accept `--sweeper` directly. Sweeps are driven by `script_utils/generate_inference_configs.py`, which writes one `configs/inference_configs/inf_{idx}_{run_name}.yaml` per sweep combination. You then loop `complexa design` over those generated configs.
+
+## What this skill enables
+
+- Pick an existing sweeper YAML from `configs/sweeps/` (`beam_width`, `bb_ca_temperature`, `search_replicas`, `example`).
+- Author a new sweeper YAML with arbitrary dot-notation axes (cartesian product).
+- Generate N inference + evaluation config pairs with `script_utils/generate_inference_configs.py`.
+- Loop `complexa design` over the generated configs (one at a time on a single GPU, or in parallel on a multi-GPU host by sharding the config list across `CUDA_VISIBLE_DEVICES`).
+- Walk per-config output directories and parse the analyze-step CSV from each.
+- Emit `sweep_summary.csv` (one row per config: axis values + success rate + mean iPAE + diversity) and `sweep_manifest.json`.
+- Identify the best config by success rate and the Pareto frontier (wall-clock vs success).
+
+## Step 1: Pre-flight
+
+```bash
+bash .claude/skills/_shared/scripts/preflight.sh
+```
+
+Read `./complexa_setup/preflight.json`. A sweep multiplies GPU time by the number of configs. **Before launching, confirm the cost with the user**:
+
+> "This sweep produces N configs × ~M minutes per config ≈ TOTAL GPU-hours. OK to proceed? (y / reduce / cancel)"
+
+If `gpu.available=false`, stop — sweeps are not feasible on CPU.
+
+## Step 2: Pick the pipeline + target
+
+Use the same dialogue as `complexa-design` — do **not** duplicate it here. See [`.claude/skills/complexa-design/SKILL.md`](../complexa-design/SKILL.md) Step 2 ("Pick the pipeline") and Step 3 ("Gather parameters"). Capture:
+
+- `pipeline_config_name` — e.g. `search_binder_local_pipeline` (default), `search_ligand_binder_local_pipeline`, `search_ame_local_pipeline`.
+- `task_name` — e.g. `02_PDL1`, `22_DerF21`, `39_7V11_LIGAND`. Passed as `--override generation.task_name=<task>`.
+- `run_name` — short tag for output dir naming.
+
+## Step 3: Pick or author the sweeper YAML
+
+Sweeper YAMLs live in `configs/sweeps/`. Each key is a dot-notation Hydra path; each value is a list. The cartesian product becomes N configs.
+
+### Canned sweepers
+
+| File | Axis | Values | Configs |
+|---|---|---|---|
+| `configs/sweeps/beam_width.yaml` | `generation.search.beam_search.beam_width` | 1, 2, 4, 8 | 4 |
+| `configs/sweeps/bb_ca_temperature.yaml` | `generation.model.bb_ca.simulation_step_params.sc_scale_noise` | 0.1, 0.4 | 2 |
+| `configs/sweeps/search_replicas.yaml` | `generation.search.best_of_n.replicas` | 1, 4, 16, 64 | 4 |
+| `configs/sweeps/example.yaml` | beam_width × nsteps | (2,4) × (200,400) | 4 |
+
+If one matches the user's intent, use it as-is. Otherwise author a new file.
+
+### Authoring a new sweeper
+
+Minimal multi-axis example (saved to `configs/sweeps/my_sweep.yaml`):
+
+```yaml
+# 3 beam widths × 2 nsteps = 6 configs
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+  - 8
+
+generation.args.nsteps:
+  - 200
+  - 400
+```
+
+Rules (from `script_utils/generate_inference_configs.py:load_sweeper_file`):
+
+- Top-level mapping only. Keys are dot-notation Hydra paths.
+- Values must be **lists**. A scalar is auto-wrapped into a single-element list (which pins a value without adding a dimension).
+- Cartesian product: total configs = product of list lengths. Two 4-value axes = 16 configs; budget accordingly.
+- If a key appears in both the sweeper file and an `--override`, the override wins and that axis collapses.
+
+See [reference/sweep_axes.md](reference/sweep_axes.md) for the full catalogue of swept keys (typical ranges, cost multipliers, what improves/regresses).
+
+### Dry-run preview before generating
+
+Always confirm the config count first:
+
+```bash
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_local_pipeline \
+    --sweeper configs/sweeps/my_sweep.yaml \
+    --override generation.task_name=22_DerF21 \
+    --run_name my_sweep \
+    --dryrun
+```
+
+The output lists every axis + value list and prints `DRY RUN — would generate N config pair(s)`.
+
+## Step 4: Generate configs + loop `complexa design`
+
+Once the dry-run looks right, drop `--dryrun` to materialize `inf_{idx}_{run_name}.yaml` + `eval_{idx}_{run_name}.yaml` pairs under `configs/inference_configs/` and `configs/eval_configs/`. Then loop `complexa design` over the inference configs.
+
+```bash
+# 1. Generate one inf_*.yaml + one eval_*.yaml per combination.
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_local_pipeline \
+    --sweeper configs/sweeps/my_sweep.yaml \
+    --override generation.task_name=22_DerF21 \
+    --run_name my_sweep
+
+# 2. Loop complexa design over each generated inference config.
+for cfg in configs/inference_configs/inf_*_my_sweep.yaml; do
+    complexa design "$cfg" || echo "FAILED: $cfg"
+done
+```
+
+This serialises the sweep on a single GPU — be honest with the user that wall-clock = N × per-run.
+
+### Multi-GPU host (optional speed-up)
+
+On a host with K GPUs, shard the config list K ways and launch one loop per GPU in parallel. Each `complexa design` call uses exactly one GPU at default `gen_njobs=1` / `eval_njobs=1`, so pinning via `CUDA_VISIBLE_DEVICES` keeps them from colliding:
+
+```bash
+CONFIGS=(configs/inference_configs/inf_*_my_sweep.yaml)
+N=${#CONFIGS[@]}; K=4   # 4 GPUs
+for gpu in $(seq 0 $((K-1))); do
+    (
+        for i in $(seq $gpu $K $((N-1))); do
+            CUDA_VISIBLE_DEVICES=$gpu complexa design "${CONFIGS[$i]}" \
+                || echo "FAILED on GPU $gpu: ${CONFIGS[$i]}"
+        done
+    ) &
+done
+wait
+```
+
+Drop `gen_njobs` / `eval_njobs` overrides into the loop only if you intentionally want each `complexa design` invocation to consume multiple GPUs (and you have a way to keep them out of each other's way).
+
+## Step 5: Collect results
+
+Each swept config writes to its own `./inference/inf_{idx}_{run_name}/` directory; the analyze step writes `./evaluation_results/eval_{idx}_{run_name}/results_*.csv`. After the sweep finishes:
+
+```bash
+ls -d ./inference/inf_*_my_sweep/
+ls ./evaluation_results/eval_*_my_sweep/results_*.csv
+```
+
+For each config, parse the analyze CSV (one row per generated binder). Standard columns used for ranking: `i_pae`, `i_plddt`, `sc_rmsd`, `binder_seq`, `passes_filter` (bool). If `passes_filter` is missing, derive a success flag with the user's chosen thresholds (defaults: `i_pae < 10`, `i_plddt > 0.7`, `sc_rmsd < 2.0` — confirm with user).
+
+## Step 6: Rank configs
+
+Emit `sweep_summary.csv` to the run directory. One row per config:
+
+| Column | How to compute |
+|---|---|
+| `config_id` | The `{idx}` from `inf_{idx}_{run_name}` |
+| `<axis_1>`, `<axis_2>`, ... | The swept value at this combination (read from the per-config `inf_*.yaml`) |
+| `n_samples` | Row count in the analyze CSV |
+| `success_rate` | `passes_filter.mean()` |
+| `mean_i_pae` | `i_pae.mean()` (lower = better) |
+| `mean_i_plddt` | `i_plddt.mean()` (higher = better) |
+| `diversity_score` | Unique sequence count / `n_samples` (or use TM-score clustering if available) |
+| `wall_clock_min` | From the per-config log timestamps |
+
+Then report:
+
+- **Best config** = argmax of `success_rate`. Tie-break on `mean_i_pae` (lower).
+- **Pareto frontier** over (`wall_clock_min`, `success_rate`): a config is on the frontier iff no other config is both faster AND has higher success rate.
+
+Print the best config + the frontier to the terminal. Save the full table to `sweep_summary.csv`.
+
+## Step 7: Emit manifest
+
+Capture the resolved invocation + outputs for replay. The shared helper takes a single `--output-dir` (it walks for CSVs and pulls the Hydra config from the run's `.hydra/`), so call it against the best-config's evaluation directory and pass the parent `complexa design` command for that run:
+
+```bash
+BEST_ID=4   # from Step 6 ranking
+python3 .claude/skills/_shared/scripts/write_manifest.py \
+    --output-dir ./evaluation_results/eval_${BEST_ID}_my_sweep \
+    --command "python script_utils/generate_inference_configs.py --config_name search_binder_local_pipeline --sweeper configs/sweeps/my_sweep.yaml --override generation.task_name=22_DerF21 --run_name my_sweep && for cfg in configs/inference_configs/inf_*_my_sweep.yaml; do complexa design \"\$cfg\"; done" \
+    --skill complexa-sweep \
+    --out ./sweep_runs/my_sweep/sweep_manifest.json
+```
+
+Alongside the manifest, save the ranked `sweep_summary.csv` from Step 6 to `./sweep_runs/my_sweep/sweep_summary.csv` and surface both paths to the user.
+
+## Recommended sweep recipes
+
+| Symptom | Sweep this | Why |
+|---|---|---|
+| Quality not good enough | `beam_width × nsteps` (use `example.yaml` as a starting point) | Both raise compute → quality; find the cheapest combination that lands. |
+| Too slow / want speed-up | `nsteps` downward (e.g. `[100, 200, 400]`) with fixed `beam_width=4` | Find the smallest nsteps that retains success rate. |
+| Mode collapse / low diversity | `generation.model.bb_ca.simulation_step_params.sc_scale_noise` (use `bb_ca_temperature.yaml`) | Higher noise → more diverse backbones. |
+| Reward over-fitting (high reward, bad metrics) | `generation.reward_model.reward_models.af2folding.reward_weights.{i_pae, plddt}` ratio | Re-balance composite reward. |
+| Want statistical robustness on one config | `search_replicas.yaml` (`best_of_n.replicas`) | Same config, more samples → tighter success-rate estimate. |
+| Algorithm shoot-out | `generation.search.algorithm` over `[single-pass, best-of-n, beam-search, fk-steering]` | Compare search regimes; pin everything else. |
+
+## Hardware
+
+Total GPU-time for a sweep = `N_configs × per_run_GPU_time`. A single `search_binder_local_pipeline` run on one A100 is roughly 30–90 min (binder length + nsteps dependent). A 4-axis × 4-value sweep = 256 configs × ~60 min = ~256 GPU-hours — at that scale, plan on a multi-GPU host with the Step-4 sharding pattern.
+
+Refer to [`.claude/skills/_shared/reference/hardware.md`](../_shared/reference/hardware.md) for the per-run baseline + VRAM minima.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Sweeper file not found` from `generate_inference_configs.py` | Path resolved from wrong CWD | Use a path relative to the repo root; or pass an absolute path. |
+| `Sweeper YAML must be a mapping` | Top-level YAML is a list or scalar | Rewrite as `key: [v1, v2]` mapping. |
+| `No configs were generated` | One of the value lists is empty `[]` | Sweeper file has a `key: []` line — add at least one value. |
+| `complexa design` rejects `--sweeper` | Confusion between entrypoints | The CLI does not accept `--sweeper`. Use `generate_inference_configs.py` first, then loop `complexa design` over the generated configs. |
+| Override silently collapses a sweep axis | `--override key=v` shadowed a sweep key | Drop either the override OR the matching key from the sweeper file. |
+| One config in the loop fails, sweep keeps going | The `\|\| echo "FAILED…"` in Step 4 swallows the error | Re-run the failed `inf_*.yaml` standalone; check the per-config log under `./logs/`. Skip failed `config_id` when ranking. |
+
+---
+
+For per-axis reference (typical ranges, cost, what gets better/worse), see [reference/sweep_axes.md](reference/sweep_axes.md).
+
+For the user-facing sweep system overview (config generation, output layout), see [`docs/SWEEP.md`](reference/SWEEP.md).

--- a/plugins/bionemo-agent-toolkit/skills/complexa-sweep/reference/SWEEP.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-sweep/reference/SWEEP.md
@@ -1,0 +1,303 @@
+# Sweep System
+
+How to run parameter sweeps and override experiment settings without modifying source code.
+
+> **Documentation Map**
+> - Running a design? See [Inference Guide](INFERENCE.md)
+> - Tuning YAML configs? See [Configuration Guide](CONFIGURATION_GUIDE.md)
+> - Understanding metrics? See [Evaluation Guide](EVALUATION_METRICS.md)
+> - Search metadata? See [Search Metadata](SEARCH_METADATA.md)
+
+## Overview
+
+The sweep system has two mechanisms that work together:
+
+- **`--sweeper FILE`** loads a YAML file defining one or more parameter axes.
+  All combinations are generated as a cartesian product.
+- **`--override KEY=VAL [KEY=VAL ...]`** pins individual parameters to scalar
+  values, applied to every generated config.
+
+Both can be used independently or combined. When a key appears in both the
+sweeper file and the CLI overrides, the override wins and that axis is
+collapsed to a single value.
+
+## Quick Start
+
+```bash
+# 1. Single experiment with a specific target (no sweep)
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --override generation.task_name=22_DerF21
+
+# 2. Sweep beam widths for a single target
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+
+# 3. Sweep beam widths with nsteps pinned to 400
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21 generation.args.nsteps=400
+
+# 4. Dry run to preview config generation
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_pipeline \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21 \
+    --dryrun
+```
+
+## Sweep YAML Format
+
+Sweep files live in `configs/sweeps/`. Each key is a dot-notation config path
+and each value is a list of values to sweep over:
+
+```yaml
+# configs/sweeps/beam_width.yaml
+generation.search.beam_search.beam_width:
+  - 1
+  - 2
+  - 4
+  - 8
+```
+
+Multiple axes produce a cartesian product:
+
+```yaml
+# 3 beam widths x 2 nsteps = 6 configs
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+  - 8
+
+generation.args.nsteps:
+  - 200
+  - 400
+```
+
+Long values (e.g., checkpoint paths) benefit from YAML block-list style:
+
+```yaml
+ckpt_path:
+  - /path/to/checkpoints/model_v1/epoch_100.ckpt
+  - /path/to/checkpoints/model_v2/epoch_200.ckpt
+  - /path/to/checkpoints/model_v3/epoch_50.ckpt
+```
+
+A scalar value (not a list) is automatically wrapped in a single-element list,
+so it pins that parameter without adding a sweep dimension:
+
+```yaml
+generation.args.self_cond: true
+```
+
+## `--override` Format
+
+Override arguments are `KEY=VALUE` strings where:
+
+- The key uses dot notation (e.g., `generation.args.nsteps`)
+- The value is auto-typed: integers, floats, booleans (`true`/`false`),
+  null (`null`/`none`), or strings
+
+```bash
+--override generation.task_name=22_DerF21 generation.args.nsteps=400 generation.args.self_cond=true
+```
+
+Multiple overrides are space-separated after a single `--override` flag.
+
+## How It Works
+
+### Config Generation Pipeline
+
+```
+                    +-----------------+
+                    | Sweeper YAML    |  (optional)
+                    +-----------------+
+                            |
+                            v
++-----------+      +------------------+      +-------------------+
+| Pipeline  | ---> | generate_infer-  | ---> | N inf_*.yaml +    |
+| Config    |      | ence_configs.py  |      | N eval_*.yaml     |
++-----------+      +------------------+      +-------------------+
+                            ^
+                            |
+                    +-----------------+
+                    | --override      |  (optional)
+                    | KEY=VAL ...     |
+                    +-----------------+
+```
+
+1. The base pipeline config (e.g., `search_binder_pipeline.yaml`) is loaded
+   via Hydra.
+2. If a `--sweeper` file is provided, its axes are combined into a cartesian
+   product.
+3. For each combination, the sweep values are merged into the base config.
+4. `--override` values are applied on top of every config (overriding sweep
+   values if they conflict).
+5. Each config gets a unique `root_path` and is saved as a pair:
+   `inf_{idx}_{run}.yaml` and `eval_{idx}_{run}.yaml`.
+
+### Config Naming
+
+Generated config filenames follow the pattern:
+
+```
+inf_{index}_{run_name}.yaml
+eval_{index}_{run_name}.yaml
+```
+
+The index is sequential (0, 1, 2, ...) and the run name comes from the
+`--run_name` argument. Task name is intentionally NOT in the filename -- it
+lives inside the config content. This keeps filenames predictable so the bash
+launcher can construct Hydra `--config-name` paths without parsing YAML.
+
+### Directory Structure
+
+On the **remote cluster** (and on-cluster direct launches), configs always live
+at the canonical paths:
+
+```
+configs/
+  inference_configs/
+    inf_0_my_run.yaml
+    inf_1_my_run.yaml
+  eval_configs/
+    eval_0_my_run.yaml
+    eval_1_my_run.yaml
+```
+
+#### Local-to-remote flow (with rsync)
+
+When launching from a local machine, configs are first generated into a unique
+temporary directory (`configs/_gen_XXXXXX/`) so that concurrent launches never
+collide.  Inside the rsync lock, the temp directory contents are **staged**
+(moved) into the canonical `configs/inference_configs/` and
+`configs/eval_configs/` paths, rsync'd to the cluster, and then cleaned up
+locally.
+
+```
+generate_configs()        →  configs/_gen_abc123/{inference_configs,eval_configs}/
+stage_configs_for_sync()  →  configs/{inference_configs,eval_configs}/   (inside lock)
+rsync                     →  $RUN_DIR/configs/{inference_configs,eval_configs}/
+cleanup_staged_configs()  →  local canonical dirs removed                (inside lock)
+```
+
+#### Direct on-cluster flow (no rsync)
+
+When running directly on the cluster, no temp directory is needed.  Configs are
+generated straight into the canonical paths and used in-place by the SLURM
+array jobs.
+
+## Integration with SLURM Scripts
+
+All three launcher scripts accept `--sweeper` and `--override`:
+
+```bash
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+```
+
+The on-cluster script works identically (no rsync needed):
+
+```bash
+./slurm_utils/launch_protein_binder_search_conda.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+```
+
+The multi-target loop wrapper also passes these through:
+
+```bash
+./slurm_utils/launch_protein_binder_search_target_loop_conda.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    ./my_targets.txt
+```
+
+### Legacy Positional Arguments
+
+The `TARGET_TASK` positional argument is still supported for backward
+compatibility. Internally it is converted to
+`--override generation.task_name=$TARGET_TASK`.
+
+## Running Concurrent Experiments
+
+The system is designed for safe concurrent launches:
+
+- **Local config isolation**: Each launch generates configs in a unique
+  `mktemp -d configs/_gen_XXXXXX` directory.  Before rsync (inside the lock),
+  configs are staged to the canonical `configs/inference_configs/` and
+  `configs/eval_configs/` paths, rsync'd, then cleaned up.  This means the
+  generation phase is fully parallel, and the staging+rsync phase is serialised
+  by the lock.
+- **Remote directory uniqueness**: The run name on the cluster includes the
+  sweeper file basename (e.g., `my_run-search-beam_width-22_DerF21`), making
+  collisions nearly impossible for different sweeps.
+- **Lock file for rsync**: The `.lock` file prevents simultaneous rsync
+  operations from corrupting the code copy.
+
+Example: launching two experiments in parallel from different terminals:
+
+```bash
+# Terminal 1: sweep beam widths for target A
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+
+# Terminal 2: sweep replicas for target B (safe to run simultaneously)
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/search_replicas.yaml \
+    --override generation.task_name=02_PDL1
+```
+
+## Running Individual Pipeline Stages
+
+The core Python modules (`generate`, `filter`, `evaluate`, `analyze`) can
+still be run independently with Hydra `++key=value` overrides:
+
+```bash
+# Run just evaluation on existing inference outputs
+python -m proteinfoundation.evaluate \
+    --config-path /path/to/eval_configs \
+    --config-name eval_0_22_DerF21_my_run \
+    ++eval_njobs=4
+```
+
+The sweep system only affects config generation and the bash pipeline
+orchestration. It does not change how individual modules consume configs.
+
+## Migration from Old System
+
+| Old                                        | New                                              |
+|--------------------------------------------|--------------------------------------------------|
+| Edit `sweeper = {...}` dict in Python      | Create a YAML file in `configs/sweeps/`          |
+| `--target_task_override 22_DerF21`         | `--override generation.task_name=22_DerF21`      |
+| `--unified` flag                           | Removed (always unified pipeline mode)           |
+| `--eval_config_name evaluate`              | Removed (eval derived from pipeline config)      |
+| `--infer_config_name search_binder`        | `--config_name search_binder_pipeline`           |
+| `generate_binder_inference_configs.py`     | `generate_inference_configs.py`                  |
+| Hardcoded `ALPHA_PROTEO_TARGETS` list      | Removed (use sweep or override)                  |
+| `rm -rf configs/inference_configs`         | Automatic: temp dir + staging (concurrent-safe)  |
+
+## Tests
+
+The sweep system is covered by `tests/test_sweep.py` (92 tests):
+
+```bash
+pytest tests/test_sweep.py -v
+```
+
+Test categories:
+- `TestParseScalar` / `TestParseOverride`: Value parsing and type inference
+- `TestLoadSweeperFile`: YAML loading and validation
+- `TestBuildSweeper`: Merge logic and conflict resolution
+- `TestDotKeyDictToNestedDict`: Dot-notation conversion
+- `TestGetTaskNameFromConfig` / `TestCreateEvalConfig`: Config helpers
+- `TestApplySweeperAndSaveConfigs`: End-to-end cartesian product, value
+  propagation, unique paths, filename conventions
+- `TestConcurrentSafety`: Parallel generation without collisions
+- `TestBuildParser`: CLI argument parser validation
+- `TestCreateEvalConfigNjobs`: eval_njobs priority regression tests
+- `TestCreateEvalConfigPaths`: Path derivation edge cases
+- `TestEmptySweepAxis`: Zero-config guard regression tests
+- `TestConfigFilenameContract`: Filename contract between Python and bash
+- `TestEvalPathEdgeCases`: Eval path derivation with adversarial inputs

--- a/plugins/bionemo-agent-toolkit/skills/complexa-sweep/reference/sweep_axes.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-sweep/reference/sweep_axes.md
@@ -1,0 +1,156 @@
+# Sweep Axes Reference
+
+Catalogue of swept keys for Proteina-Complexa design pipelines, grouped by pipeline stage. Every key is a Hydra dot-path you can put in a `configs/sweeps/*.yaml` file as a sweep axis (list value) or as an `--override KEY=VAL` pin.
+
+Defaults are read from `configs/pipeline/binder/binder_generate.yaml`, `configs/pipeline/binder/binder_evaluate.yaml`, and `configs/pipeline/model_sampling.yaml`. Verify against your actual base pipeline config before launching — different pipelines (e.g. `search_ligand_binder_local_pipeline`, `search_ame_local_pipeline`) inherit different defaults.
+
+## Generation axes
+
+These live under `generation.*` in the pipeline config (because the base pipeline pulls `binder_generate@generation`).
+
+### Search algorithm + width
+
+| Key | Default | Typical sweep values | Cost multiplier | Effect |
+|---|---|---|---|---|
+| `generation.search.algorithm` | `best-of-n` | `single-pass`, `best-of-n`, `beam-search`, `fk-steering`, `mcts` | 1× → 8× | Search regime. `single-pass` = baseline. `best-of-n` linear in replicas. `beam-search`/`fk-steering` ~ `n_branch × beam_width` extra forward passes. |
+| `generation.search.beam_search.beam_width` | 4 | 1, 2, 4, 8, 16 | linear | More beams = wider search → higher success rate. Diminishing returns past 8 in practice. |
+| `generation.search.beam_search.n_branch` | 4 | 2, 4, 8 | linear | Branching factor per beam step. Together with `beam_width` controls total samples per checkpoint. |
+| `generation.search.beam_search.keep_lookahead_samples` | `true` | `true`/`false` | minor | Whether to keep intermediate lookahead candidates as outputs. Off = fewer final PDBs. |
+| `generation.search.best_of_n.replicas` | 10 | 1, 4, 16, 64 | linear | Best-of-N draws. Increasing tightens success-rate estimate; not search depth. |
+| `generation.search.fk_steering.beam_width` | 4 | 1, 2, 4, 8 | linear | FK-steering equivalent of beam_width. |
+| `generation.search.fk_steering.n_branch` | 4 | 2, 4, 8 | linear | FK-steering branching factor. |
+| `generation.search.fk_steering.temperature` | 0.1 | 0.05, 0.1, 0.2, 0.5 | none | Softmax temperature for FK resampling. Higher = closer to uniform (more exploration). |
+| `generation.search.mcts.n_simulations` | 20 | 10, 20, 50 | linear | MCTS rollouts per decision. |
+| `generation.search.mcts.exploration_constant` | 1.0 | 0.5, 1.0, 2.0 | none | UCB exploration weight. |
+| `generation.search.reward_threshold` | `null` | `null`, -0.2, -0.1 | filters | Drop search candidates below this reward at each step. `null` = keep all. |
+
+### Diffusion / flow sampling
+
+| Key | Default | Typical sweep values | Cost multiplier | Effect |
+|---|---|---|---|---|
+| `generation.args.nsteps` | 400 | 100, 200, 400, 800 | linear | ODE integration steps. Lower = faster, lossy past ~100. 400 is a strong default. |
+| `generation.args.self_cond` | `true` | `true`, `false` | ~1.05× when true | Self-conditioning across steps; usually helps. |
+| `generation.args.guidance_w` | 1.0 | 0.0, 0.5, 1.0, 2.0 | none | Classifier-free guidance scale; 0 = unconditional, 1 = nominal, >1 = sharper conditioning. |
+| `generation.args.fold_cond` | `false` | `true`, `false` | minor | Fold-conditioning toggle. Off for most binder runs. |
+| `generation.model.bb_ca.simulation_step_params.sc_scale_noise` | 0.1 | 0.05, 0.1, 0.2, 0.4, 0.8 | none | Backbone CA noise scale ("temperature"). Higher = more diverse, less ordered structures. The `bb_ca_temperature.yaml` canned sweep tests 0.1 vs 0.4. |
+| `generation.model.bb_ca.simulation_step_params.sc_scale_score` | 1.0 | 0.5, 1.0, 1.5 | none | Score multiplier. Rarely swept. |
+| `generation.model.bb_ca.simulation_step_params.t_lim_ode` | 0.98 | 0.9, 0.95, 0.98 | none | ODE cutoff time near t=1. |
+| `generation.model.local_latents.simulation_step_params.sc_scale_noise` | 0.1 | 0.05, 0.1, 0.2 | none | Latent-feature noise. Affects sequence/local-structure diversity. |
+| `generation.n_recycle` | 0 | 0, 1, 2 | linear in N+1 | Recycling iterations through the model. Costly. |
+
+### Reward weights (`af2folding` composite)
+
+Path prefix: `generation.reward_model.reward_models.af2folding.reward_weights.*`. These compose into a single scalar reward at each search step; tuning the ratio rebalances what search optimises for.
+
+| Key (under the prefix above) | Default | Typical sweep | Effect |
+|---|---|---|---|
+| `i_pae` | -1.0 | -2.0, -1.0, -0.5, 0.0 | Negative weight on interface PAE. More negative = search pushes harder for low iPAE. |
+| `plddt` | 0.0 | 0.0, 0.5, 1.0 | Positive weight on overall pLDDT. Turn on to bias toward confident monomers. |
+| `con` | 0.0 | 0.0, 0.1, 0.5 | Binder-internal contact loss. Higher = more compact binders. |
+| `dgram_cce` | 0.0 | 0.0, 0.1, 1.0 | AF2 distogram cross-entropy. Rarely swept above 0. |
+| `min_ipae` | 0.0 | 0.0, -0.5, -1.0 | Min iPAE across chains; aggressive interface-quality push. |
+
+`generation.reward_model.reward_models.bioinformatics.reward_weights.{interface_sc, interface_hydrophobicity, surface_hydrophobicity, ...}` exist for the bioinformatics reward block (shape complementarity, SASA, hydrophobicity). Defaults live in the `binder_generate.yaml` config. Same pattern: list of floats per axis.
+
+### Refinement + filtering
+
+| Key | Default | Typical sweep | Effect |
+|---|---|---|---|
+| `generation.refinement.algorithm` | `null` | `null`, `sequence_hallucination` | Enable post-generation refinement loop. ~2× wall-clock when on. |
+| `generation.filter.reward_threshold` | `null` | `null`, -0.2, -0.1 | Hard floor on reward before top-N filtering. |
+| `generation.filter.filter_samples_limit` | 1000 | 100, 500, 1000 | Max samples to keep. |
+| `generation.filter.dedup_sequence` | `true` | `true`, `false` | Drop sequence-duplicate samples before ranking. |
+
+## Evaluation axes
+
+These live at top level (the binder_evaluate config is loaded with `@_global_`), not under `generation.*`.
+
+| Key | Default | Typical sweep | Cost multiplier | Effect |
+|---|---|---|---|---|
+| `metric.binder_folding_method` | `colabdesign` | `colabdesign`, `rf3_latest`, `boltz2_default`, `esmfold` | varies | Which refolder validates the binder. AF2 (`colabdesign`) is the standard; ESMFold ~5× faster, less accurate. |
+| `metric.num_redesign_seqs` | 2 | 1, 2, 4, 8, 16 | linear | Number of MPNN redesigns to refold per binder. Higher = more reliable designability signal. |
+| `metric.sequence_types` | `[self]` | `[self]`, `[self, mpnn]`, `[self, mpnn_fixed]` | linear per type | Which sequences to evaluate: generated, MPNN-redesigned, or MPNN with fixed interface. |
+| `metric.interface_cutoff` | 8.0 | 6.0, 8.0, 10.0 | none | Angstrom cutoff defining interface residues for MPNN_fixed and interface metrics. |
+| `metric.inverse_folding_model` | `soluble_mpnn` | `protein_mpnn`, `ligand_mpnn`, `soluble_mpnn` | none | MPNN variant used for redesign. |
+| `metric.compute_pre_refolding_metrics` | `false` | `true`, `false` | minor | Compute interface metrics on the generated structure (no fold) — fast. |
+| `metric.compute_refolded_structure_metrics` | `false` | `true`, `false` | minor | Compute interface metrics on the refolded structure — slower. |
+| `metric.pre_refolding.{bioinformatics,tmol,hbplus}` | mixed | `true`/`false` | minor | Toggle individual interface metric modules. |
+
+## Reading the sweeper YAML format
+
+Annotated example based on `configs/sweeps/example.yaml`:
+
+```yaml
+# --- Sweep axes (lists, cartesian-producted) ---
+# Each key is a Hydra dot-path. Each list value becomes one dimension.
+# Total configs = product of list lengths. Here 2 × 2 = 4.
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+generation.args.nsteps:
+  - 200
+  - 400
+
+# --- Pinned scalar (no extra dimension) ---
+# Scalars are auto-wrapped into a single-element list, so they pin a value
+# across the whole sweep without growing the cartesian product.
+# generation.args.self_cond: true
+
+# --- Long block-style list (e.g. checkpoint paths) ---
+# ckpt_path:
+#   - /lustre/checkpoints/model_v1/epoch_100.ckpt
+#   - /lustre/checkpoints/model_v2/epoch_200.ckpt
+```
+
+Validation rules (`script_utils/generate_inference_configs.py:load_sweeper_file`):
+
+- Top-level YAML must be a mapping. List or scalar at top = error.
+- All keys must be strings. Numeric keys = error.
+- List values are kept verbatim. Scalar values are wrapped to `[value]`.
+- Empty list `[]` for an axis = launcher dies with "No configs were generated."
+
+## Generating sweeper YAMLs programmatically
+
+For large parameter grids it is cleaner to render the YAML than to edit by hand:
+
+```python
+import itertools, yaml
+
+axes = {
+    "generation.search.beam_search.beam_width": [1, 2, 4, 8],
+    "generation.args.nsteps": [200, 400, 800],
+    "generation.model.bb_ca.simulation_step_params.sc_scale_noise": [0.1, 0.2, 0.4],
+}
+# 4 * 3 * 3 = 36 configs
+total = 1
+for v in axes.values():
+    total *= len(v)
+print(f"Will generate {total} configs")
+
+with open("configs/sweeps/big_grid.yaml", "w") as f:
+    yaml.safe_dump(axes, f, sort_keys=False, default_flow_style=False)
+```
+
+For an irregular set of `(key1, key2)` pairs (not a full cartesian product), there is no native support — emit one sweeper file per pair and concatenate the summary CSVs.
+
+## Result-aggregation logic
+
+`sweep_summary.csv` columns produced in Step 6 of the skill:
+
+| Column | Source | Notes |
+|---|---|---|
+| `config_id` | The index in `inf_{idx}_{run_name}.yaml` | 0-based, sequential, set by `apply_sweeper_and_save_configs`. |
+| `<axis_name>` (one per axis) | Read from the per-config `inf_*.yaml` at the swept Hydra path | Strip the dot-path to a short column header (e.g. `beam_width`). |
+| `n_samples` | `len(results_csv)` | Rows in the analyze CSV for this config. |
+| `success_rate` | `mean(passes_filter)` if column present, else thresholded `mean((i_pae < 10) & (i_plddt > 0.7) & (sc_rmsd < 2.0))` | Confirm thresholds with the user. |
+| `mean_i_pae` | `i_pae.mean()` | Lower = better. AF2 interface PAE. |
+| `mean_i_plddt` | `i_plddt.mean()` | Higher = better. Interface pLDDT. |
+| `mean_sc_rmsd` | `sc_rmsd.mean()` | Self-consistency RMSD between generated and refolded structures. |
+| `diversity_score` | Unique sequences / `n_samples`, or 1 − mean pairwise TM-score if available | Higher = more diverse pool. |
+| `wall_clock_min` | Timestamp delta from the per-config log (`./logs/design_pipeline_*_<run>_<timestamp>.log`) | Approximate (process wall-clock, not GPU time). |
+
+Ranking:
+
+- **Best by success** = argmax `success_rate`; tie-break on `mean_i_pae` ascending.
+- **Pareto frontier** on (`wall_clock_min`, `success_rate`): a config is on the frontier iff no other config has both lower wall-clock AND higher success rate. Implement with a sort + linear sweep.
+- **Sanity check**: if every config has `success_rate == 0`, the threshold is too strict OR the sweep regime is broken — surface this to the user before reporting "best".

--- a/plugins/bionemo-agent-toolkit/skills/complexa-target/SKILL.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-target/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: complexa-target
+description: Use this skill whenever the user wants to add, register, edit, list, show, or validate a Proteina-Complexa design target for any pipeline — protein binder (default), ligand binder, or AME / enzyme scaffolding. Triggers include "add a target", "define a new target for binder design", "register a hotspot", "set up a PDL1 binder target", "ligand binder pocket", "SMILES target", "AME task", "enzyme motif", "M0024_1nzy", "complexa target add", "complexa target show", "configure target X", "what targets are available", "where do hotspots live", "what does target_input mean", "chain-spec syntax", "binder length range", or any question about `configs/targets/{,ligand_}targets_dict.yaml` and `configs/design_tasks/ame_dict_v2.yaml`. Also covers `complexa validate target`. This is the only skill that touches the three targets dict files.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# complexa-target
+
+Add or edit a design target in Proteina-Complexa. Targets live in **three YAML files**, one per `complexa design` pipeline:
+
+- `configs/targets/targets_dict.yaml` — protein binder (**default pipeline**)
+- `configs/targets/ligand_targets_dict.yaml` — ligand binder
+- `configs/design_tasks/ame_dict_v2.yaml` — AME / enzyme scaffolding
+
+The `complexa target` CLI only manages the first two. AME tasks use an extended schema (the same core fields as ligand targets plus `contig_atoms` for hand-curated per-residue motif atom selections) and are file-edit-only.
+
+## Preferred path: edit the YAML directly
+
+`complexa target add` is a thin wrapper around "load YAML → build dict → append a block" (see `src/proteinfoundation/cli/target_manager.py:add_target_cli` and `append_target_to_dict`). For agentic use, **just edit the targets dict directly** — the schema is short, the existing entries are great copy templates, and you skip 14 CLI flags / SMILES shell-escaping. Use the CLI only if you explicitly want its YAML auto-quoter or its overwrite-prompt safety.
+
+The skill therefore presents both paths:
+
+| Step | Direct file edit (preferred) | CLI |
+|---|---|---|
+| Look at existing targets | Read `configs/targets/{,ligand_}targets_dict.yaml` (or `configs/design_tasks/ame_dict_v2.yaml` for AME) | `complexa target list` (protein/ligand only) |
+| Look at one target | Read the dict and grep for the key | `complexa target show NAME` |
+| Add a new target | Append a YAML block (Step 3a) | `complexa target add ...` (Step 3b) |
+| Verify the PDB resolves on disk | — *(no shortcut, this checks Hydra defaults)* | `complexa validate target CONFIG --target NAME` |
+
+`complexa target` only sees the two protein-style dicts (`targets_dict.yaml` and `ligand_targets_dict.yaml`). For AME tasks (which use a different schema), file-edit is the only path — see Step 1 below.
+
+## What this skill enables
+
+- Register a **protein target** (chain + residue range + hotspots) in `configs/targets/targets_dict.yaml`.
+- Register a **ligand target** (PDB pocket + 3-letter code + SMILES) in `configs/targets/ligand_targets_dict.yaml`.
+- Resolve the right **AME task name** (e.g. `M0024_1nzy`, `M0096_1chm`) for the AME pipeline — these are not added via `complexa target add` (see Step 1).
+- Verify a target resolves to a real PDB on disk with `complexa validate target`.
+- Emit a replayable artifact (`target_definition.yaml`) for downstream design runs.
+
+## Step 1: Decide the target type
+
+Targets live in **three different files**, one per `complexa design` pipeline. Pick the file by working out which pipeline the user will run, then add the entry to that file. Each file is consumed by exactly one pipeline.
+
+| User intent | Pipeline | Targets dict file | This skill? |
+|---|---|---|---|
+| Bind a protein surface (PD-L1, IFNAR2, TNF-α, …) — **default** | `configs/search_binder_local_pipeline.yaml` | `configs/targets/targets_dict.yaml` | Yes — Step 2 (protein) |
+| Bind a small-molecule pocket (FAD, SAM, OQO, …) | `configs/search_ligand_binder_local_pipeline.yaml` | `configs/targets/ligand_targets_dict.yaml` | Yes — Step 2 (ligand) |
+| AME / enzyme scaffolding (motif + ligand, `M####_<pdb>` names) | `configs/search_ame_local_pipeline.yaml` | `configs/design_tasks/ame_dict_v2.yaml` | Partial — see "AME tasks" below |
+
+### AME tasks (enzyme pipeline)
+
+Similar story — AME tasks live in `configs/design_tasks/ame_dict_v2.yaml` under `motif_target_dict_cfg:` with their own schema (`source`, `target_filename`, `ligand`, `contig_atoms`, `binder_length`, `use_bonds_from_file`). The `contig_atoms` string encodes per-residue motif atom selections like `"A64: [O, C]; A86: [CB, CA, N, C]; ..."` — these are hand-curated, so adding a new AME task is a file edit, not a CLI invocation. Browse the file, copy a similar entry as a template, and pass `++generation.task_name=<NAME>` to `complexa design configs/search_ame_local_pipeline.yaml`.
+
+## Step 2: Gather required info
+
+Use AskUserQuestion to collect — do not guess these. Required fields differ for protein vs ligand.
+
+### Protein target
+
+| Field | Question | Example | Required |
+|---|---|---|---|
+| name | "Target name (used as the dict key and `task_name`)?" | `02_PDL1`, `MyTarget_v1` | yes |
+| source | "Source directory under `$DATA_PATH/target_data/`?" | `bindcraft_targets`, `custom_targets` | yes (or `target_path`) |
+| target_filename | "PDB filename (no `.pdb` extension)?" | `PD-L1`, `IFNAR2` | yes (or `target_path`) |
+| target_input | "Chain + residue range — see reference for grammar." | `A1-115`, `A1-50,B1-50` | yes |
+| hotspot_residues | "Hotspot residues (interface contact residues)?" | `["A33", "A95", "A102"]` | optional, recommended |
+| binder_length | "Binder length range `[min, max]` or single `[length]`?" | `[80, 150]`, `[100]` | optional (default `[60, 120]`) |
+| pdb_id | "Reference PDB ID (optional, metadata only)?" | `"2lag"` | optional |
+
+### Ligand target — protein fields above (minus `target_input`), plus:
+
+| Field | Question | Example | Required |
+|---|---|---|---|
+| ligand | "3-letter PDB ligand residue code?" | `FAD`, `OQO`, `SAM` | yes (presence marks target as ligand) |
+| smiles | "SMILES string for the ligand?" | `"O=C2C3=Nc1cc(c(...)..."` | recommended |
+| ligand_only | "Generate pocket around ligand only (no protein-protein interface)?" | `true` / `false` | optional (default `true`) |
+| use_bonds_from_file | "Use bond info from the input PDB/CIF?" | `true` / `false` | optional (default `true`) |
+| target_input | not required for ligand targets | — | no |
+
+Check for name collisions by reading the dict (`rg '^  NEW_NAME:' configs/targets/targets_dict.yaml`) or running `complexa target list -v --ligand` / `--protein`.
+
+## Step 3a: Append the YAML block directly (preferred)
+
+Open `configs/targets/targets_dict.yaml` (or `ligand_targets_dict.yaml` for ligand targets), find a similar existing entry as a style template, and append the new block under `target_dict_cfg:`. Two-space indent, single blank line between entries.
+
+### Protein template
+
+```yaml
+  02_PDL1:
+    source: bindcraft_targets
+    target_filename: PD-L1
+    target_input: "A1-115"
+    hotspot_residues: ["A37", "A39", "A49", "A98"]
+    binder_length: [64, 155]
+    pdb_id: "4z18"
+```
+
+Rules to match the existing file style (mirrors what `complexa target add` would emit):
+
+- Quote chain/residue ranges (`"A1-115"`, `"A33"`) and any SMILES — flow-style strings get tripped up by `:` and brackets otherwise.
+- Use flow-style lists (`["A33", "A95"]`, `[64, 155]`) — that's what the on-disk dump produces.
+- `target_input`, `source`, `target_filename` are required for protein. `target_path` (absolute path) can replace `source + target_filename` if the PDB lives outside `$DATA_PATH/target_data/`.
+
+### Ligand template
+
+```yaml
+  41_7BKC_LIGAND:
+    source: ligand_targets
+    target_filename: 7BKC_ligand_centered
+    hotspot_residues: [null]
+    binder_length: [100]
+    pdb_id: 7BKC
+    ligand: 'FAD'
+    ligand_only: True
+    SMILES: "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C"
+    use_bonds_from_file: True
+```
+
+The presence of the `ligand:` key flips the target into ligand mode — there is no separate `is_ligand` flag. `target_input` is not required for ligands.
+
+After saving, skip to Step 4 to verify.
+
+## Step 3b: CLI alternative (`complexa target add`)
+
+Use the CLI when you want its automatic chain/residue quoting, the overwrite-confirm prompt, or to wire target creation into a non-Python script. Prefer non-interactive mode for agentic use (`-i / --editor` opens an editor and blocks).
+
+### Confirmed flags (from `src/proteinfoundation/cli/target_cli.py`)
+
+| Flag | Type | Applies to | Notes |
+|---|---|---|---|
+| `name` (positional) | str | both | dict key |
+| `--dict PATH` | path | both | override target dict path |
+| `-i, --interactive` | flag | both | open `$EDITOR` |
+| `-e, --editor NAME` | str | both | `code`, `nano`, `vim`, `cursor`, ... |
+| `--source NAME` | str | both | directory under `$DATA_PATH/target_data/` |
+| `--target-filename NAME` | str | both | PDB stem (no `.pdb`) |
+| `--target-path PATH` | str | both | full path; overrides `source`+`filename` |
+| `--target-input SPEC` | str | protein | chain/residue range, e.g. `A1-115` |
+| `--hotspot-residues R [R ...]` | list | both | e.g. `A33 A95` |
+| `--binder-length N [N ...]` | int list | both | `[min, max]` or `[length]` |
+| `--pdb-id ID` | str | both | metadata only |
+| `--ligand CODE` | str | ligand | presence marks ligand target |
+| `--ligand-only` | flag | ligand | pocket-only mode |
+| `--smiles STR` | str | ligand | SMILES for the ligand |
+| `--use-bonds-from-file` | flag | ligand | use PDB bonds |
+| `-f, --force` | flag | both | overwrite existing without prompt |
+
+### Protein example
+
+```bash
+complexa target add 02_PDL1 \
+  --source bindcraft_targets \
+  --target-filename PD-L1 \
+  --target-input A1-115 \
+  --hotspot-residues A37 A39 A49 A98 \
+  --binder-length 64 155 \
+  --pdb-id 4z18
+```
+
+### Ligand example
+
+```bash
+complexa target add 41_7BKC_LIGAND \
+  --source ligand_targets \
+  --target-filename 7BKC_ligand_centered \
+  --pdb-id 7BKC \
+  --ligand FAD \
+  --ligand-only \
+  --use-bonds-from-file \
+  --smiles "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C" \
+  --binder-length 100
+```
+
+Why these defaults: `--source` defaults to `custom_targets` (protein) or `ligand_targets` (ligand) and `--target-filename` defaults to `name`, so be explicit when the PDB stem differs from the target name. The dict gets `ligand_only: true` and `use_bonds_from_file: true` by default for ligand targets — pass the flags to be explicit, or omit to accept defaults.
+
+## Step 4: Verify
+
+Run two checks, in order. Stop and fix on the first failure.
+
+```bash
+# 1. Confirm the entry landed and looks right.
+#    Direct read works just as well: `rg -A 7 '^  02_PDL1:' configs/targets/targets_dict.yaml`
+complexa target show 02_PDL1
+
+# 2. Resolve the PDB path and validate it exists on disk.
+#    No shortcut for this — it traverses Hydra defaults to find the target dict.
+complexa validate target configs/search_protein_local_pipeline.yaml --target 02_PDL1
+```
+
+`complexa validate target` (from `src/proteinfoundation/cli/validate.py::validate_target`) checks:
+
+- `DATA_PATH` is set and `target_data/` exists.
+- The target name resolves in `target_dict_cfg`.
+- Either `target_path` exists, or `$DATA_PATH/target_data/<source>/<target_filename>.pdb` exists.
+- `target_input`, `hotspot_residues`, `binder_length` are reported back so a human can sanity-check them.
+
+For ligand targets, point `--target` at a ligand pipeline config (e.g. a ligand binder search config).
+
+## Step 5: Emit artifact
+
+Save a replayable record under `./target_<name>/`:
+
+```bash
+mkdir -p target_02_PDL1
+complexa target show 02_PDL1 > target_02_PDL1/target_show.txt
+```
+
+Then write the appended YAML snippet (the lines `complexa target add` wrote under `target_dict_cfg:`) to `target_02_PDL1/target_definition.yaml` using the Write tool. The artifact lets the user diff target definitions across runs and re-create the entry on another checkout via `complexa target add ... --force`.
+
+## Hardware requirements
+
+None for target definition — this is a YAML edit, not a training/inference step. Disk impact is a few KB appended to the targets dict (plus an automatic `.yaml.bak` backup written by `save_targets_dict`).
+
+For the downstream design / evaluate runs that consume the target, defer to `complexa-design` and `_shared/reference/hardware.md`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Target PDB file: File not found` from `validate target` | `<source>/<target_filename>.pdb` does not exist under `$DATA_PATH/target_data/` | Confirm the PDB stem and source dir. Use `--target-path /full/path.pdb` if the file lives outside `target_data/`. |
+| "Target 'X' already exists! Overwrite? (y/N)" | Name collision in dict | Either pick a new name, or pass `-f / --force` to overwrite. |
+| Hotspot residue not in PDB | Wrong chain or residue number | Open the PDB, re-check chain letters (case-sensitive) and residue indices. Hotspots use the format `<CHAIN><RESNUM>` — see reference. |
+| Chain not found | `target_input` references a chain that does not exist in the PDB | Inspect the PDB with `grep "^ATOM" target.pdb \| awk '{print $5}' \| sort -u`. |
+| Ligand code missing from PDB | The 3-letter `ligand` code does not appear as a `HETATM` residue name in the file | Open the PDB and check `HETATM` lines; you may need a `_ligand_centered` variant of the PDB. |
+| SMILES parse failure downstream | Bad SMILES string | Validate with `rdkit.Chem.MolFromSmiles(smiles)` before adding. Quote SMILES in shell to escape brackets and parens. |
+| Target name with leading digit breaks Hydra interpolation | YAML treats `02_PDL1` as a string fine; some override syntaxes need quoting | Use `++generation.task_name=02_PDL1`; quote if the shell strips characters. |
+| `target_input` appears ignored for a ligand target | By design — ligand targets do not use `target_input`; pocket is defined by the ligand | Leave it unset for ligand targets. |
+
+## Reference
+
+- `reference/target_schema.md` — every field, chain-spec grammar, AME task-name grammar, three worked examples.
+- `configs/targets/targets_dict.yaml` — live protein entries (copy a known-good one as a template).
+- `configs/targets/ligand_targets_dict.yaml` — live ligand entries.
+- `configs/design_tasks/ame_dict_v2.yaml` — AME task definitions (file-edit only, not exposed via `complexa target` CLI).
+- `src/proteinfoundation/cli/target_cli.py` — argparse source of truth.
+- `src/proteinfoundation/cli/target_manager.py` — `add_target_cli`, `list_targets`, `show_target`, schema in `TARGET_FIELDS`.
+- `src/proteinfoundation/cli/validate.py` — `validate_target` implementation.

--- a/plugins/bionemo-agent-toolkit/skills/complexa-target/reference/target_schema.md
+++ b/plugins/bionemo-agent-toolkit/skills/complexa-target/reference/target_schema.md
@@ -1,0 +1,228 @@
+# Target schema reference
+
+Authoritative source: `src/proteinfoundation/cli/target_manager.py::TARGET_FIELDS` and the live YAML dicts under `configs/targets/`. This document mirrors them.
+
+## Protein target schema
+
+Stored in `configs/targets/targets_dict.yaml` under `target_dict_cfg.<name>`. Either (`source` + `target_filename`) OR `target_path` is required, plus `target_input`.
+
+| Field | Type | Required | Default | Example | Controls |
+|---|---|---|---|---|---|
+| `source` | str | yes* | `custom_targets` | `bindcraft_targets` | Subdirectory of `$DATA_PATH/target_data/` where the PDB lives. |
+| `target_filename` | str | yes* | (name of target) | `PD-L1` | PDB stem (no `.pdb` extension). Combined with `source` to build the path. |
+| `target_path` | str | yes* | `null` | `/abs/path/target.pdb` | Full path to a PDB. If set, `source`+`target_filename` are optional. |
+| `target_input` | str | **yes** | `A1-100` | `A1-115`, `A1-50,B1-50` | Chain + residue range (the "target_input" chain-spec). |
+| `hotspot_residues` | list[str] | no | `[]` | `["A33", "A95", "A102"]` | Interface residues focused on during binder design. |
+| `binder_length` | list[int] | no | `[60, 120]` | `[80, 150]`, `[100]` | Binder length. Two-element list = uniform `[min, max]`; one-element = fixed length. |
+| `pdb_id` | str | no | `null` | `"2lag"` | Reference PDB ID, metadata only. |
+
+(* "yes" with the OR rule: either `target_path` OR (`source` AND `target_filename`).)
+
+## Ligand target schema
+
+Stored in `configs/targets/ligand_targets_dict.yaml`. The presence of the `ligand` key is what marks an entry as a ligand target (no separate `is_ligand` flag). `target_input` is not used for ligand targets.
+
+All protein fields above (with `target_input` optional / omitted), plus:
+
+| Field | Type | Required | Default | Example | Controls |
+|---|---|---|---|---|---|
+| `ligand` | str OR list[str] | **yes** | `null` | `"FAD"`, `["DHZ", "ZN"]` | Three-letter PDB residue name(s) for the ligand. Presence marks target as ligand. |
+| `ligand_only` | bool | no | `true` | `true` | If `true`, generate the binding pocket around the ligand only (no protein-protein interface). |
+| `SMILES` | str | no | `null` | `"O=C2C3=Nc1cc(...)C"` | SMILES string for the ligand (single-ligand targets only). Optional but recommended. |
+| `use_bonds_from_file` | bool | no | `true` | `true` | If `true`, use bond information from the input PDB/CIF file rather than inferring from coordinates. |
+
+Note: `hotspot_residues` is still present for ligand entries but is typically `[null]` since the pocket is ligand-defined.
+
+## `target_input` chain-spec grammar
+
+`target_input` selects which residues of the target PDB are exposed to the binder design model.
+
+| Form | Meaning | Example |
+|---|---|---|
+| `<CHAIN><START>-<END>` | One contiguous chain segment | `A1-115` = chain A, residues 1 through 115 |
+| `<CHAIN><START>-<END>,<CHAIN><START>-<END>` | Multiple chain segments (comma-separated) | `A1-50,B1-50` = chain A residues 1-50 plus chain B residues 1-50 |
+| `<CHAIN><START>-<END>/0 <NRES>-<NRES>` | Chain break + contigs syntax (RFdiffusion-style) | `A1-115/0 50-100` = target A1-115 plus a 50-100 residue binder placeholder |
+
+`<CHAIN>` is a single uppercase letter (case-sensitive — `A` and `a` are different). `<START>` and `<END>` are integer residue numbers as they appear in the PDB (not 0-indexed; respects insertion codes only if the PDB does).
+
+When is `target_input` required vs optional?
+
+- **Protein targets**: required. Default is `A1-100`.
+- **Ligand targets**: not required (and not used at runtime). The pocket is defined by the ligand position, not a chain range.
+
+## Hotspot residue format
+
+A hotspot is a single residue, identified by chain + residue number:
+
+```
+"A33"     # chain A, residue 33
+"B17"     # chain B, residue 17
+```
+
+Rules:
+- Must be a string (always quote in YAML — the YAML dumper auto-quotes any `<chain><digits>` pattern).
+- Chain letter is case-sensitive and must match a chain in the PDB.
+- Residue number must exist in the PDB (use `grep "^ATOM" target.pdb | awk '{print $5, $6}' | sort -u` to enumerate).
+- The list may be empty (`[]`) — no hotspots = no special interface focus.
+- The list may contain only `[null]` for ligand targets where the pocket is ligand-defined.
+
+CLI form: `--hotspot-residues A33 A95 A102` (space-separated, no quotes needed on the command line).
+
+## `binder_length` semantics
+
+| Value | Meaning |
+|---|---|
+| `[60, 120]` | Sample binder length uniformly in [60, 120] inclusive. |
+| `[100]` | Always generate length-100 binders. |
+| `[80, 150]` | Sample uniformly in [80, 150]. |
+| `[]` or unset | Falls back to default `[60, 120]`. |
+
+CLI form: `--binder-length 60 120` (two ints) or `--binder-length 100` (one int).
+
+## Source directory convention
+
+`source` is **not** a full path. It is a subdirectory name under `$DATA_PATH/target_data/`. The full path resolution is:
+
+```
+${DATA_PATH}/target_data/<source>/<target_filename>.pdb
+```
+
+Examples:
+
+| `source` | `target_filename` | Resolved path |
+|---|---|---|
+| `bindcraft_targets` | `PD-L1` | `${DATA_PATH}/target_data/bindcraft_targets/PD-L1.pdb` |
+| `ligand_targets` | `7BKC_ligand_centered` | `${DATA_PATH}/target_data/ligand_targets/7BKC_ligand_centered.pdb` |
+| `custom_targets` | `MyTarget_v1` | `${DATA_PATH}/target_data/custom_targets/MyTarget_v1.pdb` |
+
+Override the convention with `--target-path /absolute/path/to/file.pdb` (overrides both `source` and `target_filename`).
+
+Common existing `source` directories: `bindcraft_targets`, `alpha_proteo_targets`, `ligand_targets`, `custom_targets`.
+
+## AME task names (NOT `complexa target`)
+
+The AME pipeline uses **task names**, not targets-dict entries. Task names are defined in `configs/design_tasks/ame_dict_v2.yaml` under `motif_target_dict_cfg:` and are file-edit-only — they have a richer schema than protein/ligand targets and the `complexa target` CLI does not touch them.
+
+### Grammar
+
+```
+M{NNNN}_{pdb_id}
+```
+
+| Component | Values | Meaning |
+|---|---|---|
+| `M{NNNN}` | `M0001` … | Zero-padded sequential ID assigned when the task is added. |
+| `pdb_id` | 4-char PDB code (lowercase) | Source PDB for the motif + ligand context. |
+
+Examples (drawn from `configs/design_tasks/ame_dict_v2.yaml`): `M0024_1nzy`, `M0096_1chm`.
+
+### AME task schema
+
+Each entry under `motif_target_dict_cfg.<name>` has:
+
+| Field | Type | Example | Notes |
+|---|---|---|---|
+| `source` | str | `ame_targets` | Subdirectory under `$DATA_PATH/target_data/`. |
+| `target_filename` | str | `1nzy_v2` | PDB stem (no `.pdb`). |
+| `ligand` | str | `"FAD"` | 3-letter PDB ligand code in the motif PDB. |
+| `contig_atoms` | str | `"A64: [O, C]; A86: [CB, CA, N, C]; ..."` | Hand-curated per-residue atom selection for the motif. |
+| `binder_length` | list[int] | `[100, 160]` | Length range for the scaffold. |
+| `use_bonds_from_file` | bool | `true` | Use bond info from the PDB. |
+| `pdb_id` | str | `"1nzy"` | Reference PDB ID, metadata only. |
+
+To run an AME task:
+
+```bash
+complexa design configs/search_ame_local_pipeline.yaml \
+  ++run_name=ame_1nzy \
+  ++generation.task_name=M0024_1nzy
+```
+
+**Do not use `complexa target add` for AME tasks** — they live in a different dict and add the `contig_atoms` field (and use `motif_target_dict_cfg` instead of `target_dict_cfg`) that the CLI does not know how to construct.
+
+## Worked examples
+
+### 1. Protein target from PDB ID + chain (new BindCraft target)
+
+User wants to design binders against chain A, residues 1-115, of an existing PDB at `${DATA_PATH}/target_data/bindcraft_targets/PD-L1.pdb`, hotspot residues A37, A39, A49, A98, binder length 64-155.
+
+```bash
+complexa target add 02_PDL1 \
+  --source bindcraft_targets \
+  --target-filename PD-L1 \
+  --target-input A1-115 \
+  --hotspot-residues A37 A39 A49 A98 \
+  --binder-length 64 155 \
+  --pdb-id 4z18
+```
+
+Resulting YAML entry (appended to `configs/targets/targets_dict.yaml`):
+
+```yaml
+  02_PDL1:
+    target_input: "A1-115"
+    source: bindcraft_targets
+    target_filename: "PD-L1"
+    hotspot_residues: ["A37", "A39", "A49", "A98"]
+    binder_length: [64, 155]
+    pdb_id: 4z18
+```
+
+### 2. Ligand target with SMILES (FAD pocket)
+
+User wants binders for the FAD-binding pocket of 7BKC, fixed length 100.
+
+```bash
+complexa target add 41_7BKC_LIGAND \
+  --source ligand_targets \
+  --target-filename 7BKC_ligand_centered \
+  --pdb-id 7BKC \
+  --ligand FAD \
+  --ligand-only \
+  --use-bonds-from-file \
+  --smiles "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C" \
+  --binder-length 100
+```
+
+Resulting YAML entry (appended to `configs/targets/ligand_targets_dict.yaml`):
+
+```yaml
+  41_7BKC_LIGAND:
+    source: ligand_targets
+    target_filename: "7BKC_ligand_centered"
+    hotspot_residues: []
+    binder_length: [100]
+    pdb_id: 7BKC
+    ligand: FAD
+    ligand_only: True
+    SMILES: "O=C2C3=Nc1cc(c(cc1N(C3=NC(=O)N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC6OC(n5cnc4c(ncnc45)N)C(O)C6O)C)C"
+    use_bonds_from_file: True
+```
+
+### 3. Ligand target with `--use-bonds-from-file` and no SMILES
+
+User has a curated `_centered` PDB whose bonds are authoritative, and does not want to provide a SMILES (e.g. uncommon ligand). They want a length range 40-88.
+
+```bash
+complexa target add Cambridge_bloodsugar_A_4D71_pdb \
+  --source ligand_targets \
+  --target-filename Cambridge_bloodsugar_A_4D71_pdb \
+  --pdb-id 4D71 \
+  --ligand UNK \
+  --ligand-only \
+  --use-bonds-from-file \
+  --binder-length 40 88
+```
+
+(Note: `--ligand` requires a value; pass a placeholder like `UNK` or the actual 3-letter code if available. The `complexa target add` parser interprets the presence of `--ligand` as marking the target ligand-typed.)
+
+Resulting entry mirrors `Cambridge_bloodsugar_A_4D71_pdb` from `configs/targets/ligand_targets_dict.yaml` — `SMILES: null`, `use_bonds_from_file: True`, `binder_length: [40, 88]`.
+
+## Cross-references
+
+- CLI: `src/proteinfoundation/cli/target_cli.py`
+- Manager + schema: `src/proteinfoundation/cli/target_manager.py` (see `TARGET_FIELDS`)
+- Validator: `src/proteinfoundation/cli/validate.py::validate_target`
+- Protein dict: `configs/targets/targets_dict.yaml`
+- Ligand dict: `configs/targets/ligand_targets_dict.yaml`
+- AME dict: `configs/design_tasks/ame_dict_v2.yaml`

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -31,6 +31,11 @@
     {
       "title": "Open Models",
       "skills": [
+        "complexa-design",
+        "complexa-evaluate-pdbs",
+        "complexa-setup",
+        "complexa-sweep",
+        "complexa-target",
         "kermt-add-cmim-pretrain",
         "kermt-continue-pretrain",
         "kermt-embed",


### PR DESCRIPTION
## What
Re-adds **Proteina-Complexa** to the catalog, aggregated from the **`aggregator-compat`
branch** (PR #57 on the source repo) — which carries the co-located `evals/` and the
self-contained `complexa-sweep` (`reference/SWEEP.md`) that `dev` doesn't have yet.

- `components.d/proteina-complexa.yml` → `ref: aggregator-compat`
- 5 skills vendored: `complexa-design`, `complexa-evaluate-pdbs`, `complexa-setup`, `complexa-sweep`, `complexa-target` (with evals)
- re-added to `skills.sh.json` (Open Models) + `plugins.d`; plugin payload regenerated (`plugin-sync` green, 31 skills)

## Context
Proteina was temporarily removed in #13 while its upstream fixes were unmerged. This
sources it from the fix branch so the catalog gets the *good* (evals + SWEEP) version now.

## ⚠️ INTERIM — action on merge of upstream #57
`ref: aggregator-compat` points at an **ephemeral PR branch**. When Proteina-Complexa
PR #57 merges, that branch is deleted — **switch `ref` to `dev`** (a one-line change) or
the next sync will fail to clone. Tracked in the file's comment.

`complexa-slurm` is intentionally NOT included (absent from the fix branch — still an open
question for the Proteina owners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
