### PR TITLE
chore(compliance): add skill cards for sourced skills via compliance.d overlay

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -120,6 +120,49 @@ jobs:
             echo "- orphan pruning" >> /tmp/changed-components.txt
           fi
 
+      - name: Backfill compliance artifacts from compliance.d
+        # Sourced skills are rsynced with --delete, so a skill-card.md committed
+        # into a catalog dir is deleted on the next run. Cards for sourced skills
+        # therefore live in compliance.d/<catalog_path>/ — outside every rsync
+        # target and every prune root — and are copied in AFTER the rsync.
+        #
+        # Upstream ALWAYS wins: we only copy where the file is absent once the
+        # rsync has finished. The moment a source repo ships its own card, that
+        # card lands via rsync and this step becomes a no-op for it — at which
+        # point the compliance.d entry is dead weight and should be deleted.
+        # Both states are reported in the PR body so the debt stays visible.
+        #
+        # NOTE: skill-card.md only. skill.oms.sig is deliberately NOT backfilled
+        # — a signature is an attestation over specific bytes, and copying one
+        # over content it was not generated from would publish an artifact that
+        # fails verification. Signing stays a per-source-repo nvskills-ci task.
+        run: |
+          set -euo pipefail
+          : > /tmp/overlay-backfilled.txt
+          : > /tmp/overlay-retirable.txt
+          [ -d compliance.d ] || exit 0
+
+          while IFS= read -r card; do
+            dest="${card#compliance.d/}"
+            skill_dir=$(dirname "$dest")
+            if [ ! -d "$skill_dir" ]; then
+              echo "  ⚠ $skill_dir absent from catalog — overlay entry has no target"
+              continue
+            fi
+            if [ -f "$dest" ]; then
+              echo "  ✓ $skill_dir — upstream now ships a card; retire compliance.d entry"
+              echo "$skill_dir" >> /tmp/overlay-retirable.txt
+            else
+              cp "$card" "$dest"
+              echo "  ↪ $skill_dir — backfilled card from compliance.d"
+              echo "$skill_dir" >> /tmp/overlay-backfilled.txt
+            fi
+          done < <(find compliance.d -type f -name skill-card.md)
+
+          if [ -s /tmp/overlay-backfilled.txt ]; then
+            echo "- compliance backfill" >> /tmp/changed-components.txt
+          fi
+
       - name: Rebuild plugin payload
         # Regenerate plugins/bionemo-agent-toolkit/ so the sync PR ships skills +
         # payload together and stays plugin-sync green. (build-plugins.py fork is
@@ -155,6 +198,16 @@ jobs:
               echo ""
               echo "**Failed to sync:**"
               cat /tmp/failed-components.txt
+            fi
+            if [ -s /tmp/overlay-backfilled.txt ]; then
+              echo ""
+              echo "**Cards backfilled from \`compliance.d\` (upstream still owes a \`skill-card.md\`):**"
+              while read -r d; do echo "- \`$d\`"; done < /tmp/overlay-backfilled.txt
+            fi
+            if [ -s /tmp/overlay-retirable.txt ]; then
+              echo ""
+              echo "**Upstream now ships its own card — delete these \`compliance.d\` entries:**"
+              while read -r d; do echo "- \`compliance.d/$d/skill-card.md\`"; done < /tmp/overlay-retirable.txt
             fi
             echo ""
             echo "Sourced content changes + any pruning are shown in the diff. Native"

--- a/compliance.d/README.md
+++ b/compliance.d/README.md
@@ -1,0 +1,52 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# `compliance.d/` — compliance artifacts for sourced skills
+
+Skills vendored from a source repo are rsynced with `--delete` (see
+[`../.github/workflows/sync-skills.yml`](../.github/workflows/sync-skills.yml)),
+so **a file committed directly into a sourced catalog dir is deleted on the next
+nightly sync.** That is what happened to the KERMT evals (see
+[`../docs/sync-findings.md`](../docs/sync-findings.md)).
+
+This directory holds `skill-card.md` files for sourced skills, mirroring the
+catalog path, outside every rsync target and every prune root:
+
+```
+compliance.d/<catalog_dir>/<skill>/skill-card.md
+   ↓ backfilled after the rsync, only if absent
+<catalog_dir>/<skill>/skill-card.md
+```
+
+## Upstream always wins
+
+The **Backfill compliance artifacts** step in the sync workflow copies a card
+into the catalog *only when the rsync left no card there*. As soon as a source
+repo ships its own `skill-card.md`, that card lands via rsync and the backfill
+becomes a no-op for that skill — no flag to flip, no coordination needed.
+
+The sync PR body reports both states:
+
+- **backfilled** — upstream still owes a card; this is the outstanding debt list
+- **retirable** — upstream now ships its own card, so the `compliance.d` entry
+  here is dead weight and should be deleted in that PR
+
+## What does *not* belong here
+
+**`skill.oms.sig`.** A signature is a cryptographic attestation over specific
+bytes. Copying one over content it was not generated from produces an artifact
+that fails verification — and `NVIDIA/skills`' sync detects exactly this case
+and reverts the skill. Signing stays a per-source-repo task, performed by
+commenting `/nvskills-ci` on a PR in the repo that owns the skill.
+
+**Evals.** Eval definitions must be co-located with the skill in its source repo
+(`SRC-10`), for the same `--delete` reason.
+
+## Current entries
+
+| Catalog path | Source repo | Upstream card PR |
+|---|---|---|
+| `open-models-skills/kermt/*` (8) | `NVIDIA-BioNeMo/KERMT` | [KERMT#26](https://github.com/NVIDIA-BioNeMo/KERMT/pull/26) |
+| `open-models-skills/proteina-complexa/*` (5) | `NVIDIA-BioNeMo/Proteina-Complexa` | [Proteina-Complexa#60](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/60) |
+| `library-skills/nvMolKit` (1) | `NVIDIA-BioNeMo/nvMolKit` | [nvMolKit#248](https://github.com/NVIDIA-BioNeMo/nvMolKit/pull/248) |
+
+The same card content was opened as a PR against each source repo. When those
+merge, the corresponding entries here become retirable.

--- a/compliance.d/library-skills/nvMolKit/skill-card.md
+++ b/compliance.d/library-skills/nvMolKit/skill-card.md
@@ -1,0 +1,71 @@
+## Description: <br>
+Guides an agent to write correct code against the installed nvMolKit Python API for GPU-accelerated, batched RDKit-style cheminformatics — Morgan fingerprints, Tanimoto/cosine similarity, ETKDG conformer embedding, MMFF/UFF optimization, TFD, conformer RMSD, Butina clustering, and substructure search. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (Kevin Boyd, @scal444) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Cheminformaticians and ML engineers importing `nvmolkit.*`, debugging an nvMolKit call, deciding between nvMolKit and RDKit for a batched workflow, or wiring nvMolKit results into a torch/numpy pipeline. Out of scope: building nvMolKit from source. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* An existing nvMolKit installation (`uv pip install --torch-backend=cu128 nvmolkit`) <br>
+* CUDA-capable NVIDIA GPU <br>
+* Python with RDKit available for interoperation <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill emits code for the agent or user to execute; incorrect API usage could produce silently wrong cheminformatics results — for example mismatched fingerprint parameters yielding similarity scores that are not comparable across runs. <br>
+Mitigation: The skill documents result types and the asynchronous execution model (`AsyncGpuResult`, `Device3DResult`) explicitly, and includes a verification step to run against the install before writing real code. Users should review generated code before executing it. <br>
+
+Risk: nvMolKit and RDKit can differ numerically for the same nominal operation (conformer generation and force-field optimization are stochastic and hardware-sensitive), so results may not reproduce bit-for-bit across backends. <br>
+Mitigation: The skill covers where nvMolKit is and is not an appropriate substitute for RDKit, so users choose the backend deliberately rather than assuming equivalence. <br>
+
+Risk: Batched GPU operations on large molecule libraries can exhaust GPU memory mid-run. <br>
+Mitigation: The skill documents `HardwareOptions` configuration for batch and device control. <br>
+
+Risk: Asynchronous result handles can be read before completion if the execution model is misunderstood, yielding empty or partial data. <br>
+Mitigation: The skill's result-type documentation is explicit about when a result must be awaited or materialized. <br>
+
+## Reference(s): <br>
+- [nvMolKit repository](https://github.com/NVIDIA-BioNeMo/nvMolKit) <br>
+- [RDKit documentation](https://www.rdkit.org/docs/) — the API surface nvMolKit mirrors <br>
+- `SKILL.md` in this skill directory — result types, `HardwareOptions` / `SubstructSearchConfig`, and worked recipes <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Code, Analysis] <br>
+**Output Format:** [Markdown with inline Python code blocks] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [The skill produces code and guidance; it does not itself execute cheminformatics workloads. Generated code should be reviewed before execution.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+11 functional evaluation tasks in `evals/evals.json` covering fingerprinting, similarity, conformer generation, optimization, clustering, and substructure search, plus 2 trigger-activation cases in `evals/trigger_evals.json`. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+ea68428 (source: git SHA, committed 2026-08-03) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-add-cmim-pretrain/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-add-cmim-pretrain/skill-card.md
@@ -1,0 +1,77 @@
+## Description: <br>
+Converts a grover_base checkpoint into a hybrid checkpoint by adding a randomly-initialized cMIM decoder and latent distribution, then continues pretraining on the user's corpus in hybrid (vocab + contrast) mode. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML research engineers who want the cMIM contrastive objective on top of an existing grover_base KERMT checkpoint without retraining from scratch. Functionally `kermt-continue-pretrain` with a one-time checkpoint-conversion step prepended. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU (multi-GPU supported via DDP) <br>
+* A grover_base checkpoint (encoder-only, or encoder + vocab heads) <br>
+* A pretraining corpus CSV <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The newly added cMIM decoder and latent distribution are randomly initialized, so the converted checkpoint performs worse than its source until sufficient hybrid pretraining has run — a checkpoint taken too early is silently degraded. <br>
+Mitigation: The conversion step is explicitly separated from the training step, and `kermt-monitor` exposes validation loss so users can confirm convergence before adopting the result. <br>
+
+Risk: Continued pretraining is a long-running, multi-GPU workload that a single agent instruction can start, potentially consuming days of GPU time. <br>
+Mitigation: Runs launch detached with a run manifest; `kermt-monitor` provides progress visibility and the container identifiers needed to terminate early. <br>
+
+Risk: Supplying a checkpoint that is not grover_base (e.g. already cmim or hybrid) would produce an invalid conversion. <br>
+Mitigation: The skill validates the source checkpoint type before conversion. <br>
+
+Risk: Conversion and data preparation write new checkpoint and shard/vocab/feature artifacts that can overwrite prior output. <br>
+Mitigation: Artifacts are written under an explicit run/output path; the source checkpoint is not modified in place. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/run_pretrain_local.py` — extended usage examples <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-continue-pretrain`, `kermt-pretrain-scratch` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Converted hybrid checkpoint; subsequent training checkpoints; shard/vocab/feature artifacts; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, converted checkpoint path, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering source-checkpoint validation, cMIM conversion, corpus preparation, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models produced by this skill inherit the composition and biases of the user's pretraining corpus. Downstream predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-continue-pretrain/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-continue-pretrain/skill-card.md
@@ -1,0 +1,77 @@
+## Description: <br>
+Continues pretraining from an existing KERMT checkpoint — validating the checkpoint and corpus, preparing shard/vocab/feature artifacts, and launching `pretrain_ddp.py` inside the KERMT container with `--pretrain_mode` auto-dispatched from the checkpoint type. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML engineers adapting a KERMT foundation model to a domain-specific molecular corpus — for example an in-house compound collection — before task finetuning, without discarding the representations already learned. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU (multi-GPU supported via DDP) <br>
+* An existing KERMT checkpoint (grover_base vocab-only, cmim, or hybrid) <br>
+* A pretraining corpus CSV <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Continued pretraining is a long-running, multi-GPU workload that a single agent instruction can start, potentially consuming days of GPU time and substantial cloud spend. <br>
+Mitigation: Runs launch detached with a run manifest; `kermt-monitor` provides progress visibility and the container identifiers needed to terminate early. <br>
+
+Risk: Selecting the wrong `--pretrain_mode` for a checkpoint would train against the wrong objective and silently waste the entire run. <br>
+Mitigation: The skill auto-dispatches `--pretrain_mode` from the detected checkpoint type rather than relying on the user to specify it. <br>
+
+Risk: Data preparation writes shard, vocabulary, and feature artifacts that can be large and can overwrite prior preparation output. <br>
+Mitigation: Preparation writes under an explicit run/output path supplied by the user. <br>
+
+Risk: Continued pretraining on a narrow corpus can degrade general-purpose representations (catastrophic forgetting) in ways not visible until downstream finetuning. <br>
+Mitigation: The original checkpoint is not modified in place; users should retain it and compare downstream task performance before adopting the continued-pretrain checkpoint. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/run_pretrain_local.py` — extended usage examples <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-pretrain-scratch`, `kermt-add-cmim-pretrain`, `kermt-finetune` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Model checkpoint files; shard/vocab/feature artifacts; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, resolved pretrain mode, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+5 evaluation tasks defined in `evals/evals.json`, covering checkpoint validation, corpus validation, data preparation, pretrain-mode dispatch, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models produced by this skill inherit the composition and biases of the user's pretraining corpus. Downstream predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-embed/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-embed/skill-card.md
@@ -1,0 +1,69 @@
+## Description: <br>
+Extracts per-molecule embeddings from any encoder-bearing KERMT checkpoint (grover_base / cmim / hybrid / finetuned), writing one `.npy` per readout type plus `canonical_smiles.npy` and `validity.npy`. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML engineers and cheminformaticians who need fixed-length molecular representations from a KERMT encoder to feed a downstream model, clustering step, or similarity search, without training a task head. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU <br>
+* Any encoder-bearing KERMT checkpoint <br>
+* A SMILES input CSV (featurization happens on the fly — no precomputed features required) <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Embeddings from different checkpoints or readout types are not comparable, and mixing them in a downstream model produces silently meaningless results. <br>
+Mitigation: The skill writes each readout type to a separately named `.npy` and emits `canonical_smiles.npy` alongside, so provenance and row alignment are explicit. <br>
+
+Risk: Invalid SMILES rows would misalign embeddings against the caller's original input ordering. <br>
+Mitigation: The skill emits `validity.npy`, letting the caller filter or realign rows deterministically. <br>
+
+Risk: Large input libraries can produce embedding arrays of substantial size and consume significant disk. <br>
+Mitigation: Outputs are written to a user-specified directory; users should size storage for the molecule count and embedding dimensionality before running. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `task/extract_embeddings.py` — the underlying extraction entry point <br>
+- Related skills: `kermt-setup`, `kermt-finetune`, `kermt-infer` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files] <br>
+**Output Format:** [NumPy `.npy` arrays — one per readout type (atom_from_atom, bond_from_atom, atom_from_bond, bond_from_bond), plus `canonical_smiles.npy` and `validity.npy`] <br>
+**Output Parameters:** [2D — one row per input molecule, one column per embedding dimension] <br>
+**Other Properties Related to Output:** [Row order corresponds to the input CSV; `validity.npy` identifies rows whose SMILES failed to parse] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+5 evaluation tasks defined in `evals/evals.json`, covering checkpoint compatibility, readout selection, and output artifact production. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-finetune/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-finetune/skill-card.md
@@ -1,0 +1,78 @@
+## Description: <br>
+Finetunes a pretrained KERMT encoder on a labeled CSV — validating the input checkpoint and dataset, preparing features and optional splits, then launching `main.py finetune` inside the KERMT container as a detached, hours-scale run. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Computational chemists and ML engineers adapting a pretrained KERMT encoder (grover_base / cmim / hybrid) to their own labeled molecular property dataset — for example an in-house ADMET assay panel — before running predictions with `kermt-infer`. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU <br>
+* A pretrain checkpoint (grover_base, cmim, or hybrid) <br>
+* A labeled CSV with SMILES and one or more target columns <br>
+* Hyperparameters default from `agent/config/defaults_finetune.json`, overridable per flag <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Finetuning is an hours-scale GPU workload that a single agent instruction can start, consuming substantial GPU-hours or cloud spend. <br>
+Mitigation: Runs launch detached with a run manifest, and `kermt-monitor` gives the user continuous visibility and the container identifiers needed to terminate early. <br>
+
+Risk: Supplying a finetuned checkpoint instead of a pretrain checkpoint would produce an invalid training configuration. <br>
+Mitigation: The skill validates the checkpoint type before launching and rejects non-pretrain checkpoints. <br>
+
+Risk: A poorly split dataset (e.g. random splits on congeneric series) yields optimistic validation metrics that do not generalize. <br>
+Mitigation: The skill exposes explicit split handling rather than defaulting silently; users remain responsible for choosing a split strategy appropriate to their chemistry. <br>
+
+Risk: Training writes checkpoints and logs into a user-specified directory and can overwrite artifacts from a previous run. <br>
+Mitigation: Outputs are written under an explicit run directory; users should use distinct output paths per experiment. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`; users should confirm their data-handling policy before enabling it. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/config/defaults_finetune.json` — default hyperparameters <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-infer`, `kermt-embed` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Model checkpoint files; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, configured hyperparameters, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes. Use `kermt-monitor` for progress.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+5 evaluation tasks defined in `evals/evals.json`, covering checkpoint validation, dataset validation, data preparation, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models finetuned with this skill inherit the biases and coverage limits of the user's training data. Resulting predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-infer/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-infer/skill-card.md
@@ -1,0 +1,74 @@
+## Description: <br>
+Runs molecular property predictions with a finetuned KERMT checkpoint on a SMILES-only CSV, validating that the checkpoint carries task FFN heads, preparing rdkit_2d features, and launching `main.py predict` inside the KERMT container. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Computational chemists and drug-discovery teams scoring a library of candidate molecules for ADMET or other molecular properties using a KERMT model they have already finetuned. Not for use with pretrain checkpoints — the skill refuses those and redirects to `kermt-finetune`. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU <br>
+* A finetuned KERMT checkpoint containing task FFN heads <br>
+* A SMILES-only input CSV <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Predictions are computational estimates and may be applied outside the chemical space the model was finetuned on, producing confidently wrong property values for novel scaffolds. <br>
+Mitigation: Users must treat outputs as hypotheses requiring experimental validation, and should check that input chemistry resembles the finetuning set before acting on predictions. <br>
+
+Risk: Supplying a pretrain checkpoint instead of a finetuned one would yield meaningless outputs. <br>
+Mitigation: The skill validates the checkpoint for task FFN heads before running and refuses pretrain checkpoints with an explicit redirect to `kermt-finetune`. <br>
+
+Risk: Malformed or non-parseable SMILES silently reduce the effective prediction set. <br>
+Mitigation: The skill runs a data-preparation and cleaning step that reports invalid rows before inference. <br>
+
+Risk: The skill writes prediction outputs into a user-specified directory and can overwrite prior results. <br>
+Mitigation: Outputs are written under an explicit output path supplied by the user; no files outside that path are modified. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- [RDKit documentation](https://www.rdkit.org/docs/) — `rdkit_2d` descriptor featurization <br>
+- Related skills: `kermt-finetune` (produces the required checkpoint), `kermt-embed` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Files] <br>
+**Output Format:** [CSV of per-molecule predictions; Markdown summary] <br>
+**Output Parameters:** [2D — one row per input molecule, one column per predicted task] <br>
+**Other Properties Related to Output:** [Predictions are model estimates, not measurements, and are not calibrated probabilities of experimental outcome. Runs blocking, on a minutes-scale timeframe.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering checkpoint validation, CSV validation, feature preparation, and the predict invocation. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Molecular property predictions produced by this skill are computational hypotheses for research and development workflows. They must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-monitor/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-monitor/skill-card.md
@@ -1,0 +1,70 @@
+## Description: <br>
+Reports progress for a detached KERMT run by reading `run.json`, querying Docker for container state, tailing the pretrain/finetune log, and parsing progress lines (epoch, step, validation loss). <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML engineers running long KERMT pretraining or finetuning jobs who need to check status, spot divergence early, and decide whether to let a run continue or terminate it. This is the companion skill to every detached `kermt-*` training invocation. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* Docker <br>
+* `jq` <br>
+* A prior detached KERMT run that produced a `run.json` <br>
+
+Note: unlike the training skills, this skill does not require a GPU. <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: A stale or missing `run.json` can cause the skill to report on the wrong run, or to report nothing while a job is in fact still consuming GPU-hours. <br>
+Mitigation: The skill cross-checks `run.json` against live Docker container state rather than trusting the manifest alone. <br>
+
+Risk: Log tailing surfaces run output into the agent transcript, which may include file paths or environment details. <br>
+Mitigation: The skill reads only the pretrain/finetune log; users should treat agent transcripts as sensitive and avoid pasting credentials into run configuration. <br>
+
+Risk: This skill is read-only and cannot stop a runaway job, so a user may assume monitoring implies control. <br>
+Mitigation: The skill reports container identifiers so the user can terminate the run directly via Docker if needed. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/kermt_container.sh` — defines `kermt_run_detached`, the wrapper whose runs this skill observes <br>
+- Related skills: `kermt-pretrain-scratch`, `kermt-continue-pretrain`, `kermt-finetune` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis] <br>
+**Output Format:** [Markdown status report] <br>
+**Output Parameters:** [1D — container state, current epoch, current step, latest validation loss] <br>
+**Other Properties Related to Output:** [Read-only; the skill makes no changes to the run or the host] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering run discovery, container-state reporting, and log progress parsing. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-pretrain-scratch/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-pretrain-scratch/skill-card.md
@@ -1,0 +1,77 @@
+## Description: <br>
+Pretrains a fresh KERMT model from scratch on a user-provided corpus — building a new vocabulary, instantiating the model architecture from defaults, and launching `pretrain_ddp.py` inside the KERMT container with no starting checkpoint loaded. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML research engineers training a KERMT model from random initialization on a corpus sufficiently large and distinct that continued pretraining from an existing checkpoint is not appropriate. For most users, `kermt-continue-pretrain` is the better starting point. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU (multi-GPU strongly recommended; DDP supported) <br>
+* A large pretraining corpus CSV <br>
+* Substantial disk for shard, vocabulary, and feature artifacts <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: This is the most expensive skill in the KERMT family — training from random initialization can consume days to weeks of multi-GPU time, and a single agent instruction can start it. <br>
+Mitigation: Runs launch detached with a run manifest; `kermt-monitor` provides progress visibility and the container identifiers needed to terminate early. Users should confirm corpus scale justifies from-scratch training before invoking. <br>
+
+Risk: Training from scratch on an insufficiently large corpus produces a model materially worse than the available pretrained checkpoints, with the cost discovered only after the run. <br>
+Mitigation: The skill is documented as the exception path, with `kermt-continue-pretrain` as the recommended default; users should benchmark against an existing checkpoint before committing. <br>
+
+Risk: A vocabulary built from the user's corpus is not interchangeable with vocabularies from other checkpoints, so resulting models are incompatible with checkpoints trained elsewhere. <br>
+Mitigation: The new vocabulary is written alongside the checkpoint in the run directory, making the pairing explicit and auditable. <br>
+
+Risk: Data preparation writes large shard/vocab/feature artifacts and can overwrite prior preparation output. <br>
+Mitigation: Preparation writes under an explicit run/output path supplied by the user. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/run_pretrain_local.py` — extended usage examples <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-continue-pretrain`, `kermt-finetune` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Model checkpoint files; new vocabulary; shard/feature artifacts; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, vocabulary path, model configuration, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering corpus validation, vocabulary construction, architecture instantiation, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models produced by this skill inherit the composition and biases of the user's pretraining corpus entirely, with no counterbalancing from prior pretraining. Downstream predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/kermt/kermt-setup/skill-card.md
+++ b/compliance.d/open-models-skills/kermt/kermt-setup/skill-card.md
@@ -1,0 +1,69 @@
+## Description: <br>
+Bootstraps the KERMT agent environment — verifies host Docker and the NVIDIA Container Toolkit, builds the `kermt:latest` image from the repository Dockerfile if absent, and runs a GPU smoke test inside the container. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Computational chemists and ML engineers preparing a workstation or GPU node to run any `kermt-*` skill. Every other KERMT skill depends on this one; it is the first skill to invoke on a fresh clone. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* Docker <br>
+* NVIDIA Container Toolkit <br>
+* CUDA-capable NVIDIA GPU <br>
+* A local clone of the KERMT repository (supplies the Dockerfile) <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill builds a container image and runs GPU workloads, which consumes significant local disk and can take tens of minutes on a cold cache. <br>
+Mitigation: The skill checks for an existing `kermt:latest` image and skips the build when one is present; the smoke test is short and read-only. <br>
+
+Risk: Docker commands require elevated host privileges, and an agent running them has broad access to the host container runtime. <br>
+Mitigation: The skill issues only build, run, and inspect commands against the KERMT image; users should keep their agent's command-approval gate enabled and review commands before execution. <br>
+
+Risk: A partially configured host (driver/toolkit mismatch) can produce a container that starts but cannot see the GPU, causing confusing downstream failures in training skills. <br>
+Mitigation: The GPU smoke test runs inside the container and fails loudly at setup time rather than deferring the error to a long-running job. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- [NVIDIA Container Toolkit documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/) <br>
+- `agent/scripts/kermt_container.sh` — container entry points used by this skill <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Configuration instructions] <br>
+**Output Format:** [Markdown status report with inline bash commands] <br>
+**Output Parameters:** [1D — pass/fail status per environment check] <br>
+**Other Properties Related to Output:** [Side effect: builds the `kermt:latest` Docker image on the host if it does not already exist] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering environment verification, image build, and GPU smoke test paths. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-design/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-design/skill-card.md
@@ -1,0 +1,80 @@
+## Description: <br>
+Drives the end-to-end Proteina-Complexa design pipeline — `complexa design <pipeline>` from target selection through manifest emission — for protein binder, ligand binder, and AME / motif-scaffolding tasks, and reports how many designs passed. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers and computational biologists running de novo binder design against a registered target — generating candidate binders with reward-guided flow matching, refolding them with an independent structure predictor (AF2 or RF3), and ranking by interface metrics (success rate, interface pAE, scRMSD, FoldSeek diversity). This is the scientific anchor of the `complexa-*` skill set. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* `.env` populated (`complexa-setup`) and a target registered (`complexa-target`) <br>
+* 1× CUDA GPU with ≥40 GB VRAM (A100 / H100 / L40S) <br>
+* 24 CPUs, ~50 GB disk <br>
+* Folding backend weights: AF2 (ColabDesign) or RF3 <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Designed binders are computational predictions. Reported success rates, interface pAE, and scRMSD are in-silico metrics that correlate imperfectly with experimental binding; treating them as validated hits wastes wet-lab resources. <br>
+Mitigation: The pipeline refolds designs with a structure predictor independent of the generator and reports pass rates against explicit thresholds rather than a single score. All outputs require experimental validation. <br>
+
+Risk: A full design campaign is a long, GPU-intensive workload that a single agent instruction can start, consuming substantial GPU-hours or cloud spend. <br>
+Mitigation: The skill runs a pre-flight validation step before launching and emits a replayable manifest, so configuration errors surface before the expensive stage. <br>
+
+Risk: Incorrect target or hotspot configuration directs the entire campaign at the wrong surface, with the error invisible until results are inspected. <br>
+Mitigation: The skill validates the target as an explicit pipeline step and refuses to proceed on an invalid target. <br>
+
+Risk: Generation is stochastic — repeated runs with identical inputs produce different binders unless a seed is fixed, which can confound comparisons between configurations. <br>
+Mitigation: The emitted manifest records the run configuration for replay; use `complexa-sweep` for controlled comparisons across configurations. <br>
+
+Risk: The skill writes design outputs and can overwrite results from a previous campaign in the same directory. <br>
+Mitigation: Outputs are written under explicit per-run output paths. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- La-Proteina — the flow-based generative model this work builds on <br>
+- [ColabDesign / AlphaFold2](https://github.com/sokrypton/ColabDesign) and RF3 — independent refolding backends <br>
+- [Foldseek](https://github.com/steineggerlab/foldseek) — structural diversity metric <br>
+- Related skills: `complexa-setup`, `complexa-target`, `complexa-evaluate-pdbs`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [PDB structures of designed binders; result CSV of per-design metrics; replayable JSON manifest; Markdown summary] <br>
+**Output Parameters:** [3D for atomic coordinates; 2D for the per-design metric table; 1D for campaign-level pass rates] <br>
+**Other Properties Related to Output:** [Outputs are computational predictions, not measurements. Confidence and interface metrics are model-reported and are not calibrated probabilities of experimental binding. Generation is stochastic unless seeded.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering pipeline selection, pre-flight validation, design execution, and result collection with manifest emission — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+This skill generates novel protein sequences and structures. Users are responsible for screening designed sequences before synthesis, and for using the skill consistent with applicable biosecurity norms, biosafety review processes, and export-control obligations. Designed binders are research hypotheses and must not be used for clinical decision-making, diagnosis, or treatment selection. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-design/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-design/skill-card.md
@@ -7,7 +7,7 @@ This skill is ready for commercial/non-commercial use. <br>
 NVIDIA <br>
 
 ### License/Terms of Use: <br>
-This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+This repository contains multiple components under different licenses; see the [`LICENSE`](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/blob/HEAD/LICENSE) in the source repository. <br>
 
 ## Use Case: <br>
 Protein designers and computational biologists running de novo binder design against a registered target — generating candidate binders with reward-guided flow matching, refolding them with an independent structure predictor (AF2 or RF3), and ranking by interface metrics (success rate, interface pAE, scRMSD, FoldSeek diversity). This is the scientific anchor of the `complexa-*` skill set. <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/skill-card.md
@@ -1,0 +1,75 @@
+## Description: <br>
+Evaluates an existing directory of PDB files with Proteina-Complexa — selecting the correct `evaluate_*.yaml` config and folding backend, running the `complexa analysis` evaluate-then-analyze chain, parsing the result CSV, reporting pass rates against `result_type` thresholds, and emitting a replayable `eval_manifest.json`. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers scoring binder candidates that already exist as structures — refolding designs, computing interface pAE, i_pLDDT, scRMSD, and motif RMSD, and assessing designability. Works on Proteina-Complexa output and equally on third-party outputs (BindCraft, AlphaProteo, RFdiffusion, hand-curated decoys), so it serves as a common yardstick across design methods. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* CUDA GPU <br>
+* A folding backend: `AF2_DIR` (ColabDesign) or `RF3_CKPT_PATH` + `RF3_EXEC_PATH` (rf3_latest) <br>
+* ESMFold weights for monomer evaluation paths <br>
+* A directory of input PDB files <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Pass rates are only meaningful relative to the thresholds of the selected `result_type`; comparing numbers produced under different configs or folding backends is misleading. <br>
+Mitigation: The skill emits a replayable `eval_manifest.json` recording the config, backend, and thresholds used, so comparisons can be checked for like-for-like. <br>
+
+Risk: Evaluating designs with the same model family that generated them inflates apparent quality. <br>
+Mitigation: The skill supports independent folding backends (AF2/ColabDesign, RF3, ESMFold) and is documented for use as an independent check; users should choose a backend distinct from the generator. <br>
+
+Risk: Refolding a large PDB directory is GPU-intensive and can run far longer than a user expects from a single instruction. <br>
+Mitigation: The skill selects the appropriate config up front and reports the input set size before running. <br>
+
+Risk: Malformed or non-standard PDB inputs — particularly third-party outputs with unusual chain or numbering conventions — can be silently skipped or misparsed. <br>
+Mitigation: The skill parses the result CSV and reports counts, so a shortfall between inputs and scored designs is visible. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- [ColabDesign / AlphaFold2](https://github.com/sokrypton/ColabDesign), RF3, and [ESMFold](https://github.com/facebookresearch/esm) — supported folding backends <br>
+- Related skills: `complexa-setup`, `complexa-design`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Files] <br>
+**Output Format:** [Result CSV of per-design metrics; `eval_manifest.json`; Markdown pass-rate report] <br>
+**Output Parameters:** [2D — one row per evaluated design, columns for interface pAE, i_pLDDT, scRMSD, motif RMSD; 1D for aggregate pass rates] <br>
+**Other Properties Related to Output:** [Metrics are model-reported in-silico estimates, not measurements, and are not calibrated probabilities of experimental binding.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering config selection, backend wiring, evaluation execution, and pass-rate reporting with manifest emission — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Evaluation results are computational hypotheses. A high in-silico pass rate is not evidence of experimental binding, and must not be used for clinical decision-making, diagnosis, or treatment selection. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-evaluate-pdbs/skill-card.md
@@ -7,7 +7,7 @@ This skill is ready for commercial/non-commercial use. <br>
 NVIDIA <br>
 
 ### License/Terms of Use: <br>
-This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+This repository contains multiple components under different licenses; see the [`LICENSE`](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/blob/HEAD/LICENSE) in the source repository. <br>
 
 ## Use Case: <br>
 Protein designers scoring binder candidates that already exist as structures — refolding designs, computing interface pAE, i_pLDDT, scRMSD, and motif RMSD, and assessing designability. Works on Proteina-Complexa output and equally on third-party outputs (BindCraft, AlphaProteo, RFdiffusion, hand-curated decoys), so it serves as a common yardstick across design methods. <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-setup/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-setup/skill-card.md
@@ -1,0 +1,68 @@
+## Description: <br>
+Performs first-time setup for Proteina-Complexa — driving `complexa init`, `complexa download`, and `complexa validate env` end to end, editing required `.env` keys, selecting the UV or Docker runtime, and emitting a replayable setup artifact. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers and computational biologists making a fresh Proteina-Complexa checkout runnable — verifying GPU preflight, configuring `.env`, and installing model weights (Complexa, AF2, RF3, ProteinMPNN, LigandMPNN, ESM2, ESMFold). This is the first skill to run on a new clone; every other `complexa-*` skill depends on it. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): Credentials for model-weight sources, as required by the individual checkpoints being downloaded <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* bash 4+ <br>
+* `nvidia-smi` optional at setup time; a CUDA GPU is required for the design and evaluation skills <br>
+* Substantial disk for model checkpoints <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill edits the user's `.env` file, which holds paths and may hold credentials; a mis-edit could break the environment or expose values in an agent transcript. <br>
+Mitigation: The skill edits only the required keys and reports what changed; `.env` is git-ignored in this repository and must never be committed. Users should treat agent transcripts as sensitive. <br>
+
+Risk: Model-weight downloads are large and fetch third-party checkpoints (AF2/ColabDesign, RF3, ESMFold, ProteinMPNN, LigandMPNN) whose licenses differ from this repository's. <br>
+Mitigation: `complexa download --status` reports what is present before fetching; users are responsible for reviewing and complying with each checkpoint's upstream license terms. <br>
+
+Risk: A partially completed setup produces confusing failures much later, inside long-running design jobs. <br>
+Mitigation: `complexa validate env` runs as an explicit final step so environment problems surface at setup time. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- Related skills: `complexa-target`, `complexa-design`, `complexa-evaluate-pdbs`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Files, Configuration instructions] <br>
+**Output Format:** [Markdown setup report; edited `.env`; downloaded checkpoint files; replayable setup artifact] <br>
+**Output Parameters:** [1D — per-check pass/fail status, resolved runtime, installed model inventory] <br>
+**Other Properties Related to Output:** [Side effects: writes `.env`, downloads model weights to disk] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering init, weight download and status reporting, `.env` configuration, and environment validation — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-setup/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-setup/skill-card.md
@@ -7,7 +7,7 @@ This skill is ready for commercial/non-commercial use. <br>
 NVIDIA <br>
 
 ### License/Terms of Use: <br>
-This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+This repository contains multiple components under different licenses; see the [`LICENSE`](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/blob/HEAD/LICENSE) in the source repository. <br>
 
 ## Use Case: <br>
 Protein designers and computational biologists making a fresh Proteina-Complexa checkout runnable — verifying GPU preflight, configuring `.env`, and installing model weights (Complexa, AF2, RF3, ProteinMPNN, LigandMPNN, ESM2, ESMFold). This is the first skill to run on a new clone; every other `complexa-*` skill depends on it. <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-sweep/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-sweep/skill-card.md
@@ -1,0 +1,75 @@
+## Description: <br>
+Runs parameter sweeps over a Proteina-Complexa design pipeline — authoring sweeper YAML, expanding cartesian-product configurations, and ranking per-configuration results for hyperparameter scans and Pareto search over generation, reward, and evaluation knobs. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers and method developers tuning a design pipeline — scanning beam width, step count, temperature, or reward weights; ablating reward components; or trading binder quality against wall-clock. This is the only skill that owns sweeper YAML authoring and per-configuration result ranking. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* `complexa-setup` completed and a target registered (`complexa-target`) <br>
+* CUDA GPU meeting the `complexa-design` requirements, for each configuration in the sweep <br>
+* Disk and GPU-hours proportional to the size of the cartesian product <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: This is the highest-cost skill in the family. A cartesian product expands multiplicatively, so a sweep specified in one short instruction can launch dozens of full design campaigns and consume very large amounts of GPU time or cloud spend. <br>
+Mitigation: The skill expands and reports the configuration list before execution, so the user sees the run count before committing. Users should start with a small grid and confirm cost before widening. <br>
+
+Risk: Ranking configurations on a stochastic pipeline can select a configuration that merely got a lucky seed rather than one that is genuinely better. <br>
+Mitigation: Results are reported per configuration rather than as a single winner, so users can judge whether differences exceed run-to-run variance. Seeds should be fixed for like-for-like comparison. <br>
+
+Risk: Sweeping on a small or unrepresentative target set overfits hyperparameters to that target, and the choice may not transfer. <br>
+Mitigation: Per-configuration results are retained so users can re-examine the ranking against a held-out target. <br>
+
+Risk: A large sweep writes many output directories and can exhaust disk mid-run, losing partially completed configurations. <br>
+Mitigation: Outputs are written under explicit per-configuration paths; users should size storage against the expanded run count. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- `reference/sweep_axes.md` in this skill directory — the sweepable parameter axes <br>
+- `configs/sweeps/` — example sweep definitions <br>
+- Related skills: `complexa-design`, `complexa-target`, `complexa-evaluate-pdbs` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Sweeper YAML; per-configuration design outputs and result CSVs; Markdown ranking table] <br>
+**Output Parameters:** [2D — one row per configuration, columns for the swept parameters and resulting metrics] <br>
+**Other Properties Related to Output:** [Rankings reflect in-silico metrics on a stochastic pipeline; differences within run-to-run variance should not be treated as meaningful.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering sweeper YAML authoring, cartesian-product expansion, sweep execution, and per-configuration ranking — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Sweeps generate novel protein sequences and structures at scale. Users are responsible for screening designed sequences before synthesis, and for using the skill consistent with applicable biosecurity norms, biosafety review processes, and export-control obligations. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-sweep/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-sweep/skill-card.md
@@ -7,7 +7,7 @@ This skill is ready for commercial/non-commercial use. <br>
 NVIDIA <br>
 
 ### License/Terms of Use: <br>
-This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+This repository contains multiple components under different licenses; see the [`LICENSE`](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/blob/HEAD/LICENSE) in the source repository. <br>
 
 ## Use Case: <br>
 Protein designers and method developers tuning a design pipeline — scanning beam width, step count, temperature, or reward weights; ablating reward components; or trading binder quality against wall-clock. This is the only skill that owns sweeper YAML authoring and per-configuration result ranking. <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-target/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-target/skill-card.md
@@ -1,0 +1,70 @@
+## Description: <br>
+Adds, registers, edits, lists, shows, and validates Proteina-Complexa design targets — protein binder, ligand binder, and AME / enzyme-scaffolding — and is the only skill that writes the three target dictionary files. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers defining what to design against — registering a target structure, chain specification, hotspot residues, and binder length range before running `complexa-design`. Also covers `complexa validate target` and questions about chain-spec syntax and where hotspots live. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* `complexa-setup` completed <br>
+* A target structure (PDB/mmCIF) or SMILES for ligand-binder targets <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: This skill has exclusive write access to `configs/targets/{,ligand_}targets_dict.yaml` and `configs/design_tasks/ame_dict_v2.yaml`; a malformed edit could corrupt target definitions shared across a team's design runs. <br>
+Mitigation: `complexa validate target` runs as an explicit validation path, and the skill is the single documented owner of those files so edits are not made ad hoc from multiple places. <br>
+
+Risk: Incorrect hotspot residue numbering — a common failure when structure numbering differs from sequence numbering — silently redirects design to the wrong surface, wasting an entire downstream design campaign. <br>
+Mitigation: The skill validates targets before use and supports structure-confirmed hotspot specification rather than accepting bare residue indices without checking. <br>
+
+Risk: Target definitions may be derived from third-party structures (e.g. RCSB PDB entries) whose terms of use apply to downstream work. <br>
+Mitigation: Users are responsible for confirming the provenance and licensing of any structure they register. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- [RCSB Protein Data Bank](https://www.rcsb.org/) — common source of target structures <br>
+- Related skills: `complexa-setup`, `complexa-design`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [YAML target dictionary entries; Markdown summary of registered targets] <br>
+**Output Parameters:** [1D — target identifier, chain spec, hotspot residues, binder length range] <br>
+**Other Properties Related to Output:** [Side effect: writes to the repository's target dictionary configuration files] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering target registration, listing/showing, chain and hotspot specification, and validation — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Target selection determines what a downstream design campaign is aimed at. Users are responsible for ensuring their design targets are consistent with applicable biosecurity norms and export-control obligations. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/compliance.d/open-models-skills/proteina-complexa/complexa-target/skill-card.md
+++ b/compliance.d/open-models-skills/proteina-complexa/complexa-target/skill-card.md
@@ -7,7 +7,7 @@ This skill is ready for commercial/non-commercial use. <br>
 NVIDIA <br>
 
 ### License/Terms of Use: <br>
-This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+This repository contains multiple components under different licenses; see the [`LICENSE`](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/blob/HEAD/LICENSE) in the source repository. <br>
 
 ## Use Case: <br>
 Protein designers defining what to design against — registering a target structure, chain specification, hotspot residues, and binder length range before running `complexa-design`. Also covers `complexa validate target` and questions about chain-spec syntax and where hotspots live. <br>


### PR DESCRIPTION
Adds `skill-card.md` for all 14 **sourced** skills, in a way that survives the nightly sync and retires itself once upstream ships its own cards.

Companion to the three upstream PRs carrying the same card content:
[KERMT#26](https://github.com/NVIDIA-BioNeMo/KERMT/pull/26) · [Proteina-Complexa#60](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/60) · [nvMolKit#248](https://github.com/NVIDIA-BioNeMo/nvMolKit/pull/248)

## The problem

`sync-skills.yml` runs `rsync -a --delete "$src/" "$catalog_dir/"`. A `skill-card.md` committed into a sourced catalog dir is **deleted on the next nightly run** — not overwritten, deleted. Verified:

```
$ ls dst/            → SKILL.md  skill-card.md
$ rsync -a --delete src/ dst/
$ ls dst/            → SKILL.md
```

This is exactly what happened to the KERMT evals, recorded in `docs/sync-findings.md`. But we can't wait for three upstream PRs to merge before the catalog has cards.

## The fix: overlay + backfill

Cards for sourced skills live in `compliance.d/<catalog_path>/`, outside every rsync target and every prune root. A new workflow step copies them in **after** the rsync, and **only where the rsync left no card**:

- **Immediate** — cards present in the catalog on merge, surviving every sync
- **Upstream always wins** — the moment a source repo ships its own card, rsync lands it and the backfill becomes a no-op. No flag to flip, no coordination
- **Self-retiring, with a signal** — the sync PR body now reports both the outstanding debt (*backfilled*) and entries upstream has made redundant (*retirable*, i.e. delete them)

### `skill.oms.sig` is deliberately NOT backfilled

A signature attests to specific bytes. Copying one over content it wasn't generated from publishes an artifact that fails verification — and NVIDIA/skills' sync has a dedicated defense that hash-checks exactly this case and reverts the skill. Signing stays a per-source-repo `nvskills-ci` task. Same reasoning for evals (SRC-10).

## Scope

| Catalog path | Source repo | Skills |
|---|---|---:|
| `open-models-skills/kermt/*` | `NVIDIA-BioNeMo/KERMT` | 8 |
| `open-models-skills/proteina-complexa/*` | `NVIDIA-BioNeMo/Proteina-Complexa` | 5 |
| `library-skills/nvMolKit` | `NVIDIA-BioNeMo/nvMolKit` | 1 |

The other 17 skills are native and take cards directly in-tree — not in this PR.

## Validation

**No CI will run on this PR** — neither `plugin-sync.yml` nor `skill-security.yml` has a path filter matching `compliance.d/**` or `.github/workflows/sync-skills.yml`, and `sync-skills.yml` itself only runs on schedule/dispatch. So the riskiest part of this change first executes unattended at 07:00 UTC. Verified by hand instead:

- backfill logic simulated against a fixture for all three cases — absent → backfilled, **already present → upstream wins**, orphaned overlay entry → warned and skipped
- `bash -n` on every `run:` block in the workflow → all pass
- workflow parses as YAML; step ordering correct (after prune, before payload rebuild)
- `python3 scripts/plugin_sync.py --check` → OK, 31 skills, payload matches source

**That gap is worth closing separately** — either extend `plugin-sync.yml`'s path filter to cover the sync workflow, or add a small job that exercises the backfill against a fixture. Happy to follow up.

## Heads-up on conflicts

⚠️ This touches `.github/workflows/sync-skills.yml`, which #15 also modifies. Worth sequencing with @ohadmo rather than merging blind.

Also noted while writing the Complexa cards: `.gitignore` in Proteina-Complexa ignores `.claude/` wholesale while the skills inside are tracked, so **new files added to a Complexa skill dir are silently dropped** unless force-added. Fixed as a separable commit in Proteina-Complexa#60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
